### PR TITLE
add piemonte patterns: base classes and velocity set

### DIFF
--- a/src/main/java/apotheneum/piemonte/CrashingOut.java
+++ b/src/main/java/apotheneum/piemonte/CrashingOut.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * CrashingOut — LockedIn's restless sibling. A set of thick bars beams in
+ * from an edge as solid columns, each on its own clock — fast travel,
+ * decelerating approach, bounces on the entry velocity model — and locks
+ * into the center. But nothing stays locked: the bars keep bouncing, restless,
+ * until the whole set crashes back out — each bar retreating mid-bounce in
+ * reverse off its entry edge, slow to break loose and accelerating away. Then the next set enters from
+ * the opposite edge at a new horizontal offset and the next of five colors.
+ * Beats punch the bounces; Wow adds bounce reach and speeds the crash.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class CrashingOut extends StrandPattern {
+
+  private static final int N_COLORS = 5;
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_MS = 1800;    // sustained bounce before the crash
+  private static final double GONE = 1.25;         // off-canvas travel distance
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // one set at a time (normalized; shared across surfaces)
+  private final double[] barX = new double[MAX_BARS];
+  private final double[] barLen = new double[MAX_BARS];
+  private final double[] barYc = new double[MAX_BARS];
+  private final int[] barPhase = new int[MAX_BARS]; // 0 enter, 1 bounce, 3 crash
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barRnd = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];
+  private final int[] barBounce = new int[MAX_BARS];
+
+  private int gen = 0;          // total sets launched (drives color + edge)
+  private boolean fromTop = false;
+  private int mode = 0;         // 0 = animating in, 1 = bouncing, 2 = crashing out
+  private double holdT = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  public CrashingOut(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(this.gen * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void launchSet() {
+    this.fromTop = (this.gen & 1) == 1; // alternate bottom / top entries
+    this.mode = 0;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.barX[b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.barLen[b] = (0.14 + Math.random() * 0.30) * (0.8 + Math.random() * 0.4);
+      this.barYc[b] = 0.42 + Math.random() * 0.16;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.fromTop ? -1 : 1) * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barRnd[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    final int nBars = this.bars.getValuei();
+
+    // bars never sit still: they enter, bounce, and bounce until they crash away
+    boolean allArrived = true;
+    boolean allGone = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          allArrived = false;
+          allGone = false;
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            this.barBounce[b] = 0;
+            this.barTgt[b] = (this.fromTop ? 1 : -1) * bounceAmp(b);
+          }
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel, sustained
+          allGone = false;
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            // reverse into a fresh bounce, each with its own reach — no settling
+            ++this.barBounce[b];
+            this.barTgt[b] = -Math.signum(this.barTgt[b]) * bounceAmp(b)
+              * (0.55 + 0.45 * hashd(this.gen * 31 + b * 7 + this.barBounce[b] * 13));
+          }
+          break;
+        }
+        case 3: { // crashing out: the entry run in reverse, off the canvas
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allGone = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          // slow to break loose, accelerating as it pulls away
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1)) * (1 + wow * 0.8);
+          final double dir = this.fromTop ? -1 : 1; // back toward its entry edge
+          this.barPos[b] += dir * v * dt;
+          if (dist < GONE) {
+            allGone = false;
+          }
+          break;
+        }
+      }
+    }
+
+    if (this.mode == 0 && allArrived) { // everyone's in and bouncing
+      this.mode = 1;
+      this.holdT = 0;
+    } else if (this.mode == 1) { // bounce it out, then break for the edges
+      this.holdT += dt;
+      if (this.holdT >= BOUNCE_MS) {
+        this.mode = 2;
+        for (int b = 0; b < MAX_BARS; ++b) {
+          this.barPhase[b] = 3;
+          this.barDelay[b] = Math.random() * 500; // staggered break-loose
+        }
+      }
+    } else if (this.mode == 2 && allGone) { // next color from the opposite edge
+      ++this.gen;
+      launchSet();
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    final int col = LXColor.hsb(
+      (float) (((LXColor.h(getColor()) + HUE_STEPS[this.gen % N_COLORS]) % 360) + 360) % 360,
+      92, 100);
+    final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+
+    for (int b = 0; b < nBars; ++b) {
+      final double len = this.barLen[b];
+      double yc = this.barYc[b];
+      boolean traveling = false;
+      if (this.barPhase[b] == 0 || this.barPhase[b] == 3) {
+        if (this.barPhase[b] == 0 && this.barDelay[b] > 0) continue; // not launched
+        yc += this.barPos[b];
+        traveling = true;
+      } else if (this.barPhase[b] == 1) {
+        yc += this.barPos[b]; // bouncing
+      }
+      // solid column anchored to its entry edge, reaching to its lead end
+      final double leadF = this.fromTop
+        ? (yc + len / 2) * (h - 1)
+        : (yc - len / 2) * (h - 1);
+      if (this.fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+      final int x0 = (int) Math.round(this.barX[b] * w);
+      final int bw = (int) thickC;
+      final double span = this.fromTop
+        ? Math.max(1, leadF)
+        : Math.max(1, (h - 1) - leadF);
+
+      for (int dx = 0; dx < bw; ++dx) {
+        final int x = x0 + dx;
+        final int yStart = this.fromTop ? 0 : (int) Math.floor(leadF);
+        final int yEnd = this.fromTop ? (int) Math.ceil(leadF) : h - 1;
+        for (int yy = yStart; yy <= yEnd; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = this.fromTop ? (yy - leadF) : (leadF - yy);
+          final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+          if (cov <= 0.02) continue;
+          final double back = Math.abs(yy - leadF) / span;
+          int c = col;
+          double bb = cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+            * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + tq));
+          if (traveling && Math.abs(yy - leadF) < 1.5) {
+            c = hot;
+            bb = Math.min(1, bb * 1.5);
+          }
+          addPix(o, x, yy, c, bb);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/LockedIn.java
+++ b/src/main/java/apotheneum/piemonte/LockedIn.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * LockedIn — sets of thick bars lock into the center of the canvas, one color
+ * at a time. Each bar is a solid column anchored to its entry edge, growing
+ * toward the middle with the UFOAbduction feel — fast travel, decelerating on
+ * approach — then bouncing on the same velocity model, each bar on its own
+ * clock and reach, before freezing in place. Sets alternate bottom and top
+ * entries, each at a new horizontal offset, cycling through five colors and
+ * layering endlessly: the stack never fades — new sets keep locking in over
+ * the old, and only when a color comes back around does its previous layer
+ * yield to the fresh one rising from the edge. Beats punch the bounces; Wow
+ * adds bounce reach and shimmer.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class LockedIn extends StrandPattern {
+
+  private static final int N_COLORS = 5;    // hues cycled across sets
+  private static final int MAX_LAYERS = 10; // frozen sets kept on the canvas
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_DECAY = 0.78; // per-bounce settle
+  private static final double RELAUNCH_MS = 450;   // breath between sets
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // layered set state (normalized; shared across surfaces)
+  private final double[][] layX = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layLen = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layYc = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] lenVar = new double[MAX_LAYERS][MAX_BARS];
+  private final int[] layerHue = new int[MAX_LAYERS];
+  private final boolean[] layerFromTop = new boolean[MAX_LAYERS];
+  private final boolean[] layerLive = new boolean[MAX_LAYERS];
+
+  private int gen = 0;           // total sets launched
+  private int activeLayer = -1;  // layer currently animating, -1 = between sets
+  private double pauseMs = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  // per-bar independent motion within the active set
+  private final int[] barPhase = new int[MAX_BARS];  // 0 enter, 1 bounce, 2 frozen
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barBopPh = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];   // current bounce target
+  private final int[] barBounce = new int[MAX_BARS];      // reversals remaining
+
+  public LockedIn(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int l, int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(l * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Launch the next set: claim a layer (recycling the oldest) and arm bars. */
+  private void launchSet() {
+    final int l = this.gen % MAX_LAYERS;
+    this.activeLayer = l;
+    this.layerHue[l] = this.gen % N_COLORS;
+    this.layerFromTop[l] = (this.gen & 1) == 1; // alternate bottom / top
+    this.layerLive[l] = true;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.layX[l][b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.layLen[l][b] = 0.14 + Math.random() * 0.30; // varied reach
+      this.layYc[l][b] = 0.42 + Math.random() * 0.16;  // tips around center
+      this.lenVar[l][b] = 0.8 + Math.random() * 0.4;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.layerFromTop[l] ? -1 : 1)
+        * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barBopPh[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    if (this.activeLayer < 0) { // between sets: breathe, then launch the next
+      this.pauseMs -= dt;
+      if (this.pauseMs <= 0) {
+        launchSet();
+      }
+      return;
+    }
+
+    final int l = this.activeLayer;
+    final int nBars = this.bars.getValuei();
+    boolean allFrozen = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allFrozen = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            // momentum carries into the first bounce, past the rest point
+            this.barBounce[b] = 3 + (int) (this.barBopPh[b] * 3);
+            this.barTgt[b] = (this.layerFromTop[l] ? 1 : -1) * bounceAmp(l, b);
+          }
+          allFrozen = false;
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            if (--this.barBounce[b] <= 0) {
+              // ease home and freeze
+              if (Math.abs(this.barPos[b]) < 0.008) {
+                this.barPos[b] = 0;
+                this.barPhase[b] = 2;
+              } else {
+                this.barTgt[b] = 0;
+                this.barBounce[b] = 1;
+              }
+            } else {
+              // reverse, each bounce a little smaller
+              this.barTgt[b] = -Math.signum(this.barTgt[b])
+                * bounceAmp(l, b)
+                * Math.pow(BOUNCE_DECAY, 6 - this.barBounce[b]);
+            }
+          }
+          allFrozen = false;
+          break;
+        }
+      }
+    }
+    if (allFrozen) { // set locked; the stack stays — queue the next set
+      ++this.gen;
+      this.activeLayer = -1;
+      this.pauseMs = RELAUNCH_MS;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double hueShift = LXColor.h(getColor());
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int l = 0; l < MAX_LAYERS; ++l) {
+      if (!this.layerLive[l]) continue;
+      final boolean active = (l == this.activeLayer);
+      final boolean fromTop = this.layerFromTop[l];
+      final int col = LXColor.hsb(
+        (float) (((hueShift + HUE_STEPS[this.layerHue[l]]) % 360) + 360) % 360, 92, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+      final double genB = active ? 1.0 : 0.82;
+
+      for (int b = 0; b < nBars; ++b) {
+        final double xN = this.layX[l][b];
+        final double len = this.layLen[l][b] * this.lenVar[l][b];
+        double yc = this.layYc[l][b];
+        boolean entering = false;
+        if (active) {
+          if (this.barPhase[b] == 0) {
+            if (this.barDelay[b] > 0) continue; // not launched yet
+            yc += this.barPos[b]; // still traveling in
+            entering = true;
+          } else if (this.barPhase[b] == 1) {
+            yc += this.barPos[b]; // bouncing on the entry velocity model
+          }
+        }
+        // solid column anchored to its entry edge, reaching to its lead end:
+        // bottom-entering bars fill floor-to-lead, top-entering sky-to-lead
+        final double leadF = fromTop
+          ? (yc + len / 2) * (h - 1)   // lead end grows downward from the sky
+          : (yc - len / 2) * (h - 1);  // lead end grows upward from the floor
+        if (fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+        final int x0 = (int) Math.round(xN * w);
+        final int bw = (int) thickC;
+        final double span = fromTop
+          ? Math.max(1, leadF)
+          : Math.max(1, (h - 1) - leadF);
+
+        for (int dx = 0; dx < bw; ++dx) {
+          final int x = x0 + dx;
+          final int yStart = fromTop ? 0 : (int) Math.floor(leadF);
+          final int yEnd = fromTop ? (int) Math.ceil(leadF) : h - 1;
+          for (int yy = yStart; yy <= yEnd; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final double dOut = fromTop ? (yy - leadF) : (leadF - yy);
+            final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+            if (cov <= 0.02) continue;
+            // brightest at the lead end, easing back toward the anchor edge
+            final double back = Math.abs(yy - leadF) / span;
+            int c = col;
+            double bb = genB * cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+              * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + (active ? tq : 0)));
+            if (entering && Math.abs(yy - leadF) < 1.5) {
+              c = hot;
+              bb = Math.min(1, bb * 1.5);
+            }
+            addPix(o, x, yy, c, bb);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -33,9 +33,22 @@ package apotheneum.piemonte;
 import apotheneum.ApotheneumPattern;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
 
 public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Shared render-target selector: both structures, cube only, or cylinder only. */
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  /** Created by addTargetParameter(); null when a pattern doesn't opt in. */
+  public EnumParameter<Target> target;
 
   /** Primary hue (degrees) — the single dial that steers pattern color. */
   public final CompoundParameter hue =
@@ -53,6 +66,36 @@ public abstract class ParameterPattern extends ApotheneumPattern {
   public final CompoundParameter wow =
     new CompoundParameter("Wow", 0, 0, 1)
     .setDescription("Extra flourish / special-effect intensity");
+
+  /**
+   * External audio inputs. Nothing in these patterns samples the LX audio
+   * meter — installation volume is expected to change, which would rescale
+   * every internally-analyzed level. Instead the envelope-follower step runs
+   * in the audio program (e.g. Ableton feeding the show-control M4L device),
+   * which sends a volume-stable signal here over OSC/MIDI modulation.
+   */
+  public final CompoundParameter level =
+    new CompoundParameter("Level", 0, 0, 1)
+    .setDescription("Audio level input — map an external envelope follower (OSC/MIDI)");
+
+  public final BooleanParameter pulse =
+    new BooleanParameter("Pulse", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Beat trigger input — map an external beat source (OSC/MIDI)");
+
+  // --- audio state derived from the external inputs, once per frame ---
+  private boolean prevPulse;
+  private double prevLevel, sinceBeatMs = 1e9;
+  /** Slow-average of the level input; useful for contrast ratios. */
+  protected double levelAvg;
+  /** True on the frame a beat fires (Pulse edge, or a Level onset). */
+  protected boolean beat;
+  /** Normalized beat strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Level input shaped by a 25ms attack / 220ms release envelope. */
+  protected double levelEnv;
+  /** Accumulated pattern time in ms. */
+  protected double timeMs = 0;
 
   /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
   protected ParameterPattern(LX lx) {
@@ -82,6 +125,94 @@ public abstract class ParameterPattern extends ApotheneumPattern {
     addParameter("speed", this.speed);
     addParameter("size", this.size);
     addParameter("wow", this.wow);
+    addParameter("level", this.level);
+    addParameter("pulse", this.pulse);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addTargetParameter(Target.BOTH);
+  }
+
+  /** Target with a pattern-specific default. */
+  protected void addTargetParameter(Target def) {
+    this.target = new EnumParameter<Target>("Target", def)
+      .setDescription("Which structures to render to");
+    addParameter("target", this.target);
+  }
+
+  /** Current target; BOTH when the pattern doesn't expose the selector. */
+  protected Target getTarget() {
+    return (this.target != null) ? this.target.getEnum() : Target.BOTH;
+  }
+
+  /** Beat threshold multiplier for Level onsets; override to wire a Sens param. */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  /**
+   * Advance the derived audio state from the external Level/Pulse inputs.
+   * StrandPattern calls this automatically each frame; patterns that extend
+   * ParameterPattern directly call it at the top of render().
+   */
+  protected void stepAudio(double deltaMs) {
+    this.timeMs += deltaMs;
+    final double lvl = this.level.getValue();
+
+    // attack/release envelope + slow average for contrast ratios
+    final double alpha = (lvl > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (lvl - this.levelEnv) * alpha;
+    this.levelAvg += (lvl - this.levelAvg) * (1 - Math.exp(-deltaMs / 2000.0));
+
+    // beats: a Pulse edge always fires; Level onsets fire when it climbs
+    // clear of its own slow average (volume-stable, since the follower is
+    // upstream of any installation volume changes)
+    this.sinceBeatMs += deltaMs;
+    final boolean p = this.pulse.isOn();
+    final boolean pulseEdge = p && !this.prevPulse;
+    this.prevPulse = p;
+    final boolean onset = (lvl > this.levelAvg * beatThreshold())
+      && (lvl > this.prevLevel)
+      && (this.sinceBeatMs >= 130)
+      && (lvl > 0.01);
+    this.prevLevel = lvl;
+    this.beat = pulseEdge || onset;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = pulseEdge ? 1.0
+      : LXUtils.clamp((lvl / Math.max(1e-4, this.levelAvg) - 1.0) / 1.5, 0, 1);
+  }
+
+  /**
+   * Pseudo-spectrum: the level envelope spread across n bands with slow
+   * per-band drift, so band-indexed visuals keep independent motion without
+   * sampling the internal meter.
+   */
+  protected double band(int i, int n) {
+    final double drift = 0.5 + 0.5 * Math.sin(
+      this.timeMs * (0.0009 + 0.0008 * phash(i * 31 + n * 7)) + i * 2.1);
+    return this.levelEnv * (0.45 + 0.55 * drift);
+  }
+
+  private boolean prevPulseLocal;
+
+  /** True exactly once per Pulse press; for patterns running bespoke detectors. */
+  protected boolean pulseHit() {
+    final boolean p = this.pulse.isOn();
+    final boolean edge = p && !this.prevPulseLocal;
+    this.prevPulseLocal = p;
+    return edge;
+  }
+
+  private static double phash(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
   }
 
   // Convenience getters. Subclasses can also tweak the

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2026- Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * Created by patrick piemonte
+ *
+ * ParameterPattern — an intermediate base (ApotheneumPattern → ParameterPattern
+ * → your pattern) that fixes a consistent leading parameter order: hue,
+ * speed, size, wow. Every pattern that extends it gets those four controls in
+ * the same place. Subclasses extend this, then add their own parameters (and
+ * any extra colors) after super(...). Kept self-contained so
+ * last-minute changes don't ripple across other authors' content.
+ *
+ * "Wow" is a shared performance macro in the spirit of LXStudio-TE's WOW knobs:
+ * a 0..1 "extra flourish" each pattern interprets in its own way. It defaults to
+ * 0 (inert), so a pattern that ignores it is unaffected and its resting look is
+ * unchanged; patterns that read getWow() add a special-effect layer as it rises.
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.ApotheneumPattern;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+
+public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Primary hue (degrees) — the single dial that steers pattern color. */
+  public final CompoundParameter hue =
+    new CompoundParameter("Hue", 0, 0, 360)
+    .setDescription("Primary hue")
+    .setWrappable(true);
+
+  /** Animation speed. Range/polarity set per-subclass via the constructor. */
+  public final CompoundParameter speed;
+
+  /** Element size. Range set per-subclass via the constructor. */
+  public final CompoundParameter size;
+
+  /** Shared "wow" performance macro (0..1). Defaults to 0 (inert). */
+  public final CompoundParameter wow =
+    new CompoundParameter("Wow", 0, 0, 1)
+    .setDescription("Extra flourish / special-effect intensity");
+
+  /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
+  protected ParameterPattern(LX lx) {
+    this(lx, 0.4, -1, 1, 0.5, 0, 1);
+  }
+
+  /**
+   * CompoundParameter ranges are immutable after construction, so subclasses
+   * pass their desired speed/size ranges here. Speed becomes bipolar when its
+   * minimum is negative.
+   */
+  protected ParameterPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx);
+
+    this.speed = new CompoundParameter("Speed", speedDef, speedMin, speedMax)
+      .setDescription("Animation speed");
+    if (speedMin < 0) {
+      this.speed.setPolarity(CompoundParameter.Polarity.BIPOLAR);
+    }
+    this.size = new CompoundParameter("Size", sizeDef, sizeMin, sizeMax)
+      .setDescription("Element size");
+
+    // Canonical leading order: hue, speed, size, wow. Subclasses add the rest.
+    addParameter("hue", this.hue);
+    addParameter("speed", this.speed);
+    addParameter("size", this.size);
+    addParameter("wow", this.wow);
+  }
+
+  // Convenience getters. Subclasses can also tweak the
+  // inherited params directly, e.g. this.speed.setExponent(2) or
+  // this.size.setUnits(LXParameter.Units.INTEGER), in their constructor.
+
+  /** Resolved primary color for this frame — the Hue knob at full strength. */
+  protected int getColor() {
+    return LXColor.hsb(this.hue.getValuef() % 360, 100, 100);
+  }
+
+  /** Current speed value (bipolar when the configured minimum is negative). */
+  protected double getSpeed() {
+    return this.speed.getValue();
+  }
+
+  /** Current size value. */
+  protected double getSize() {
+    return this.size.getValue();
+  }
+
+  /** Current "wow" macro value (0..1); 0 means the flourish is off. */
+  protected double getWow() {
+    return this.wow.getValue();
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * StrandPattern — shared engine for the "hanging light-strand curtain" family of
+ * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
+ * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
+ * vertical strands of light with a top-lit drip gradient, glowing floor pools,
+ * comet rain, and heavy audio reactivity. Subclasses implement one "program"
+ * each; this base provides the column/drip/pool math, a comet renderer,
+ * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
+ * attack/release envelope, coarse FFT bins).
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+public abstract class StrandPattern extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  // --- audio state, computed once per frame ---
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  /** True on the frame a bass onset fires. */
+  protected boolean beat;
+  /** Normalized bass onset strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Broadband level envelope: 25ms attack / 220ms release. */
+  protected double levelEnv;
+  protected double timeMs = 0;
+
+  protected StrandPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addParameter("target", this.target);
+  }
+
+  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  private void stepAudio(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    this.beat = (bass > this.bassAvg * beatThreshold())
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 130)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+  }
+
+  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
+  protected double band(int i, int n) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    int lo = i * nb / n;
+    int hi = Math.max(lo + 1, (i + 1) * nb / n);
+    return m.getAveragef(lo, hi - lo);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+    stepAudio(deltaMs);
+    advance(deltaMs);
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      renderStrands(Apotheneum.cube.exterior, deltaMs, true);
+    }
+    if (t != Target.CUBE) {
+      renderStrands(Apotheneum.cylinder.exterior, deltaMs, false);
+    }
+    copyExterior();
+  }
+
+  /** Per-frame global state update before surfaces render. */
+  protected void advance(double deltaMs) {}
+
+  /** Draw one surface's strand program. Called for cube and/or cylinder exterior. */
+  protected abstract void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube);
+
+  // ------------------------------------------------------------------
+  // strand look utilities
+
+  /** Top-lit drip gradient: strands are brightest at the hang point. */
+  protected static double drip(int y, int h) {
+    return 1.0 - 0.35 * (double) y / Math.max(1, h - 1);
+  }
+
+  /** Additive floor-pool boost for the bottom rows (strand puddles glowing). */
+  protected static double pool(int y, int h) {
+    int fromBottom = (h - 1) - y;
+    if (fromBottom >= 4) return 0;
+    return 0.35 * (1.0 - fromBottom / 4.0);
+  }
+
+  /**
+   * Mirror the rows above the floor line into the bottom rows at reduced gain —
+   * the reflective-floor signature. Call AFTER drawing surface content.
+   */
+  protected void mirrorFloor(Apotheneum.Orientation o, int rows, float gain) {
+    final int w = o.width();
+    final int h = o.height();
+    final int axis = h - rows;
+    for (int x = 0; x < w; ++x) {
+      for (int y = axis; y < h; ++y) {
+        int src = 2 * axis - 1 - y;
+        if (src < 0) continue;
+        int c = this.colors[o.point(x, src).index];
+        int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, gain));
+      }
+    }
+  }
+
+  /** Additive pixel write with wrapped x; y outside the surface is dropped. */
+  protected void addPix(Apotheneum.Orientation o, int x, int y, int color, double b) {
+    if (b <= 0.004) return;
+    final int h = o.height();
+    if (y < 0 || y >= h) return;
+    final int w = o.width();
+    final int xi = ((x % w) + w) % w;
+    final int idx = o.point(xi, y).index;
+    this.colors[idx] = LXColor.lightest(this.colors[idx],
+      LXColor.scaleBrightness(color, (float) LXUtils.clamp(b, 0, 1)));
+  }
+
+  /**
+   * Falling comet: sub-pixel head at (x, y) with an exponential tail rising
+   * above it. White-hot head when hot is true.
+   */
+  protected void comet(Apotheneum.Orientation o, double x, double y, double tail,
+      int color, double bright, boolean hot) {
+    final int xi = (int) Math.round(x);
+    final int head = (int) Math.floor(y);
+    final double hf = y - head;
+    final int n = Math.max(1, (int) tail);
+    final int headColor = hot ? LXColor.lerp(color, LXColor.WHITE, 0.55f) : color;
+    for (int k = 0; k <= n; ++k) {
+      double b = bright * Math.exp(-2.2 * k / tail);
+      addPix(o, xi, head - k, (k == 0) ? headColor : color, (k == 0) ? b * (0.4 + 0.6 * hf) : b);
+    }
+    addPix(o, xi, head + 1, headColor, bright * hf * 0.5);
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -7,10 +7,10 @@
  * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
  * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
  * vertical strands of light with a top-lit drip gradient, glowing floor pools,
- * comet rain, and heavy audio reactivity. Subclasses implement one "program"
- * each; this base provides the column/drip/pool math, a comet renderer,
- * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
- * attack/release envelope, coarse FFT bins).
+ * comet rain, and audio reactivity driven by the external Level/Pulse inputs
+ * on ParameterPattern. Subclasses implement one "program" each; this base
+ * provides the column/drip/pool math, a comet renderer, and wrapped-x pixel
+ * writes.
  */
 
 package apotheneum.piemonte;
@@ -18,30 +18,9 @@ package apotheneum.piemonte;
 import apotheneum.Apotheneum;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 public abstract class StrandPattern extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
-
-  // --- audio state, computed once per frame ---
-  private double bassAvg, prevBass, sinceBeatMs = 1e9;
-  /** True on the frame a bass onset fires. */
-  protected boolean beat;
-  /** Normalized bass onset strength 0..1 for the current frame. */
-  protected double beatLevel;
-  /** Broadband level envelope: 25ms attack / 220ms release. */
-  protected double levelEnv;
-  protected double timeMs = 0;
 
   protected StrandPattern(LX lx,
       double speedDef, double speedMin, double speedMax,
@@ -49,56 +28,13 @@ public abstract class StrandPattern extends ParameterPattern {
     super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
   }
 
-  /** Subclasses call this LAST in their constructor to keep Target at the end. */
-  protected void addTargetParameter() {
-    addParameter("target", this.target);
-  }
-
-  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
-  protected double beatThreshold() {
-    return 1.4;
-  }
-
-  private void stepAudio(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
-    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
-    this.sinceBeatMs += deltaMs;
-    this.beat = (bass > this.bassAvg * beatThreshold())
-      && (bass > this.prevBass)
-      && (this.sinceBeatMs >= 130)
-      && (bass > 0.01);
-    this.prevBass = bass;
-    if (this.beat) {
-      this.sinceBeatMs = 0;
-    }
-    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
-
-    double level = m.getAveragef(0, nb);
-    double alpha = (level > this.levelEnv)
-      ? 1 - Math.exp(-deltaMs / 25.0)
-      : 1 - Math.exp(-deltaMs / 220.0);
-    this.levelEnv += (level - this.levelEnv) * alpha;
-  }
-
-  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
-  protected double band(int i, int n) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    int lo = i * nb / n;
-    int hi = Math.max(lo + 1, (i + 1) * nb / n);
-    return m.getAveragef(lo, hi - lo);
-  }
-
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
-    this.timeMs += deltaMs;
     stepAudio(deltaMs);
     advance(deltaMs);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       renderStrands(Apotheneum.cube.exterior, deltaMs, true);
     }

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -209,6 +209,9 @@ public class UFOAbduction extends StrandPattern {
         this.collapseT = -1;
         this.cube.reset();
         this.cylinder.reset();
+        // drop queued staggered spawns too, so a wave launched just before
+        // the collapse can't fire into the clean relaunch
+        java.util.Arrays.fill(this.pendAlive, false);
         this.relaunchQueued = true;
       }
     } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
@@ -226,8 +229,15 @@ public class UFOAbduction extends StrandPattern {
       final double strength = this.relaunchQueued ? 1.0
         : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
       final int n = this.lanes.getValuei();
-      launchWave(this.cube, true, n, strength, this.relaunchQueued);
-      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      // only feed the surfaces actually being rendered — a hidden target
+      // would otherwise pile up frozen heads at their spawn points
+      final Target t = getTarget();
+      if (t != Target.CYLINDER) {
+        launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      }
+      if (t != Target.CUBE) {
+        launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      }
       this.relaunchQueued = false;
     }
     this.launchFlash *= Math.exp(-deltaMs / 160.0);

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -1,0 +1,373 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * UFOAbduction — beat-locked counter-propagating waves on strand lanes. On every
+ * beat, green blocks launch upward from the floor at full speed, decelerate
+ * as they pass through the center — slowing to a crawl but never stopping,
+ * fattening into chunky bright slabs — then accelerate back to launch speed
+ * as they exit the top, like waves passing through a dense medium. Red
+ * streaks run the other way, top to floor, threading through the risers.
+ * Tails stretch with speed: long streamers at the edges, short stubs through
+ * the slow center; white-hot cores at speed. Lanes fire in synchronized
+ * clusters, the palette snaps between green-dominant, red-dominant, and
+ * mixed sections, and a big drop collapses the field to black before
+ * slamming a fresh wave up every lane. Modeled on the wave.mov reference.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class UFOAbduction extends StrandPattern {
+
+  private static final int MAX_HEADS = 96;
+  private static final double GREEN_HUE = 120;
+  private static final double RED_HUE = 10;
+  // calibrated from wave.mov: 800ms transit = 165ms entry + 565ms center stall
+  // + 65ms exit burst; stall:exit velocity ratio ~1:36; 900ms launch cadence
+  private static final double V_ENTRY = 0.00135;  // heights/ms, bottom leg
+  private static final double V_STALL = 0.00024;  // crawl through the center
+  private static final double V_EXIT = 0.0075;    // explosive top exit
+  private static final double V_RED = 0.0011;     // ~0.9s full-height descent
+  private static final double STALL_LO = 0.60;    // stall band (y, 0 = top)
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;     // full burst above here
+  private static final double IDLE_WAVE_MS = 900; // measured launch cadence
+  private static final double SECTION_MS = 4500;  // palette section length
+  private static final double COLLAPSE_MS = 450;
+
+  public final DiscreteParameter lanes =
+    new DiscreteParameter("Lanes", 14, 6, 24)
+    .setDescription("Strand lanes around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of launches and drops");
+
+  public final CompoundParameter glow =
+    new CompoundParameter("Glow", 0.6, 0, 1)
+    .setDescription("How far the blocks radiate light");
+
+  public final CompoundParameter trail =
+    new CompoundParameter("Trail", 0.5, 0, 1)
+    .setDescription("How long the gradient tails stream behind");
+
+  private final class Surface {
+    boolean inited;
+    final int[] lane = new int[MAX_HEADS];
+    final double[] y = new double[MAX_HEADS];     // normalized 0..1, 0 = top
+    final double[] v = new double[MAX_HEADS];     // heights/ms, +down -up
+    final boolean[] isRed = new boolean[MAX_HEADS];
+    final boolean[] thin = new boolean[MAX_HEADS]; // single-line red beams
+    final boolean[] waveR = new boolean[MAX_HEADS]; // reds riding the stall profile
+    final boolean[] alive = new boolean[MAX_HEADS];
+    void reset() {
+      for (int i = 0; i < MAX_HEADS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void spawn(int lane, boolean red) {
+      for (int i = 0; i < MAX_HEADS; ++i) {
+        if (this.alive[i]) continue;
+        this.lane[i] = lane;
+        this.isRed[i] = red;
+        this.thin[i] = red && Math.random() < 0.5;
+        // half the single lines mirror the risers' stall trajectory downward;
+        // the rest plummet straight to the floor
+        this.waveR[i] = red && this.thin[i] && Math.random() < 0.5;
+        if (red) {
+          this.y[i] = -0.02 - Math.random() * 0.08;
+          this.v[i] = this.waveR[i]
+            ? (0.9 + Math.random() * 0.2) // variance factor for the profile
+            : V_RED * (0.9 + Math.random() * 0.25) * (this.thin[i] ? 1.25 : 1.0);
+        } else {
+          this.y[i] = 1.02 + Math.random() * 0.10;
+          this.v[i] = -(0.75 + Math.random() * 0.5); // wide variance staggers the field
+        }
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double waveTimer = 0;
+  private double launchFlash = 0;
+  private double collapseT = -1;
+  private boolean relaunchQueued = false;
+  private int section = 0;
+
+  public UFOAbduction(LX lx) {
+    // Base registers color (hue shift), speed (cadence + velocity), size (block thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("lanes", this.lanes);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("glow", this.glow);
+    addParameter("trail", this.trail);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  /** Measured rise profile: brisk entry, long center stall, explosive exit. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Section palette mode: 0 = green-dominant, 1 = red-dominant, 2 = mixed. */
+  private int sectionMode() {
+    final double r = hashd(this.section * 613 + 29);
+    return (r < 0.42) ? 0 : (r < 0.68 ? 1 : 2);
+  }
+
+  // pending staggered spawns for launch wipes (lane, color, delay)
+  private final int[] pendLane = new int[MAX_HEADS];
+  private final boolean[] pendRed = new boolean[MAX_HEADS];
+  private final double[] pendMs = new double[MAX_HEADS];
+  private final boolean[] pendCube = new boolean[MAX_HEADS];
+  private final boolean[] pendAlive = new boolean[MAX_HEADS];
+
+  private void launchWave(Surface s, boolean isCube, int nLanes, double strength, boolean forceAll) {
+    final int mode = sectionMode();
+    final double redFrac = (mode == 0) ? 0.20 : (mode == 1 ? 0.75 : 0.5);
+    // per-event wipe: 0 = global, 1 = left->right, 2 = right->left, 3 = edges->center
+    final int wipe = (int) (hashd((int) (this.timeMs * 7) + 31) * 4);
+    for (int l = 0; l < nLanes; ++l) {
+      final int cluster = l / 3;
+      final double on = hashd(this.section * 977 + cluster * 131 + (int) (this.timeMs / 400));
+      if (!forceAll && on > 0.40 + strength * 0.55) continue;
+      final boolean red = hashd(this.section * 313 + cluster * 53) < redFrac;
+      double delay = 0;
+      final double u = (double) l / Math.max(1, nLanes - 1);
+      if (wipe == 1) delay = u * 370;
+      else if (wipe == 2) delay = (1 - u) * 370;
+      else if (wipe == 3) delay = (1.0 - Math.abs(u - 0.5) * 2) * 200; // edges first
+      // per-lane scatter on every wave so blocks never march in one big group
+      delay += hashd(l * 641 + (int) (this.timeMs * 3)) * 280;
+      queueSpawn(s, isCube, l, red, delay);
+      if (mode == 2 && hashd(l * 97 + (int) this.timeMs) < 0.3) {
+        queueSpawn(s, isCube, l, !red, delay + 60);
+      }
+    }
+  }
+
+  private void queueSpawn(Surface s, boolean isCube, int lane, boolean red, double delay) {
+    if (delay <= 0) {
+      s.spawn(lane, red);
+      return;
+    }
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) {
+        this.pendLane[i] = lane;
+        this.pendRed[i] = red;
+        this.pendMs[i] = delay;
+        this.pendCube[i] = isCube;
+        this.pendAlive[i] = true;
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    this.section = (int) (this.timeMs / SECTION_MS);
+
+    // collapse-to-black then hard re-drop on big hits
+    if (this.collapseT >= 0) {
+      this.collapseT += deltaMs;
+      if (this.collapseT >= COLLAPSE_MS) {
+        this.collapseT = -1;
+        this.cube.reset();
+        this.cylinder.reset();
+        this.relaunchQueued = true;
+      }
+    } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
+      this.collapseT = 0;
+    }
+
+    // beat-locked launches, with an idle subdivision cadence as fallback
+    this.waveTimer += deltaMs * speed * 2;
+    final boolean waveDue = this.waveTimer >= IDLE_WAVE_MS;
+    final boolean launch = this.relaunchQueued
+      || (this.collapseT < 0 && ((this.beat && this.beatLevel > 0.15) || waveDue));
+    if (launch) {
+      this.waveTimer = 0;
+      this.launchFlash = 1;
+      final double strength = this.relaunchQueued ? 1.0
+        : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
+      final int n = this.lanes.getValuei();
+      launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      this.relaunchQueued = false;
+    }
+    this.launchFlash *= Math.exp(-deltaMs / 160.0);
+
+    // fire staggered wipe spawns as their delays elapse
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) continue;
+      this.pendMs[i] -= deltaMs;
+      if (this.pendMs[i] <= 0) {
+        (this.pendCube[i] ? this.cube : this.cylinder).spawn(this.pendLane[i], this.pendRed[i]);
+        this.pendAlive[i] = false;
+      }
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((GREEN_HUE + hueShift) % 360)), 96, 100);
+    final int red = LXColor.hsb((float) (((RED_HUE + hueShift) % 360)), 98, 100);
+    final int nLanes = this.lanes.getValuei();
+    final double laneW = (double) w / nLanes;
+    // collapse envelope dims everything toward black before the re-drop
+    final double collapse = (this.collapseT >= 0)
+      ? 1.0 - this.collapseT / COLLAPSE_MS : 1.0;
+
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!s.alive[i]) continue;
+
+      // --- velocity field: green decelerates through the center and accelerates
+      // back out — waves passing through a dense medium, never stopping ---
+      final double vScale = speed * 2; // default Speed 0.5 == measured reference speed
+      if (s.isRed[i]) {
+        if (s.waveR[i]) {
+          // mirrored riser trajectory: zoom in from the top, slow-motion crawl
+          // through the center, burst out the floor
+          s.y[i] += s.v[i] * riseProfile(1.0 - s.y[i]) * vScale * deltaMs;
+        } else {
+          s.y[i] += s.v[i] * vScale * deltaMs; // straight plummet
+        }
+        if (s.y[i] >= 1.05) { s.alive[i] = false; continue; }
+      } else {
+        s.y[i] += s.v[i] * riseProfile(s.y[i]) * vScale * deltaMs;
+        if (s.y[i] <= -0.08) { s.alive[i] = false; continue; } // bursts out the top
+      }
+
+      // --- geometry: thick through the slow center, thin at speed; tail follows ---
+      double vNorm;
+      if (s.isRed[i] && !s.waveR[i]) {
+        vNorm = LXUtils.clamp(Math.abs(s.v[i]) / V_ENTRY, 0, 1.2);
+      } else {
+        final double yp = s.isRed[i] ? 1.0 - s.y[i] : s.y[i];
+        vNorm = LXUtils.clamp(riseProfile(yp) / V_ENTRY, 0, 1.2);
+      }
+      final double thickN = LXUtils.lerp(0.11 * (0.6 + getSize() * 0.9), 0.045, Math.min(1, vNorm));
+      final int thick = Math.max(2, (int) Math.round(thickN * h));
+      // Trail dial: 0.5 == 2x the original length; up to ~4x at full
+      final double trailK = 0.7 + this.trail.getValue() * 2.6;
+      final double tailN = LXUtils.clamp(vNorm * 0.85 * trailK, 0.16 * trailK, 1.9);
+      final int tail = (int) Math.round(tailN * h);
+      double bright = collapse;
+      if (bright <= 0.01) continue;
+
+      final int base = s.isRed[i] ? red : green;
+      // white-hot core at launch speed and on the beat flash
+      final double hot = LXUtils.clamp(vNorm * 0.7 + this.launchFlash * 0.4, 0, 0.85);
+      final int headC = LXColor.lerp(base, LXColor.WHITE, (float) hot);
+
+      int x0 = (int) (s.lane[i] * laneW);
+      int x1 = Math.min(w - 1, (int) ((s.lane[i] + 1) * laneW) - 2); // 1-col dark seam
+      if (s.isRed[i]) {
+        // red runs thin down the lane: some 2-wide strands, some single lines
+        final int cxr = (x0 + x1) / 2;
+        x0 = cxr;
+        x1 = s.thin[i] ? cxr : Math.min(w - 1, cxr + 1);
+      }
+      // strictly monotonic travel: the slow-motion crawl through the center is
+      // pure velocity — no positional oscillation (it read as shaking at LED scale)
+      final double ycF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final int yc = (int) Math.round(ycF);
+      final int dir = s.isRed[i] ? 1 : -1; // travel direction (+down)
+      // red pulses as it descends: a throb riding the moving packet
+      final double throb = s.isRed[i]
+        ? 0.55 + 0.45 * Math.sin(2 * Math.PI * this.timeMs / 1000.0 + i * 0.4) : 1.0;
+
+      final int headThick = s.isRed[i] ? Math.max(2, thick / 2) : thick; // compact red pulse
+
+      // radiant aura: soft gradient bloom bleeding off the block (ComeUp-style),
+      // strongest around the slow heavy slabs; the Glow dial sets reach + intensity
+      final double glowV = this.glow.getValue();
+      final int auraR = (s.isRed[i] ? 1 : 2) + (int) Math.round(glowV * 4);
+      final double auraB = bright * throb * (s.isRed[i] ? 0.5 : 1.0)
+        * (0.08 + glowV * 0.50) * (1.0 - 0.4 * Math.min(1, vNorm));
+      if (auraB > 0.02) {
+        final int byTop = Math.min(yc, yc - dir * (headThick - 1));
+        final int byBot = Math.max(yc, yc - dir * (headThick - 1));
+        for (int x = x0 - auraR; x <= x1 + auraR; ++x) {
+          final int dxo = (x < x0) ? (x0 - x) : ((x > x1) ? (x - x1) : 0);
+          for (int yy = byTop - auraR; yy <= byBot + auraR; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final int dyo = (yy < byTop) ? (byTop - yy) : ((yy > byBot) ? (yy - byBot) : 0);
+            final int dout = dxo + dyo;
+            if (dout == 0) continue; // inside the block
+            addPix(o, x, yy, base, auraB * Math.exp(-dout * (1.4 - glowV * 0.7)));
+          }
+        }
+      }
+
+      // continuous block span with sub-pixel feathered edges — glides, no snapping
+      final double leadF = ycF;
+      final double trailF = ycF - dir * (headThick - 1);
+      final double topF = Math.min(leadF, trailF);
+      final double botF = Math.max(leadF, trailF);
+      for (int x = x0; x <= x1; ++x) {
+        for (int yy = (int) Math.floor(topF) - 1; yy <= (int) Math.ceil(botF) + 1; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = (yy < topF) ? (topF - yy) : ((yy > botF) ? (yy - botF) : 0);
+          final double cov = LXUtils.clamp(1.0 - dOut, 0, 1); // edge feather
+          if (cov <= 0.02) continue;
+          final double u = LXUtils.clamp(1.0 - Math.abs(leadF - yy) / headThick, 0, 1);
+          addPix(o, x, yy, (u > 0.5) ? headC : base, bright * throb * (0.55 + 0.45 * u) * cov);
+        }
+        // tail streams behind, sub-pixel anchored to the trailing edge
+        for (int k = 1; k <= tail; ++k) {
+          final double yyF = trailF - dir * k;
+          final double fFall = Math.exp(-1.8 * k / tail);
+          if (fFall < 0.02) break;
+          final int yy0 = (int) Math.floor(yyF);
+          final double frac = yyF - yy0;
+          final double tb = bright * throb * fFall * 0.8;
+          if (yy0 >= 0 && yy0 < h) addPix(o, x, yy0, base, tb * (1 - frac));
+          if (yy0 + 1 >= 0 && yy0 + 1 < h) addPix(o, x, yy0 + 1, base, tb * frac);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
adds the apotheneum/piemonte package: two shared base classes and the velocity-model pattern set.

base classes:
- parameterpattern: consistent leading controls on every pattern - a wrappable hue dial, speed, size, and a wow performance macro that layers an extra flourish as it rises
- strandpattern: target selector (cube / cylinder / both), shared audio state (beat detection and level envelopes), and common drawing helpers

patterns:
- ufoabduction: beat-locked counter-propagating waves on strand lanes. on every beat, green blocks launch upward from the floor at full speed, decelerate as they pass through the center — slowing to a crawl but never stopping, fattening into chunky bright slabs — then...
- lockedin: sets of thick bars lock into the center of the canvas, one color at a time. each bar is a solid column anchored to its entry edge, growing toward the middle with the ufoabduction feel — fast travel, decelerating on approach — then bouncing on the same...
- crashingout: lockedin's restless sibling. a set of thick bars beams in from an edge as solid columns, each on its own clock — fast travel, decelerating approach, bounces on the entry velocity model — and locks into the center.

will attach video