### PR TITLE
Add Column class to Apotheneum model

### DIFF
--- a/src/main/java/apotheneum/Apotheneum.java
+++ b/src/main/java/apotheneum/Apotheneum.java
@@ -63,6 +63,7 @@ public class Apotheneum {
     public int height() {
       return orientations()[0].height();
     }
+
   }
 
   public abstract static class Orientation {
@@ -70,13 +71,13 @@ public class Apotheneum {
     public static final int EXTERIOR = 0;
     public static final int INTERIOR = 1;
 
-    public abstract LXModel[] columns();
+    public abstract Column[] columns();
 
     public LXPoint point(int x, int y) {
       return column(x).points[y];
     }
 
-    public LXModel column(int index) {
+    public Column column(int index) {
       return columns()[index];
     }
 
@@ -97,18 +98,71 @@ public class Apotheneum {
     }
   }
 
-  public static class Ring {
+  /**
+   * One sequential set of points in Apotheneum.
+   */
+  public abstract static class Sequence {
 
     public final int index;
     public final LXPoint[] points;
 
-    private Ring(int index, LXModel[] columns) {
+    Sequence(int index, LXPoint[] points) {
       this.index = index;
-      this.points = new LXPoint[columns.length];
-      int i = 0;
-      for (LXModel column : columns) {
-        this.points[i++] = column.points[index];
+      this.points = points;
+    }
+  }
+
+  /**
+   * A vertical sequence of points. A thin wrapper around the LXModel that defined the column.
+   * The super class tracks the index of this column within the parent.
+   */
+  public static class Column extends Sequence {
+
+    public final LXModel model;
+
+    /**
+     * Number of points in the column
+     */
+    public final int size;
+
+    public Column(LXModel model, int index) {
+      super(index, model.points);
+      this.model = model;
+      this.size = model.size;
+    }
+
+    /**
+     * Create an array of columns from an array of LXModels
+     */
+    static Column[] arrayFrom(LXModel[] models) {
+      Column[] columns = new Column[models.length];
+      for (int i = 0; i < models.length; ++i) {
+        columns[i] = new Column(models[i], i);
       }
+      return columns;
+    }
+  }
+
+  public abstract static class HorizontalSequence extends Sequence {
+
+    private static LXPoint[] extractPoints(final int index, final Column[] columns) {
+      LXPoint[] points = new LXPoint[columns.length];
+      int i = 0;
+      for (Column column : columns) {
+        points[i++] = column.points[index];
+      }
+      return points;
+    }
+
+    HorizontalSequence(int index, Column[] columns) {
+      super(index, extractPoints(index, columns));
+    }
+  }
+
+  public static class Ring extends HorizontalSequence {
+
+    public Ring(int index, Column[] columns) {
+      super(index, columns);
     }
   }
 
@@ -127,7 +181,7 @@ public class Apotheneum {
 
       public final Face[] faces;
 
-      public final LXModel[] columns;
+      public final Column[] columns;
       public final Ring[] rings;
 
       private Orientation(LXModel model, String suffix) {
@@ -137,7 +191,7 @@ public class Apotheneum {
         this.left = new Face(model.sub("cubeLeft" + suffix).get(0));
         this.faces = new Face[] { this.front, this.right, this.back, this.left };
 
-        this.columns = new LXModel[this.front.columns.length + this.right.columns.length + this.back.columns.length + this.left.columns.length];
+        this.columns = new Column[this.front.columns.length + this.right.columns.length + this.back.columns.length + this.left.columns.length];
         int cIndex = 0;
         System.arraycopy(this.front.columns, 0, this.columns, cIndex, this.front.columns.length);
         cIndex += this.front.columns.length;
@@ -160,7 +214,7 @@ public class Apotheneum {
       }
 
       @Override
-      public LXModel[] columns() {
+      public Column[] columns() {
         return this.columns;
       }
 
@@ -181,18 +235,18 @@ public class Apotheneum {
 
     public static class Face {
       public final LXModel model;
-      public final LXModel[] columns;
+      public final Column[] columns;
       public final Row[] rows;
 
       private Face(LXModel face) {
         this.model = face;
-        this.columns = face.children;
+        this.columns = Column.arrayFrom(face.children);
         this.rows = new Row[GRID_HEIGHT];
 
         if (this.columns.length != GRID_WIDTH) {
           throw new IllegalStateException("Apotheneum face expects " + GRID_WIDTH + " columns, found " + this.columns.length);
         }
-        for (LXModel column : this.columns) {
+        for (Column column : this.columns) {
           if (column.size != GRID_HEIGHT) {
             throw new IllegalStateException("Apotheneum cube column expects " + GRID_HEIGHT + " points, found " + column.size);
           }
@@ -205,18 +259,10 @@ public class Apotheneum {
 
     }
 
-    public static class Row {
+    public static class Row extends HorizontalSequence {
 
-      public final int index;
-      public final LXPoint[] points;
-
-      private Row(int index, LXModel[] columns) {
-        this.index = index;
-        this.points = new LXPoint[columns.length];
-        int i = 0;
-        for (LXModel column : columns) {
-          this.points[i++] = column.points[index];
-        }
+      private Row(int index, Column[] columns) {
+        super(index, columns);
       }
     }
 
@@ -224,7 +270,7 @@ public class Apotheneum {
 
       public static final int LENGTH = 200;
 
-      private Ring(int index, LXModel[] columns) {
+      private Ring(int index, Column[] columns) {
         super(index, columns);
       }
     }
@@ -259,15 +305,15 @@ public class Apotheneum {
 
     public static class Orientation extends Apotheneum.Orientation {
       public final int size;
-      public final LXModel[] columns;
+      public final Column[] columns;
       public final Ring[] rings;
 
       private Orientation(LXModel model, String suffix) {
-        this.columns = model.sub("cylinder" + suffix).toArray(new LXModel[0]);
+        this.columns = Column.arrayFrom(model.sub("cylinder" + suffix).toArray(new LXModel[0]));
         if (this.columns.length != Ring.LENGTH) {
           throw new IllegalStateException("Apotheneum cylinder expects " + Ring.LENGTH + " columns, found " + this.columns.length);
         }
-        for (LXModel column : this.columns) {
+        for (Column column : this.columns) {
           if (column.size != CYLINDER_HEIGHT) {
             throw new IllegalStateException("Apotheneum cylinder column expects " + CYLINDER_HEIGHT + " points, found " + column.size);
           }
@@ -281,7 +327,7 @@ public class Apotheneum {
       }
 
       @Override
-      public LXModel[] columns() {
+      public Column[] columns() {
         return this.columns;
       }
 
@@ -303,7 +349,7 @@ public class Apotheneum {
 
       public static final int LENGTH = 120;
 
-      private Ring(int index, LXModel[] columns) {
+      private Ring(int index, Column[] columns) {
         super(index, columns);
       }
     }

--- a/src/main/java/apotheneum/ApotheneumEffect.java
+++ b/src/main/java/apotheneum/ApotheneumEffect.java
@@ -21,7 +21,6 @@ package apotheneum;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.effect.LXEffect;
-import heronarts.lx.model.LXModel;
 
 public abstract class ApotheneumEffect extends LXEffect {
 
@@ -81,8 +80,8 @@ public abstract class ApotheneumEffect extends LXEffect {
     assertExists();
     if ((from != null) && (to != null)) {
       int colIndex = 0;
-      for (LXModel fromCol : from.columns) {
-        LXModel toCol = to.columns[to.columns.length - 1 - colIndex];
+      for (Apotheneum.Column fromCol : from.columns) {
+        Apotheneum.Column toCol = to.columns[to.columns.length - 1 - colIndex];
         System.arraycopy(colors, fromCol.points[0].index, colors, toCol.points[0].index, fromCol.size);
         ++colIndex;
       }
@@ -111,9 +110,13 @@ public abstract class ApotheneumEffect extends LXEffect {
   }
 
   protected void setColor(Apotheneum.Cube.Face face, int color) {
-    for (LXModel column : face.columns) {
+    for (Apotheneum.Column column : face.columns) {
       setColor(column, color);
     }
+  }
+
+  protected void setColor(Apotheneum.Column column, int color) {
+    setColor(column.model, color);
   }
 
 }

--- a/src/main/java/apotheneum/ApotheneumPattern.java
+++ b/src/main/java/apotheneum/ApotheneumPattern.java
@@ -20,7 +20,6 @@ package apotheneum;
 
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.pattern.LXPattern;
 
 public abstract class ApotheneumPattern extends LXPattern {
@@ -79,8 +78,8 @@ public abstract class ApotheneumPattern extends LXPattern {
     assertExists();
     if ((from != null) && (to != null)) {
       int colIndex = 0;
-      for (LXModel fromCol : from.columns) {
-        LXModel toCol = to.columns[to.columns.length - 1 - colIndex];
+      for (Apotheneum.Column fromCol : from.columns) {
+        Apotheneum.Column toCol = to.columns[to.columns.length - 1 - colIndex];
         System.arraycopy(colors, fromCol.points[0].index, colors, toCol.points[0].index, fromCol.size);
         ++colIndex;
       }
@@ -120,15 +119,19 @@ public abstract class ApotheneumPattern extends LXPattern {
   }
 
   protected void setColor(Apotheneum.Orientation orientation, int color) {
-    for (LXModel column : orientation.columns()) {
+    for (Apotheneum.Column column : orientation.columns()) {
       setColor(column, color);
     }
   }
 
   protected void setColor(Apotheneum.Cube.Face face, int color) {
-    for (LXModel column : face.columns) {
+    for (Apotheneum.Column column : face.columns) {
       setColor(column, color);
     }
+  }
+
+  protected void setColor(Apotheneum.Column column, int color) {
+    setColor(column.model, color);
   }
 
   protected abstract void render(double deltaMs);

--- a/src/main/java/apotheneum/core/ApotheneumDoors.java
+++ b/src/main/java/apotheneum/core/ApotheneumDoors.java
@@ -24,7 +24,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.parameter.BooleanParameter;
 
 @LXCategory("Apotheneum/core")
@@ -92,7 +91,7 @@ public class ApotheneumDoors extends ApotheneumEffect {
 
       // Mute cube face doors
       for (Apotheneum.Cube.Face face : Apotheneum.cube.faces) {
-        final LXModel column = face.columns[FACE_DOOR_START_COLUMN + c];
+        final Apotheneum.Column column = face.columns[FACE_DOOR_START_COLUMN + c];
         for (int i = FACE_DOOR_START_PIXEL; i < column.points.length; ++i) {
           colors[column.points[i].index] = LXColor.BLACK;
         }
@@ -100,12 +99,12 @@ public class ApotheneumDoors extends ApotheneumEffect {
 
       // Mute cylinder doors
       for (int cylinderColumn : CYLINDER_DOOR_START_COLUMNS) {
-        final LXModel exterior = Apotheneum.cylinder.exterior.columns[cylinderColumn + c];
+        final Apotheneum.Column exterior = Apotheneum.cylinder.exterior.columns[cylinderColumn + c];
         for (int i = CYLINDER_DOOR_START_PIXEL; i < exterior.points.length; ++i) {
           colors[exterior.points[i].index] = LXColor.BLACK;
         }
         if (Apotheneum.cylinder.interior != null) {
-          final LXModel interior = Apotheneum.cylinder.interior.columns[cylinderColumn + c];
+          final Apotheneum.Column interior = Apotheneum.cylinder.interior.columns[cylinderColumn + c];
           for (int i = CYLINDER_DOOR_START_PIXEL; i < exterior.points.length; ++i) {
             colors[interior.points[i].index] = LXColor.BLACK;
           }

--- a/src/main/java/apotheneum/doved/patterns/EdgeTracer.java
+++ b/src/main/java/apotheneum/doved/patterns/EdgeTracer.java
@@ -6,7 +6,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.EnumParameter;
 import java.util.ArrayList;
@@ -104,13 +103,13 @@ public class EdgeTracer extends ApotheneumPattern {
     // Door handling utility methods
     private static class DoorTraversal {
         
-        static void addPointsWithDoorHandling(List<LXPoint> path, LXModel[] columns, 
+        static void addPointsWithDoorHandling(List<LXPoint> path, Apotheneum.Column[] columns,
                                              Apotheneum.Orientation orientation, int faceOffset, 
                                              int heightConstant, int doorHeight) {
             for (int col = 0; col < columns.length; col++) {
                 int globalCol = faceOffset + col;
                 int available = orientation.available(globalCol);
-                LXModel column = columns[col];
+                Apotheneum.Column column = columns[col];
                 
                 boolean isInDoor = available < heightConstant;
                 boolean nextInDoor = (col < columns.length - 1) && 
@@ -133,14 +132,14 @@ public class EdgeTracer extends ApotheneumPattern {
                     
                     // If this is the last door column, add the descent
                     if (!nextInDoor && col < columns.length - 1) {
-                        LXModel nextColumn = columns[col + 1];
+                        Apotheneum.Column nextColumn = columns[col + 1];
                         addDescentTransition(path, nextColumn, heightConstant, doorHeight);
                     }
                 }
             }
         }
         
-        static void addVerticalTransition(List<LXPoint> path, LXModel column, int heightConstant, int doorHeight) {
+        static void addVerticalTransition(List<LXPoint> path, Apotheneum.Column column, int heightConstant, int doorHeight) {
             for (int y = heightConstant - 2; y >= heightConstant - doorHeight; y--) {
                 if (y >= 0 && y < column.points.length) {
                     path.add(column.points[y]);
@@ -148,7 +147,7 @@ public class EdgeTracer extends ApotheneumPattern {
             }
         }
         
-        static void addDescentTransition(List<LXPoint> path, LXModel nextColumn, int heightConstant, int doorHeight) {
+        static void addDescentTransition(List<LXPoint> path, Apotheneum.Column nextColumn, int heightConstant, int doorHeight) {
             for (int y = heightConstant - doorHeight; y < heightConstant; y++) {
                 if (y >= 0 && y < nextColumn.points.length) {
                     path.add(nextColumn.points[y]);
@@ -164,21 +163,21 @@ public class EdgeTracer extends ApotheneumPattern {
                                                    Apotheneum.GRID_HEIGHT, Apotheneum.DOOR_HEIGHT);
             
             // Right edge (bottom to top)
-            LXModel rightColumn = cubeFace.columns[cubeFace.columns.length - 1];
+            Apotheneum.Column rightColumn = cubeFace.columns[cubeFace.columns.length - 1];
             for (int y = rightColumn.points.length - 2; y >= 0; y--) {
                 facePath.add(rightColumn.points[y]);
             }
             
             // Top edge (right to left)
             for (int col = cubeFace.columns.length - 2; col >= 0; col--) {
-                LXModel column = cubeFace.columns[col];
+                Apotheneum.Column column = cubeFace.columns[col];
                 if (column.points.length > 0) {
                     facePath.add(column.points[0]);
                 }
             }
             
             // Left edge (top to bottom) - but don't duplicate the starting point
-            LXModel leftColumn = cubeFace.columns[0];
+            Apotheneum.Column leftColumn = cubeFace.columns[0];
             int leftAvailable = orientation.available(face * Apotheneum.GRID_WIDTH);
             int startY = (leftAvailable < Apotheneum.GRID_HEIGHT) ? leftAvailable - 1 : leftColumn.points.length - 2;
             
@@ -193,7 +192,7 @@ public class EdgeTracer extends ApotheneumPattern {
             for (int col = 0; col < Apotheneum.GRID_WIDTH; col++) {
                 int globalCol = face * Apotheneum.GRID_WIDTH + col;
                 int available = orientation.available(globalCol);
-                LXModel column = orientation.columns()[globalCol];
+                Apotheneum.Column column = orientation.columns()[globalCol];
                 
                 boolean isInDoor = available < Apotheneum.GRID_HEIGHT;
                 boolean nextInDoor = (col < Apotheneum.GRID_WIDTH - 1) && 
@@ -210,7 +209,7 @@ public class EdgeTracer extends ApotheneumPattern {
                     }
                     if (!nextInDoor && col < Apotheneum.GRID_WIDTH - 1) {
                         int nextGlobalCol = face * Apotheneum.GRID_WIDTH + col + 1;
-                        LXModel nextColumn = orientation.columns()[nextGlobalCol];
+                        Apotheneum.Column nextColumn = orientation.columns()[nextGlobalCol];
                         addDescentTransition(facePath, nextColumn, Apotheneum.GRID_HEIGHT, Apotheneum.DOOR_HEIGHT);
                     }
                 }
@@ -218,7 +217,7 @@ public class EdgeTracer extends ApotheneumPattern {
             
             // Right edge (bottom to top)
             int rightGlobalCol = face * Apotheneum.GRID_WIDTH + (Apotheneum.GRID_WIDTH - 1);
-            LXModel rightColumn = orientation.columns()[rightGlobalCol];
+            Apotheneum.Column rightColumn = orientation.columns()[rightGlobalCol];
             for (int y = rightColumn.points.length - 2; y >= 0; y--) {
                 facePath.add(rightColumn.points[y]);
             }
@@ -226,7 +225,7 @@ public class EdgeTracer extends ApotheneumPattern {
             // Top edge (right to left)
             for (int col = Apotheneum.GRID_WIDTH - 2; col >= 0; col--) {
                 int globalCol = face * Apotheneum.GRID_WIDTH + col;
-                LXModel column = orientation.columns()[globalCol];
+                Apotheneum.Column column = orientation.columns()[globalCol];
                 if (column.points.length > 0) {
                     facePath.add(column.points[0]);
                 }
@@ -234,7 +233,7 @@ public class EdgeTracer extends ApotheneumPattern {
             
             // Left edge (top to bottom) - but don't duplicate the starting point
             int leftGlobalCol = face * Apotheneum.GRID_WIDTH;
-            LXModel leftColumn = orientation.columns()[leftGlobalCol];
+            Apotheneum.Column leftColumn = orientation.columns()[leftGlobalCol];
             int leftAvailable = orientation.available(leftGlobalCol);
             int startY = (leftAvailable < Apotheneum.GRID_HEIGHT) ? leftAvailable - 1 : leftColumn.points.length - 2;
             
@@ -292,7 +291,7 @@ public class EdgeTracer extends ApotheneumPattern {
         // Simple top edge - no doors to worry about
         for (int face = 0; face < 4; face++) {
             Apotheneum.Cube.Face cubeFace = cube.faces[face];
-            for (LXModel column : cubeFace.columns) {
+            for (Apotheneum.Column column : cubeFace.columns) {
                 if (column.points.length > 0) {
                     cubeTopPath.add(column.points[0]);
                 }
@@ -329,7 +328,7 @@ public class EdgeTracer extends ApotheneumPattern {
             for (int col = 0; col < Apotheneum.GRID_WIDTH; col++) {
                 int globalCol = face * Apotheneum.GRID_WIDTH + col;
                 int available = cube.interior.available(globalCol);
-                LXModel column = cube.interior.columns()[globalCol];
+                Apotheneum.Column column = cube.interior.columns()[globalCol];
                 
                 boolean isInDoor = available < Apotheneum.GRID_HEIGHT;
                 boolean nextInDoor = (col < Apotheneum.GRID_WIDTH - 1) && 
@@ -346,7 +345,7 @@ public class EdgeTracer extends ApotheneumPattern {
                     }
                     if (!nextInDoor && col < Apotheneum.GRID_WIDTH - 1) {
                         int nextGlobalCol = face * Apotheneum.GRID_WIDTH + col + 1;
-                        LXModel nextColumn = cube.interior.columns()[nextGlobalCol];
+                        Apotheneum.Column nextColumn = cube.interior.columns()[nextGlobalCol];
                         DoorTraversal.addDescentTransition(cubeBottomPathInterior, nextColumn, Apotheneum.GRID_HEIGHT, Apotheneum.DOOR_HEIGHT);
                     }
                 }
@@ -365,7 +364,7 @@ public class EdgeTracer extends ApotheneumPattern {
         for (int face = 0; face < 4; face++) {
             for (int col = 0; col < Apotheneum.GRID_WIDTH; col++) {
                 int globalCol = face * Apotheneum.GRID_WIDTH + col;
-                LXModel column = cube.interior.columns[globalCol];
+                Apotheneum.Column column = cube.interior.columns[globalCol];
                 if (column.points.length > 0) {
                     cubeTopPathInterior.add(column.points[0]);
                 }
@@ -408,7 +407,7 @@ public class EdgeTracer extends ApotheneumPattern {
         for (int col = 0; col < cubeFace.columns.length; col++) {
             int globalCol = frontFace * Apotheneum.GRID_WIDTH + col;
             int available = orientation.available(globalCol);
-            LXModel column = cubeFace.columns[col];
+            Apotheneum.Column column = cubeFace.columns[col];
             
             // Always use the last available LED (bottom-most) from each column
             if (available > 0 && (available - 1) < column.points.length) {
@@ -429,7 +428,7 @@ public class EdgeTracer extends ApotheneumPattern {
         for (int col = 0; col < Apotheneum.GRID_WIDTH; col++) {
             int globalCol = frontFace * Apotheneum.GRID_WIDTH + col;
             int available = orientation.available(globalCol);
-            LXModel column = orientation.columns()[globalCol];
+            Apotheneum.Column column = orientation.columns()[globalCol];
             
             // Always use the last available LED (bottom-most) from each column
             if (available > 0 && (available - 1) < column.points.length) {

--- a/src/main/java/apotheneum/mcslee/Abacus.java
+++ b/src/main/java/apotheneum/mcslee/Abacus.java
@@ -27,7 +27,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.modulator.Damper;
 import heronarts.lx.parameter.CompoundDiscreteParameter;
@@ -89,7 +88,7 @@ public class Abacus extends ApotheneumPattern {
 
     private final int NUM_BEADS = 7;
     private final BeadMetrics metrics;
-    private final LXModel[] columns;
+    private final Apotheneum.Column[] columns;
     private final CompoundDiscreteParameter placeValue;
     private final int xPos;
 
@@ -103,7 +102,7 @@ public class Abacus extends ApotheneumPattern {
       this(orientation.columns, CYLINDER_METRICS, placeValue, xPos);
     }
 
-    private Digit(LXModel[] columns, BeadMetrics metrics, CompoundDiscreteParameter placeValue, int xPos) {
+    private Digit(Apotheneum.Column[] columns, BeadMetrics metrics, CompoundDiscreteParameter placeValue, int xPos) {
       this.columns = columns;
       this.metrics = metrics;
       this.placeValue = placeValue;
@@ -137,7 +136,7 @@ public class Abacus extends ApotheneumPattern {
         int pos = (int) Math.round(this.base[i] - this.dampers.get(i).getValue() * this.metrics.beadShift);
 
         for (int x = 0; x < this.metrics.beadWidth; ++x) {
-          final LXModel column = this.columns[this.xPos+x];
+          final Apotheneum.Column column = this.columns[this.xPos+x];
           int yMin = 0, yMax = BEAD_HEIGHT;
           if (x == 0 || x == this.metrics.beadWidth - 1) {
             ++yMin;
@@ -174,7 +173,7 @@ public class Abacus extends ApotheneumPattern {
     // NB: the exterior front is used to render, whether or not it's in the view,
     // so make sure that we black it out!
     setColor(Apotheneum.cube.exterior.front.model, LXColor.BLACK);
-    for (LXModel column : Apotheneum.cylinder.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cylinder.exterior.columns) {
       setColor(column, LXColor.BLACK);
     }
 

--- a/src/main/java/apotheneum/mcslee/Bursts.java
+++ b/src/main/java/apotheneum/mcslee/Bursts.java
@@ -160,7 +160,7 @@ public abstract class Bursts extends ApotheneumPattern implements ApotheneumPatt
 
   protected class Burst {
 
-    private final LXModel[] columns;
+    private final Apotheneum.Column[] columns;
     private float basis;
     private final float xn;
     private final float yn;
@@ -181,7 +181,7 @@ public abstract class Bursts extends ApotheneumPattern implements ApotheneumPatt
       this(orientation.columns(), null);
     }
 
-    protected Burst(LXModel[] columns, Burst copy) {
+    protected Burst(Apotheneum.Column[] columns, Burst copy) {
       this.columns = columns;
 
       if (copy != null) {
@@ -234,7 +234,7 @@ public abstract class Bursts extends ApotheneumPattern implements ApotheneumPatt
         final float wrapOffset = wrap ? 0 : 1;
 
         int x = 0;
-        for (LXModel column : this.columns) {
+        for (Apotheneum.Column column : this.columns) {
           int y = 0;
           for (LXPoint p : column.points) {
             float pxn = x / (this.columns.length - wrapOffset);

--- a/src/main/java/apotheneum/mcslee/CubeBlinks.java
+++ b/src/main/java/apotheneum/mcslee/CubeBlinks.java
@@ -12,7 +12,6 @@ import heronarts.lx.LXDeviceComponent;
 import heronarts.lx.LXLayer;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.midi.MidiNoteOn;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
@@ -67,7 +66,7 @@ public class CubeBlinks extends ApotheneumPattern implements LXDeviceComponent.M
       final double releaseLevel = LXUtils.lerp(1, 0, Math.pow(this.basis, this.releaseShape));
 
       int ci = 0;
-      for (LXModel column : this.face.columns) {
+      for (Apotheneum.Column column : this.face.columns) {
         final float xn = ci / (Apotheneum.GRID_WIDTH-1f);
         int pi = 0;
         for (LXPoint p : column.points) {

--- a/src/main/java/apotheneum/mcslee/CubeSparkles.java
+++ b/src/main/java/apotheneum/mcslee/CubeSparkles.java
@@ -127,11 +127,11 @@ public class CubeSparkles extends ApotheneumPattern implements ApotheneumPattern
 
   private class Sparkle {
 
-    private final LXModel column;
+    private final Apotheneum.Column column;
     private final float basePos;
     private float basis;
 
-    private Sparkle(LXModel[] columns) {
+    private Sparkle(Apotheneum.Column[] columns) {
       this.column = columns[LXUtils.randomi(columns.length-1)];
       this.basePos = LXUtils.randomf(maxHeight.getValuef());
     }

--- a/src/main/java/apotheneum/mcslee/DoorMask.java
+++ b/src/main/java/apotheneum/mcslee/DoorMask.java
@@ -24,7 +24,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
@@ -81,28 +80,28 @@ public class DoorMask extends ApotheneumEffect {
     }
 
     int i = 0;
-    for (LXModel column : Apotheneum.cube.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cube.exterior.columns) {
       renderColumn(column, i, true, enabledAmount);
       ++i;
     }
     i = 0;
-    for (LXModel column : Apotheneum.cube.interior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cube.interior.columns) {
       renderColumn(column, i, true, enabledAmount);
       ++i;
     }
     i = 0;
-    for (LXModel column : Apotheneum.cylinder.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cylinder.exterior.columns) {
       renderColumn(column, i, false, enabledAmount);
       ++i;
     }
     i = 0;
-    for (LXModel column : Apotheneum.cylinder.interior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cylinder.interior.columns) {
       renderColumn(column, i, false, enabledAmount);
       ++i;
     }
   }
 
-  protected void renderColumn(LXModel column, int index, boolean isCube, double amount) {
+  protected void renderColumn(Apotheneum.Column column, int index, boolean isCube, double amount) {
     int xDist = 0;
     if (isCube) {
       xDist = (int) LXUtils.max(0, Math.abs((index % 50) - 24.5) - 4.5);

--- a/src/main/java/apotheneum/mcslee/Gravity.java
+++ b/src/main/java/apotheneum/mcslee/Gravity.java
@@ -25,7 +25,6 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.LXLayer;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.osc.OscInt;
 import heronarts.lx.osc.OscMessage;
@@ -44,7 +43,7 @@ public class Gravity extends ApotheneumPattern implements UIDeviceControls<Gravi
   private class Orb extends LXLayer {
 
     private final int numCols;
-    private final LXModel[] columns;
+    private final Apotheneum.Column[] columns;
     private final int yMax;
     private final float rnd;
     private float x;
@@ -54,7 +53,7 @@ public class Gravity extends ApotheneumPattern implements UIDeviceControls<Gravi
     private final float vxd;
     private final boolean box;
 
-    private Orb(LX lx, LXModel[] columns, boolean box) {
+    private Orb(LX lx, Apotheneum.Column[] columns, boolean box) {
       super(lx);
       this.columns = columns;
       this.numCols = columns.length;

--- a/src/main/java/apotheneum/mcslee/Overtones.java
+++ b/src/main/java/apotheneum/mcslee/Overtones.java
@@ -24,7 +24,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.osc.OscMessage;
 import heronarts.lx.parameter.BooleanParameter;
@@ -114,7 +113,7 @@ public class Overtones extends ApotheneumPattern {
     }
 
     // Map tones over all strips
-    for (LXModel strip : Apotheneum.cylinder.exterior.columns) {
+    for (Apotheneum.Column strip : Apotheneum.cylinder.exterior.columns) {
       final int sm = si % NUM_TONES;
       final int sd = si / NUM_TONES;
       final int toneIndex = (sd % 2 == 0) ? sm : (NUM_TONES - sm);

--- a/src/main/java/apotheneum/mcslee/Portals.java
+++ b/src/main/java/apotheneum/mcslee/Portals.java
@@ -24,7 +24,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.utils.LXUtils;
@@ -75,19 +74,19 @@ public class Portals extends ApotheneumPattern {
     setColors(LXColor.BLACK);
     setApotheneumColor(LXColor.BLACK);
     int i = 0;
-    for (LXModel column : Apotheneum.cube.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cube.exterior.columns) {
       renderColumn(column, i, true);
       ++i;
     }
     i = 0;
-    for (LXModel column : Apotheneum.cylinder.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cylinder.exterior.columns) {
       renderColumn(column, i, false);
       ++i;
     }
     copyExterior();
   }
 
-  protected void renderColumn(LXModel column, int index, boolean isCube) {
+  protected void renderColumn(Apotheneum.Column column, int index, boolean isCube) {
     int xDist = 0;
     if (isCube) {
       xDist = (int) LXUtils.max(0, Math.abs((index % 50) - 24.5) - 4.5);

--- a/src/main/java/apotheneum/mcslee/Raindrops.java
+++ b/src/main/java/apotheneum/mcslee/Raindrops.java
@@ -27,7 +27,6 @@ import heronarts.lx.LXLayer;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.midi.MidiNoteOn;
 import heronarts.lx.mixer.LXChannel;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.osc.OscMessage;
 import heronarts.lx.parameter.BooleanParameter;
@@ -106,7 +105,7 @@ public class Raindrops extends ApotheneumPattern implements ApotheneumPattern.Mi
   private class Drop extends LXLayer {
 
     private final Apotheneum.Orientation orientation;
-    private final LXModel column;
+    private final Apotheneum.Column column;
     private final int ringIndex;
     private double pos;
     private double velocity = 0;

--- a/src/main/java/apotheneum/mcslee/Surfacing.java
+++ b/src/main/java/apotheneum/mcslee/Surfacing.java
@@ -30,7 +30,6 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.LXSerializable;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.osc.LXOscComponent;
 import heronarts.lx.parameter.BooleanParameter;
@@ -216,7 +215,7 @@ public class Surfacing extends ApotheneumPattern implements UIDeviceControls<Sur
 
     int cylinderIndex = 0;
     if (this.cylinderOn.isOn()) {
-      for (LXModel column : Apotheneum.cylinder.exterior.columns) {
+      for (Apotheneum.Column column : Apotheneum.cylinder.exterior.columns) {
         renderColumn(column, cylinderIndex, level);
         ++cylinderIndex;
       }
@@ -225,7 +224,7 @@ public class Surfacing extends ApotheneumPattern implements UIDeviceControls<Sur
 
     if (this.cubeOn.isOn()) {
       cylinderIndex = -1;
-      for (LXModel column : Apotheneum.cube.exterior.columns) {
+      for (Apotheneum.Column column : Apotheneum.cube.exterior.columns) {
         renderColumn(column, cylinderIndex, level);
       }
       copyCubeExterior();
@@ -239,7 +238,7 @@ public class Surfacing extends ApotheneumPattern implements UIDeviceControls<Sur
     return this.cylinderLevels[cylinderIndex];
   }
 
-  private void renderColumn(LXModel column, int cylinderIndex, double level) {
+  private void renderColumn(Apotheneum.Column column, int cylinderIndex, double level) {
     final LXPoint c = column.points[0];
 
     final float xn =

--- a/src/main/java/apotheneum/test/ApotheneumTest.java
+++ b/src/main/java/apotheneum/test/ApotheneumTest.java
@@ -24,7 +24,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.parameter.EnumParameter;
@@ -250,7 +249,7 @@ public class ApotheneumTest extends ApotheneumPattern implements UIDeviceControl
 
   private static final int NET_WIDTH = 10;
 
-  private void renderColumn(Apotheneum.Orientation orientation, LXModel column, int columnIndex) {
+  private void renderColumn(Apotheneum.Orientation orientation, Apotheneum.Column column, int columnIndex) {
     switch (this.mode.getEnum()) {
     case HORIZONTAL_STRIPE -> renderHorizontal(orientation, column, columnIndex);
     case VERTICAL_STRIPE -> renderVertical(orientation, column, columnIndex);
@@ -259,7 +258,7 @@ public class ApotheneumTest extends ApotheneumPattern implements UIDeviceControl
     }
   }
 
-  private void renderGradient(Apotheneum.Orientation orientation, LXModel column, int columnIndex) {
+  private void renderGradient(Apotheneum.Orientation orientation, Apotheneum.Column column, int columnIndex) {
     final int height = orientation.available(columnIndex);
     switch (columnIndex % NET_WIDTH) {
       case 0 -> {
@@ -307,7 +306,7 @@ public class ApotheneumTest extends ApotheneumPattern implements UIDeviceControl
     }
   }
 
-  private void renderHorizontal(Apotheneum.Orientation orientation, LXModel column, int columnIndex) {
+  private void renderHorizontal(Apotheneum.Orientation orientation, Apotheneum.Column column, int columnIndex) {
     final int stripeY = this.stripeY.getValuei();
     final int color = this.color.getEnum().color;
     int py = 0;
@@ -319,13 +318,13 @@ public class ApotheneumTest extends ApotheneumPattern implements UIDeviceControl
     }
   }
 
-  private void renderVertical(Apotheneum.Orientation orientation, LXModel column, int columnIndex) {
+  private void renderVertical(Apotheneum.Orientation orientation, Apotheneum.Column column, int columnIndex) {
     if (columnIndex % 10 == this.stripeX.getValuei()) {
       setColor(column, this.color.getEnum().color);
     }
   }
 
-  private void renderDMX(Apotheneum.Orientation orientation, LXModel column, int columnIndex) {
+  private void renderDMX(Apotheneum.Orientation orientation, Apotheneum.Column column, int columnIndex) {
 
     final int perStrand = orientation.available(columnIndex);
     final int strandIndex = columnIndex % 10;
@@ -353,7 +352,7 @@ public class ApotheneumTest extends ApotheneumPattern implements UIDeviceControl
 
   private void render(Apotheneum.Orientation orientation) {
     int columnIndex = 0;
-    for (LXModel column : orientation.columns()) {
+    for (Apotheneum.Column column : orientation.columns()) {
       renderColumn(orientation, column, columnIndex++);
     }
   }

--- a/src/main/java/apotheneum/test/StripDiagnostic.java
+++ b/src/main/java/apotheneum/test/StripDiagnostic.java
@@ -24,7 +24,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.DiscreteParameter;
@@ -53,17 +52,17 @@ public class StripDiagnostic extends ApotheneumPattern {
     setColors(LXColor.BLACK);
     setApotheneumColor(LXColor.BLACK);
 
-    for (LXModel column : Apotheneum.cube.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cube.exterior.columns) {
       renderColumn(column);
     }
-    for (LXModel column : Apotheneum.cylinder.exterior.columns) {
+    for (Apotheneum.Column column : Apotheneum.cylinder.exterior.columns) {
       renderColumn(column);
     }
     copyExterior();
 
   }
 
-  protected void renderColumn(LXModel model) {
+  protected void renderColumn(Apotheneum.Column model) {
     final int start = this.start.getValuei();
     final int num = this.num.getValuei();
     final int mute = this.mute.getValuei();


### PR DESCRIPTION
I'd like to add a `Column` class to the model for the convenience of calling `for (Column c : face.columns)` in the same way that we can currently call `for (Row r : face.rows)`.

Columns are currently represented by `LXModel`, but adding a thin wrapper allows us to include an `index` field similar to `Ring.index` and `Row.index`.  By adding the index and named class, the usage patterns can now be the same across columns, rows, and rings.  I think the consistency will make adoption easier for new folks.

This required a one-time refactor of existing patterns to use `Apotheneum.Column` instead of `LXModel`.  But usage within the class is unchanged; people are universally just calling the points[] array.