### PR TITLE
add piemonte patterns: audio and pulse set

### DIFF
--- a/src/main/java/apotheneum/piemonte/ComeUp.java
+++ b/src/main/java/apotheneum/piemonte/ComeUp.java
@@ -22,18 +22,11 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class ComeUp extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double RISE_RATE_PER_MS = 1.0 / 6000.0; // full rise in ~6s at speed 1
   private static final double MAX_HOLD_MS = 2500.0;
@@ -142,10 +135,6 @@ public class ComeUp extends ParameterPattern {
     }
   }
 
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures the glass fills");
-
   private final Tide exterior = new Tide(0.0, 0.0, 0.0);
   // Interior seeded out of lockstep (height + time) and in a different hue.
   private final Tide interior = new Tide(0.4, 4000.0, INTERIOR_HUE_OFFSET);
@@ -158,7 +147,7 @@ public class ComeUp extends ParameterPattern {
     addParameter("hold", this.hold);
     addParameter("bubbles", this.bubbles);
     addParameter("sparkle", this.sparkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -174,7 +163,7 @@ public class ComeUp extends ParameterPattern {
     final double wow = getWow();
     final int base = getColor();
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     this.exterior.advance(deltaMs, speed, holdAmt);
     this.exterior.updateBubbles(deltaMs, speed, bubbleCount);
     if (Apotheneum.hasInterior) {

--- a/src/main/java/apotheneum/piemonte/ComeUp.java
+++ b/src/main/java/apotheneum/piemonte/ComeUp.java
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * ComeUp — a glass of water filling up. On the cylinder and/or cube (Target;
+ * interior and exterior,
+ * two independent glasses out of lockstep) a liquid tide rises bottom-to-top with
+ * a crisp, turbulent, foamy waterline. The body below the surface teems with
+ * rising bubbles and scintillating sparkles. Each time the glass fills, the flood
+ * color rotates to a new hue, so the piece cycles color with every fill.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class ComeUp extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double RISE_RATE_PER_MS = 1.0 / 6000.0; // full rise in ~6s at speed 1
+  private static final double MAX_HOLD_MS = 2500.0;
+  private static final double TEMPORAL_HZ = 0.5;
+  private static final double EDGE_BAND = 0.02;                // crisp waterline
+  private static final double INV_BAND = 1.0 / EDGE_BAND;
+  private static final int MAX_BUBBLES = 96;
+  private static final double BUBBLE_RISE = 0.00010;           // normalized rise / ms at speed 1
+  private static final double HUE_STEP = 43.0;                 // hue advance per fill (deg)
+  private static final double INTERIOR_HUE_OFFSET = 137.0;     // interior glass differs
+
+  public final DiscreteParameter detail =
+    new DiscreteParameter("Detail", 3, 1, 11)
+    .setDescription("Spatial frequency of the surface noise");
+
+  public final CompoundParameter chop =
+    new CompoundParameter("Chop", 0.35, 0, 1)
+    .setDescription("Turbulent whitewater chop (dreamy roll to full storm)");
+
+  public final CompoundParameter hold =
+    new CompoundParameter("Hold", 0.30, 0, 1)
+    .setDescription("How long the tide rests at the crest before the next surge");
+
+  public final DiscreteParameter bubbles =
+    new DiscreteParameter("Bubbles", 40, 0, MAX_BUBBLES)
+    .setDescription("Bubbles rising through each tide");
+
+  public final CompoundParameter sparkle =
+    new CompoundParameter("Sparkle", 0.4, 0, 1)
+    .setDescription("Sparse scintillating glints suspended in the liquid");
+
+  private enum Phase {
+    RISING,
+    HOLD
+  }
+
+  /** Per-surface animation state, so interior/exterior are fully independent. */
+  private static final class Tide {
+    double fillLevel;
+    double holdElapsedMs;
+    double timeMs;
+    double currOffsetDeg;   // hue offset of the flood currently rising
+    double prevOffsetDeg;   // hue offset of the receding flood above it
+    Phase phase = Phase.RISING;
+
+    // bubbles (normalized: bx 0..1 wraps, by 0=bottom..1=top)
+    final double[] bx = new double[MAX_BUBBLES];
+    final double[] by = new double[MAX_BUBBLES];
+    final double[] bsize = new double[MAX_BUBBLES];
+    final double[] bspeed = new double[MAX_BUBBLES];
+    final double[] bphase = new double[MAX_BUBBLES];
+    final boolean[] binit = new boolean[MAX_BUBBLES];
+
+    Tide(double fillLevel, double timeMs, double hueSeedDeg) {
+      this.fillLevel = fillLevel;
+      this.timeMs = timeMs;
+      this.currOffsetDeg = hueSeedDeg;
+      this.prevOffsetDeg = hueSeedDeg;
+    }
+
+    void advance(double deltaMs, double speed, double holdAmt) {
+      this.timeMs += deltaMs;
+      if (this.phase == Phase.RISING) {
+        this.fillLevel += deltaMs * speed * RISE_RATE_PER_MS;
+        if (this.fillLevel >= 1.0) {
+          this.fillLevel = 1.0;
+          this.holdElapsedMs = 0.0;
+          this.phase = Phase.HOLD;
+        }
+      } else {
+        this.holdElapsedMs += deltaMs;
+        if (this.holdElapsedMs >= holdAmt * MAX_HOLD_MS) {
+          // next glass fills with a fresh hue rising over the previous color
+          this.prevOffsetDeg = this.currOffsetDeg;
+          this.currOffsetDeg = (this.currOffsetDeg + HUE_STEP) % 360.0;
+          this.fillLevel = 0.0;
+          this.phase = Phase.RISING;
+        }
+      }
+    }
+
+    private void spawnBubble(int i) {
+      this.bx[i] = Math.random();
+      this.by[i] = 0;
+      this.bsize[i] = 0.6 + Math.random() * 1.2;
+      this.bspeed[i] = 0.6 + Math.random() * 0.9;
+      this.bphase[i] = Math.random() * Math.PI * 2;
+      this.binit[i] = true;
+    }
+
+    void updateBubbles(double deltaMs, double speed, int count) {
+      for (int i = 0; i < count; ++i) {
+        if (!this.binit[i]) {
+          spawnBubble(i);
+          // stagger initial heights so they don't all start at the floor
+          this.by[i] = Math.random() * Math.max(0.01, this.fillLevel);
+        }
+        this.by[i] += BUBBLE_RISE * speed * this.bspeed[i] * deltaMs;
+        this.bx[i] += Math.sin(this.timeMs * 0.002 + this.bphase[i]) * 0.00003 * deltaMs;
+        this.bx[i] -= Math.floor(this.bx[i]);
+        // pop at the surface, respawn at the floor
+        if (this.by[i] >= this.fillLevel || this.by[i] > 1.0) {
+          spawnBubble(i);
+        }
+      }
+    }
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures the glass fills");
+
+  private final Tide exterior = new Tide(0.0, 0.0, 0.0);
+  // Interior seeded out of lockstep (height + time) and in a different hue.
+  private final Tide interior = new Tide(0.4, 4000.0, INTERIOR_HUE_OFFSET);
+
+  public ComeUp(LX lx) {
+    // Base registers color (starting hue), speed (rise rate), size (surface amplitude), wow.
+    super(lx, 1, 0.1, 4, 0.1, 0, 0.3);
+    addParameter("detail", this.detail);
+    addParameter("chop", this.chop);
+    addParameter("hold", this.hold);
+    addParameter("bubbles", this.bubbles);
+    addParameter("sparkle", this.sparkle);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    // power curve: default (1.0) unchanged, but the ends bite — crawl at the
+    // bottom of the knob, ~9x fill rate at the top
+    final double speed = Math.pow(getSpeed(), 1.6);
+    final double holdAmt = this.hold.getValue();
+    final int bubbleCount = this.bubbles.getValuei();
+    final double sparkleAmt = this.sparkle.getValue();
+    final double wow = getWow();
+    final int base = getColor();
+
+    final Target t = this.target.getEnum();
+    this.exterior.advance(deltaMs, speed, holdAmt);
+    this.exterior.updateBubbles(deltaMs, speed, bubbleCount);
+    if (Apotheneum.hasInterior) {
+      this.interior.advance(deltaMs, speed, holdAmt);
+      this.interior.updateBubbles(deltaMs, speed, bubbleCount);
+    }
+
+    // one shared fluid state per surface pair: cube and cylinder fill in step
+    if (t != Target.CUBE) {
+      renderTide(this.exterior, Apotheneum.cylinder.exterior, base, bubbleCount, sparkleAmt, wow);
+      if (Apotheneum.hasInterior) {
+        renderTide(this.interior, Apotheneum.cylinder.interior, base, bubbleCount, sparkleAmt, wow);
+      }
+    }
+    if (t != Target.CYLINDER) {
+      renderTide(this.exterior, Apotheneum.cube.exterior, base, bubbleCount, sparkleAmt, wow);
+      if (Apotheneum.hasInterior) {
+        renderTide(this.interior, Apotheneum.cube.interior, base, bubbleCount, sparkleAmt, wow);
+      }
+    }
+
+    // Intentionally no copyExterior(): the two surfaces render independently.
+  }
+
+  private void renderTide(Tide tide, Apotheneum.Orientation o, int baseColor,
+      int bubbleCount, double sparkleAmt, double wow) {
+    // Rotate hue only; keep the palette color's saturation/brightness.
+    final float baseHue = LXColor.h(baseColor);
+    final float baseSat = LXColor.s(baseColor);
+    final float baseBri = LXColor.b(baseColor);
+    final int curr = LXColor.hsb((float) ((baseHue + tide.currOffsetDeg) % 360.0), baseSat, baseBri);
+    final int prev = LXColor.hsb((float) ((baseHue + tide.prevOffsetDeg) % 360.0), baseSat, baseBri);
+
+    final double amp = getSize();
+    final double chopAmt = this.chop.getValue();
+    final float freq = Math.max(1, this.detail.getValuei());
+    final float t = (float) (tide.timeMs * 0.001 * TEMPORAL_HZ);
+    final float driftX = t * 0.3f;
+    final float driftZ = t * 0.17f;
+    final double level = tide.fillLevel;
+
+    final double foamW = 0.012 + 0.020 * chopAmt;
+    final double foamGain = (0.55 + 0.45 * chopAmt) * (1.0 + wow * 0.8);
+    final double sTime = tide.timeMs * 0.004;
+    final int tq = (int) sTime;
+    final double tf = sTime - tq;
+    final double twEnv = Math.sin(tf * Math.PI);
+    final float glint = (float) (twEnv * twEnv);
+    final double sparkThresh = 1.0 - sparkleAmt * (0.05 + wow * 0.08);
+
+    // --- liquid body + churning surface + foam + sparkles ---
+    for (Apotheneum.Column column : o.columns()) {
+      final LXPoint[] points = column.points;
+      final int len = points.length;
+      final int last = len - 1;
+      for (int j = 0; j < len; ++j) {
+        final LXPoint p = points[j];
+        final float nx = (p.xn + driftX) * freq;
+        final float nz = (p.zn + driftZ) * freq;
+        final float base = Noise.stb_perlin_fbm_noise3(nx, nz, t, 2.0f, 0.5f, 3);
+        final float chopRaw =
+          Noise.stb_perlin_turbulence_noise3(nx * 2.3f, nz * 2.3f, t * 1.7f, 2.2f, 0.5f, 4);
+        final float chopN = (chopRaw - 0.5f) * 2.0f;
+        final double n = base + chopN * chopAmt * 1.2;
+
+        // Y=0 is the top of the column, so invert the index for a bottom-up fill.
+        final double vBottom = (last == 0) ? 0.0 : (double) (last - j) / last;
+        final double localLevel = level + n * amp;
+        final double d = localLevel - vBottom; // >0 below the surface (in the liquid)
+        final double mix = LXUtils.clamp(0.5 + 0.5 * d * INV_BAND, 0, 1);
+
+        int c;
+        if (mix <= 0.0) {
+          c = prev;
+        } else if (mix >= 1.0) {
+          c = curr;
+        } else {
+          c = LXColor.lerp(prev, curr, (float) mix);
+        }
+
+        // depth-shade the liquid body: brightest at the waterline, noise-modulated below
+        if (d > 0) {
+          double glow = 0.62 + 0.23 * LXUtils.clamp(1.0 - d * 2.0, 0, 1) + 0.15 * (base * 0.5 + 0.5);
+          c = LXColor.scaleBrightness(c, (float) Math.min(1.0, glow));
+        }
+
+        // whitewater foam riding the turbulent surface
+        final double fd = Math.abs(d) / foamW;
+        if (fd < 1.0) {
+          double foam = (1.0 - fd) * LXUtils.clamp((chopRaw - 0.35) * 3.0, 0, 1) * foamGain;
+          if (foam > 0) {
+            foam = LXUtils.clamp(foam, 0, 1);
+            foam = foam * foam * (3 - 2 * foam);
+            c = LXColor.lerp(c, LXColor.WHITE, (float) foam);
+          }
+        }
+
+        // sparse scintillating glints suspended below the surface
+        if (sparkleAmt > 0 && d > 0) {
+          int hs = p.index * 374761393 + tq * 668265263;
+          hs = (hs ^ (hs >>> 13)) * 1274126177;
+          double r = ((hs >>> 8) & 0xFFFF) / 65535.0;
+          if (r > sparkThresh) {
+            c = LXColor.lightest(c, LXColor.scaleBrightness(LXColor.WHITE, glint));
+          }
+        }
+
+        this.colors[p.index] = c;
+      }
+    }
+
+    // --- bubbles rising through the liquid ---
+    if (bubbleCount > 0 && level > 0.02) {
+      final int w = o.width();
+      final int h = o.height();
+      final int bubbleColor = LXColor.lerp(curr, LXColor.WHITE, 0.7f);
+      for (int i = 0; i < bubbleCount; ++i) {
+        if (!tide.binit[i] || tide.by[i] >= level) {
+          continue; // only visible within the liquid body
+        }
+        double gx = tide.bx[i] * w;
+        double gy = (h - 1) * (1.0 - tide.by[i]); // by=0 bottom -> y=h-1
+        // brighter deep down, fading as it nears the surface
+        double depth = (level - tide.by[i]) / level;
+        double b = 0.35 + 0.65 * LXUtils.clamp(depth * 1.8, 0, 1);
+        splat(o, w, h, gx, gy, 1.0 + tide.bsize[i], b, bubbleColor);
+      }
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Cope.java
+++ b/src/main/java/apotheneum/piemonte/Cope.java
@@ -20,17 +20,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Cope extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_PULSE = 8;
   private static final double MIN_BEAT_MS = 110;
@@ -48,10 +41,6 @@ public class Cope extends ParameterPattern {
   public final DiscreteParameter lines =
     new DiscreteParameter("Lines", 6, 1, 24)
     .setDescription("Number of vertical lines around the cylinder");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** A surface's edge columns + a pool of expanding glow pulses. */
   private final class Surface {
@@ -119,19 +108,17 @@ public class Cope extends ParameterPattern {
     addParameter("reactivity", this.reactivity);
     addParameter("sensitivity", this.sensitivity);
     addParameter("lines", this.lines);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private boolean detectBeat(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
     this.sinceBeatMs += deltaMs;
 
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= MIN_BEAT_MS)
       && (bass > 0.01);
@@ -144,8 +131,7 @@ public class Cope extends ParameterPattern {
   }
 
   private double broadband() {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    return m.getAveragef(0, Math.max(1, m.numBands));
+    return this.level.getValue();
   }
 
   @Override
@@ -169,7 +155,7 @@ public class Cope extends ParameterPattern {
     this.beatKick *= Math.exp(-deltaMs / 250.0);
     final double norm = LXUtils.clamp((ratio - 0.55) * 1.6, 0, 1.2)
       + this.beatKick * 0.6;
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     final int nLines = this.lines.getValuei();
 
     if (t != Target.CYLINDER) {

--- a/src/main/java/apotheneum/piemonte/Cope.java
+++ b/src/main/java/apotheneum/piemonte/Cope.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Cope — the structure's vertical edges lit as thick glowing bars: the four
+ * corners of the cube and a set of evenly spaced lines around the cylinder. The
+ * bars breathe with the music, swelling thicker as the sound gets louder, and on
+ * a bass drop a bright radial glow erupts from an edge and blooms outward across
+ * the surface. Audio-reactive architecture.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Cope extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_PULSE = 8;
+  private static final double MIN_BEAT_MS = 110;
+  private static final double GLOW_BASE = 0.055;   // bloom growth, cells / ms at speed 1
+  private static final double MAXAGE_BASE = 1400;  // pulse lifetime (ms) at speed 1
+
+  public final CompoundParameter reactivity =
+    new CompoundParameter("Reactivity", 0.6, 0, 1)
+    .setDescription("How strongly audio thickens the edge bars");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Bass-drop trigger sensitivity for the radial glow");
+
+  public final DiscreteParameter lines =
+    new DiscreteParameter("Lines", 6, 1, 24)
+    .setDescription("Number of vertical lines around the cylinder");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** A surface's edge columns + a pool of expanding glow pulses. */
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    boolean isCube;
+    int builtLines = -1;
+    int[] edgeX = new int[0];
+    final double[] ox = new double[MAX_PULSE];
+    final double[] oy = new double[MAX_PULSE];
+    final double[] age = new double[MAX_PULSE];
+    final boolean[] alive = new boolean[MAX_PULSE];
+
+    void ensure(int w, int h, boolean isCube, int nLines) {
+      if (this.inited && this.w == w && this.h == h
+          && (isCube || this.builtLines == nLines)) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.isCube = isCube;
+      this.inited = true;
+      if (isCube) {
+        this.edgeX = new int[] { 0, 50, 100, 150 }; // the four vertical corners
+        this.builtLines = -1;
+      } else {
+        this.edgeX = new int[nLines];
+        for (int k = 0; k < nLines; ++k) {
+          this.edgeX[k] = (int) Math.round((double) k * w / nLines);
+        }
+        this.builtLines = nLines;
+      }
+      for (int i = 0; i < MAX_PULSE; ++i) {
+        this.alive[i] = false;
+      }
+    }
+
+    void spawnPulse(double x, double y) {
+      for (int i = 0; i < MAX_PULSE; ++i) {
+        if (!this.alive[i]) {
+          this.ox[i] = x;
+          this.oy[i] = y;
+          this.age[i] = 0;
+          this.alive[i] = true;
+          return;
+        }
+      }
+      // pool full -> drop the request (oldest keeps blooming)
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  // shared bass-onset state (computed once per frame)
+  private double bassAvg, prevBass, sinceBeatMs, beatLevel;
+  private double levelEnv = 0;
+  private double levelAvg = 0; // slow auto-gain reference
+  private double beatKick = 0; // bars snap wide on each hit
+
+  public Cope(LX lx) {
+    // Base registers color (edge/glow tint), speed (glow expand/decay), size (base
+    // thickness), wow (glow intensity). We add audio + geometry controls.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("reactivity", this.reactivity);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("lines", this.lines);
+    addParameter("target", this.target);
+  }
+
+  private boolean detectBeat(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
+    this.sinceBeatMs += deltaMs;
+
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= MIN_BEAT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    return beat;
+  }
+
+  private double broadband() {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    return m.getAveragef(0, Math.max(1, m.numBands));
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final boolean beat = detectBeat(deltaMs);
+    final double level = broadband();
+    // attack/release envelope so the bars snap up quickly and relax smoothly
+    double aAtk = 1 - Math.exp(-deltaMs / 25.0);
+    double aRel = 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * (level > this.levelEnv ? aAtk : aRel);
+    // auto-gain drive: the envelope/average RATIO carries the dynamics (steady
+    // music sits ~0.9-1.0; hits spike it, gaps drop it). Expand the contrast
+    // around that resting point and snap on beats so the bars actually pump.
+    this.levelAvg += (level - this.levelAvg) * (1 - Math.exp(-deltaMs / 2500.0));
+    final double ratio = this.levelEnv / Math.max(1e-4, this.levelAvg);
+    if (beat) {
+      this.beatKick = 1;
+    }
+    this.beatKick *= Math.exp(-deltaMs / 250.0);
+    final double norm = LXUtils.clamp((ratio - 0.55) * 1.6, 0, 1.2)
+      + this.beatKick * 0.6;
+    final Target t = this.target.getEnum();
+    final int nLines = this.lines.getValuei();
+
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, beat, norm, true, 0);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, beat, norm, false, nLines);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs,
+      boolean beat, double level, boolean isCube, int nLines) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h, isCube, nLines);
+
+    final double wow = getWow();
+    final int base = getColor();
+
+    // --- thick vertical edge bars, thickness breathes with audio ---
+    final double baseR = 0.5 + getSize() * 4.0 + wow * 2.0;
+    final double thickMax = isCube ? w * 0.25 : 0.45 * (double) w / Math.max(1, nLines);
+    final double thick = LXUtils.clamp(
+      baseR + this.reactivity.getValue() * level * (thickMax - baseR) * 0.85, 0.5, thickMax);
+    final double barBright = 0.50 + 0.50 * LXUtils.clamp(level * 0.8, 0, 1);
+    for (int ex : s.edgeX) {
+      for (int y = 0; y < h; ++y) {
+        vbar(o, w, h, ex, y, thick, barBright, base);
+      }
+    }
+
+    // --- bass drop spawns a radial glow from a random edge ---
+    if (beat && s.edgeX.length > 0) {
+      double x0 = s.edgeX[(int) (Math.random() * s.edgeX.length)];
+      double y0 = (0.2 + 0.6 * Math.random()) * h;
+      s.spawnPulse(x0, y0);
+    }
+
+    // --- advance + draw glow pulses (bounded bbox, X-wrapped) ---
+    final double speed = getSpeed();
+    final double glowSpeed = GLOW_BASE * (0.5 + speed);
+    final double maxAge = MAXAGE_BASE / (0.5 + speed);
+    for (int i = 0; i < MAX_PULSE; ++i) {
+      if (!s.alive[i]) continue;
+      s.age[i] += deltaMs;
+      if (s.age[i] >= maxAge) {
+        s.alive[i] = false;
+        continue;
+      }
+      double R = glowSpeed * s.age[i] * (1.0 + wow * 0.5);
+      if (R < 0.5) continue;
+      double fade = LXUtils.clamp((1.0 - s.age[i] / maxAge) * (1.0 + wow), 0, 1.5);
+      double cx = s.ox[i], cy = s.oy[i];
+      int y0 = (int) Math.max(0, Math.floor(cy - R));
+      int y1 = (int) Math.min(h - 1, Math.ceil(cy + R));
+      int x0 = (int) Math.floor(cx - R);
+      int x1 = (int) Math.ceil(cx + R);
+      for (int yy = y0; yy <= y1; ++yy) {
+        double dy = yy - cy;
+        for (int xx = x0; xx <= x1; ++xx) {
+          double dx = xx - cx;
+          dx = dx - w * Math.rint(dx / w); // X-wrap distance
+          double d = Math.sqrt(dx * dx + dy * dy);
+          if (d > R) continue;
+          // traveling shock ring: Gaussian shell near the wavefront
+          double sigma = Math.max(1.0, 0.18 * R);
+          double rd = d - 0.85 * R;
+          double ring = Math.exp(-(rd * rd) / (2 * sigma * sigma));
+          double b = LXUtils.clamp(ring * fade * fade, 0, 1);
+          if (b <= 0) continue;
+          // white flash core, only during the pulse's early life
+          double core = (s.age[i] < 150) ? LXUtils.clamp(1.0 - d / (R * 0.4), 0, 1) : 0;
+          int c = LXColor.lerp(base, LXColor.WHITE, (float) core);
+          int xi = ((xx % w) + w) % w;
+          int idx = o.point(xi, yy).index;
+          this.colors[idx] = LXColor.lightest(this.colors[idx],
+            LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+        }
+      }
+    }
+  }
+
+  /** A thick vertical bar segment: 1-D horizontal falloff, X-wrapped (corner spill). */
+  private void vbar(Apotheneum.Orientation o, int w, int h, double cx, int y,
+      double r, double bright, int color) {
+    int x0 = (int) Math.floor(cx - r);
+    int x1 = (int) Math.ceil(cx + r);
+    for (int xx = x0; xx <= x1; ++xx) {
+      double u = 1.0 - Math.abs(xx - cx) / r;
+      if (u <= 0) continue;
+      double f = u * u * bright; // gamma falloff for a tighter profile
+      int cc = color;
+      if (u > 0.8) {
+        cc = LXColor.lerp(color, LXColor.WHITE, (float) ((u - 0.8) / 0.2 * 0.6)); // hot core
+      }
+      int xi = ((xx % w) + w) % w;
+      int idx = o.point(xi, y).index;
+      this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(cc, (float) f));
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/CrashingOut.java
+++ b/src/main/java/apotheneum/piemonte/CrashingOut.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * CrashingOut — LockedIn's restless sibling. A set of thick bars beams in
+ * from an edge as solid columns, each on its own clock — fast travel,
+ * decelerating approach, bounces on the entry velocity model — and locks
+ * into the center. But nothing stays locked: the bars keep bouncing, restless,
+ * until the whole set crashes back out — each bar retreating mid-bounce in
+ * reverse off its entry edge, slow to break loose and accelerating away. Then the next set enters from
+ * the opposite edge at a new horizontal offset and the next of five colors.
+ * Beats punch the bounces; Wow adds bounce reach and speeds the crash.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class CrashingOut extends StrandPattern {
+
+  private static final int N_COLORS = 5;
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_MS = 1800;    // sustained bounce before the crash
+  private static final double GONE = 1.25;         // off-canvas travel distance
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // one set at a time (normalized; shared across surfaces)
+  private final double[] barX = new double[MAX_BARS];
+  private final double[] barLen = new double[MAX_BARS];
+  private final double[] barYc = new double[MAX_BARS];
+  private final int[] barPhase = new int[MAX_BARS]; // 0 enter, 1 bounce, 3 crash
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barRnd = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];
+  private final int[] barBounce = new int[MAX_BARS];
+
+  private int gen = 0;          // total sets launched (drives color + edge)
+  private boolean fromTop = false;
+  private int mode = 0;         // 0 = animating in, 1 = bouncing, 2 = crashing out
+  private double holdT = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  public CrashingOut(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(this.gen * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void launchSet() {
+    this.fromTop = (this.gen & 1) == 1; // alternate bottom / top entries
+    this.mode = 0;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.barX[b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.barLen[b] = (0.14 + Math.random() * 0.30) * (0.8 + Math.random() * 0.4);
+      this.barYc[b] = 0.42 + Math.random() * 0.16;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.fromTop ? -1 : 1) * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barRnd[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    final int nBars = this.bars.getValuei();
+
+    // bars never sit still: they enter, bounce, and bounce until they crash away
+    boolean allArrived = true;
+    boolean allGone = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          allArrived = false;
+          allGone = false;
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            this.barBounce[b] = 0;
+            this.barTgt[b] = (this.fromTop ? 1 : -1) * bounceAmp(b);
+          }
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel, sustained
+          allGone = false;
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            // reverse into a fresh bounce, each with its own reach — no settling
+            ++this.barBounce[b];
+            this.barTgt[b] = -Math.signum(this.barTgt[b]) * bounceAmp(b)
+              * (0.55 + 0.45 * hashd(this.gen * 31 + b * 7 + this.barBounce[b] * 13));
+          }
+          break;
+        }
+        case 3: { // crashing out: the entry run in reverse, off the canvas
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allGone = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          // slow to break loose, accelerating as it pulls away
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1)) * (1 + wow * 0.8);
+          final double dir = this.fromTop ? -1 : 1; // back toward its entry edge
+          this.barPos[b] += dir * v * dt;
+          if (dist < GONE) {
+            allGone = false;
+          }
+          break;
+        }
+      }
+    }
+
+    if (this.mode == 0 && allArrived) { // everyone's in and bouncing
+      this.mode = 1;
+      this.holdT = 0;
+    } else if (this.mode == 1) { // bounce it out, then break for the edges
+      this.holdT += dt;
+      if (this.holdT >= BOUNCE_MS) {
+        this.mode = 2;
+        for (int b = 0; b < MAX_BARS; ++b) {
+          this.barPhase[b] = 3;
+          this.barDelay[b] = Math.random() * 500; // staggered break-loose
+        }
+      }
+    } else if (this.mode == 2 && allGone) { // next color from the opposite edge
+      ++this.gen;
+      launchSet();
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    final int col = LXColor.hsb(
+      (float) (((LXColor.h(getColor()) + HUE_STEPS[this.gen % N_COLORS]) % 360) + 360) % 360,
+      92, 100);
+    final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+
+    for (int b = 0; b < nBars; ++b) {
+      final double len = this.barLen[b];
+      double yc = this.barYc[b];
+      boolean traveling = false;
+      if (this.barPhase[b] == 0 || this.barPhase[b] == 3) {
+        if (this.barPhase[b] == 0 && this.barDelay[b] > 0) continue; // not launched
+        yc += this.barPos[b];
+        traveling = true;
+      } else if (this.barPhase[b] == 1) {
+        yc += this.barPos[b]; // bouncing
+      }
+      // solid column anchored to its entry edge, reaching to its lead end
+      final double leadF = this.fromTop
+        ? (yc + len / 2) * (h - 1)
+        : (yc - len / 2) * (h - 1);
+      if (this.fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+      final int x0 = (int) Math.round(this.barX[b] * w);
+      final int bw = (int) thickC;
+      final double span = this.fromTop
+        ? Math.max(1, leadF)
+        : Math.max(1, (h - 1) - leadF);
+
+      for (int dx = 0; dx < bw; ++dx) {
+        final int x = x0 + dx;
+        final int yStart = this.fromTop ? 0 : (int) Math.floor(leadF);
+        final int yEnd = this.fromTop ? (int) Math.ceil(leadF) : h - 1;
+        for (int yy = yStart; yy <= yEnd; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = this.fromTop ? (yy - leadF) : (leadF - yy);
+          final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+          if (cov <= 0.02) continue;
+          final double back = Math.abs(yy - leadF) / span;
+          int c = col;
+          double bb = cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+            * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + tq));
+          if (traveling && Math.abs(yy - leadF) < 1.5) {
+            c = hot;
+            bb = Math.min(1, bb * 1.5);
+          }
+          addPix(o, x, yy, c, bb);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Drip.java
+++ b/src/main/java/apotheneum/piemonte/Drip.java
@@ -54,6 +54,7 @@ public class Drip extends StrandPattern {
   private double pulse = 0;
   private double sceneClock = 0;
   private int scene = 0;
+  private int prevScene = 0; // the scene actually showing before the last change
 
   public Drip(LX lx) {
     // Base registers color (hue shift), speed (scene pace + shimmer), size (strand weight).
@@ -98,6 +99,7 @@ public class Drip extends StrandPattern {
         while (jump == this.scene) {
           jump = (int) (Math.random() * SCENES.length);
         }
+        this.prevScene = this.scene; // fade from what was actually showing
         this.scene = jump;
         return;
       } else if (this.beatLevel > 0.45 - sens * 0.15) {
@@ -106,6 +108,7 @@ public class Drip extends StrandPattern {
     }
     if (advanceScene) {
       this.sceneClock = 0;
+      this.prevScene = this.scene;
       this.scene = (this.scene + 1) % SCENES.length;
     }
   }
@@ -125,7 +128,7 @@ public class Drip extends StrandPattern {
     final double hueShift = LXColor.h(getColor());
 
     final double[] cur = SCENES[this.scene];
-    final double[] prev = SCENES[((this.scene - 1) % SCENES.length + SCENES.length) % SCENES.length];
+    final double[] prev = SCENES[this.prevScene];
     final double in = sceneIn();
     final double hue = LXUtils.lerp(prev[0], prev[0] + wrapDeg(cur[0] - prev[0]), in) + hueShift;
     final double sat = LXUtils.lerp(prev[1], cur[1], in);

--- a/src/main/java/apotheneum/piemonte/Drip.java
+++ b/src/main/java/apotheneum/piemonte/Drip.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Drip — standing strands of light hang from the rim to the floor like a
+ * beaded curtain in a cathedral dome, each one scintillating downward so the
+ * light seems to pour without ever falling. At the base every strand bends
+ * into a hook and trails outward along the floor, and a bright fountain
+ * cluster glows at the center of each wall. The room moves through scenes —
+ * green with a red heart, full green flood, blue beaded sparkle, violet dusk,
+ * a gold flood, red matrix, a pale white passage, and near-blackout lulls —
+ * some easing in, some snapping. Modeled on the holotrigger rotunda show.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Drip extends StrandPattern {
+
+  private static final int MAX_STREAMS = 40;
+  // scene legs: { perimeterHue, sat, bright, centerHue, holdMs, snap(0/1) }
+  private static final double[][] SCENES = {
+    { 120, 90, 100,   0,  6000, 0 }, // green columns, red center heart
+    { 130, 90, 100, 130,  3500, 1 }, // full green flood (snaps in)
+    { 225, 88,  95, 205,  7000, 0 }, // blue beaded sparkle, cyan center
+    { 275, 80,  80, 350,  4500, 0 }, // violet dusk, rose center
+    {  48, 95, 100,  48,  3500, 1 }, // gold flood
+    {   0, 92, 100, 225,  6000, 0 }, // red matrix, blue center
+    {   0,  0,  85,   0,  3500, 0 }, // white/lavender passage
+    {   0, 60,   8,   0,  2500, 1 }, // near-blackout lull (red embers)
+  };
+  private static final double XFADE_MS = 1200;
+  private static final double SNAP_MS = 180;
+
+  public final DiscreteParameter streams =
+    new DiscreteParameter("Streams", 16, 6, MAX_STREAMS)
+    .setDescription("Standing strands per surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of shimmer surge");
+
+  private double pulse = 0;
+  private double sceneClock = 0;
+  private int scene = 0;
+
+  public Drip(LX lx) {
+    // Base registers color (hue shift), speed (scene pace + shimmer), size (strand weight).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("streams", this.streams);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 220.0);
+    final double speed = Math.max(0.05, getSpeed());
+    this.sceneClock += deltaMs * speed * 2 * (1 + getWow() * 0.5);
+    final double[] cur = SCENES[this.scene];
+    final double sens = this.sensitivity.getValue();
+
+    // the music drives the style: solid hits advance the scene early, and a
+    // hard drop jumps the journey to a random scene — after a minimum dwell
+    // so the room never thrashes
+    boolean advanceScene = this.sceneClock >= cur[4];
+    if (this.beat && this.sceneClock > 1200) {
+      if (this.beatLevel > 0.80 - sens * 0.2) {
+        // drop: leap somewhere unexpected in the journey
+        this.sceneClock = 0;
+        int jump = this.scene;
+        while (jump == this.scene) {
+          jump = (int) (Math.random() * SCENES.length);
+        }
+        this.scene = jump;
+        return;
+      } else if (this.beatLevel > 0.45 - sens * 0.15) {
+        advanceScene = true; // solid hit: move the journey along now
+      }
+    }
+    if (advanceScene) {
+      this.sceneClock = 0;
+      this.scene = (this.scene + 1) % SCENES.length;
+    }
+  }
+
+  /** Eased 0..1 entry progress into the current scene (fast when it snaps). */
+  private double sceneIn() {
+    final double dur = (SCENES[this.scene][5] > 0.5) ? SNAP_MS : XFADE_MS;
+    final double f = LXUtils.clamp(this.sceneClock / dur, 0, 1);
+    return f * f * (3 - 2 * f);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double hueShift = LXColor.h(getColor());
+
+    final double[] cur = SCENES[this.scene];
+    final double[] prev = SCENES[((this.scene - 1) % SCENES.length + SCENES.length) % SCENES.length];
+    final double in = sceneIn();
+    final double hue = LXUtils.lerp(prev[0], prev[0] + wrapDeg(cur[0] - prev[0]), in) + hueShift;
+    final double sat = LXUtils.lerp(prev[1], cur[1], in);
+    final double sceneBright = LXUtils.lerp(prev[2], cur[2], in) / 100.0;
+    final double cHue = LXUtils.lerp(prev[3], prev[3] + wrapDeg(cur[3] - prev[3]), in) + hueShift;
+    final int colPerim = LXColor.hsb((float) (((hue % 360) + 360) % 360), (float) sat, 100);
+    final int colCenter = LXColor.hsb((float) (((cHue % 360) + 360) % 360),
+      (float) Math.max(sat, 60), 100);
+
+    // strand population scales with scene brightness: floods fill the wall,
+    // blackout lulls collapse to a few dim embers
+    final int count = Math.max(2, (int) Math.round(
+      Math.min(MAX_STREAMS, this.streams.getValuei() + wow * 8) * (0.25 + 0.75 * sceneBright)));
+    final boolean glyphScene = (this.scene == 5 || this.scene == 0); // matrix-textured legs
+    final double shimSurge = 1.0 + this.levelEnv * this.sensitivity.getValue() + this.pulse * 0.4;
+    final int floorY = h - 6;
+
+    for (int i = 0; i < count; ++i) {
+      // fixed even spacing with per-strand jitter: a standing curtain
+      final int cx = (int) ((i + 0.5) * w / count + (hashd(i * 31 + 7) - 0.5) * 3);
+      // center/perimeter bicolor split: strands near each wall's center take the accent
+      final double centerDist = Math.abs(((cx % w) + w) % w % (isCube ? 50 : w)
+        - (isCube ? 25 : w / 2)) / (double) (isCube ? 25 : w / 2);
+      final int col = (centerDist < 0.25) ? colCenter : colPerim;
+
+      for (int y = 0; y <= floorY; ++y) {
+        double b;
+        if (glyphScene) {
+          // blocky code-rain segments descending
+          final int seg = (int) Math.floor((y - this.timeMs * 0.010) / 3.0);
+          b = (hashd(cx * 131 + seg * 977) > 0.45) ? 0.85 : 0.08;
+        } else {
+          // beaded scintillation scrolling down a stationary strand
+          final double spark = hashd(cx * 262147 + (int) Math.floor(y - this.timeMs * 0.012) * 8191);
+          b = (spark > 0.55) ? 0.55 + 0.45 * spark : 0.12;
+        }
+        b *= sceneBright * shimSurge * (0.75 + 0.25 * drip(y, h)) * (0.7 + 0.3 * getSize());
+        addPix(o, cx, y, col, b);
+      }
+
+      // persistent floor hook curling outward
+      final int dir = (hashd(i * 53 + 11) < 0.5) ? -1 : 1;
+      for (int k = 1; k <= 6; ++k) {
+        final double wig = Math.sin(this.timeMs * 0.002 + i * 1.7) * 1.0;
+        final int yy = Math.min(h - 1, floorY + (int) Math.round(k * 0.4 + wig * (k / 6.0)));
+        addPix(o, cx + dir * k, yy, col, sceneBright * (1.0 - k / 8.0) * 0.8);
+      }
+    }
+
+    // fountain cluster glowing at the center of each wall
+    final int nWalls = isCube ? 4 : 1;
+    final int wallW = w / nWalls;
+    for (int wi = 0; wi < nWalls; ++wi) {
+      final int cx0 = wi * wallW + wallW / 2;
+      for (int dx = -3; dx <= 3; ++dx) {
+        for (int y = floorY; y < h; ++y) {
+          final double g = Math.exp(-dx * dx / 4.0) * (0.55 + this.pulse * 0.3);
+          addPix(o, cx0 + dx, y, colCenter, g * sceneBright);
+        }
+      }
+    }
+
+    // waterline scrim: only in the blue scenes, at ~43% height
+    if (this.scene == 2) {
+      final int scrimY = (int) (h * 0.43);
+      final int scrim = LXColor.hsb((float) (((215 + hueShift) % 360)), 80, 100);
+      for (int x = 0; x < w; ++x) {
+        addPix(o, x, scrimY, scrim, 0.22 * in);
+        addPix(o, x, scrimY + 1, scrim, 0.10 * in);
+      }
+    }
+  }
+
+  private static double wrapDeg(double d) {
+    d = ((d % 360) + 360) % 360;
+    return (d > 180) ? d - 360 : d;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/FeelSomething.java
+++ b/src/main/java/apotheneum/piemonte/FeelSomething.java
@@ -19,17 +19,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class FeelSomething extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_STICKS = 64;
   private static final int MAX_SPARKS = 1500;
@@ -46,10 +39,6 @@ public class FeelSomething extends ParameterPattern {
   public final CompoundParameter sparkle =
     new CompoundParameter("Sparkle", 0.5, 0, 1)
     .setDescription("How many sparkles fly off on each bounce");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     int w, h;
@@ -126,7 +115,7 @@ public class FeelSomething extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("sticks", this.sticks);
     addParameter("sparkle", this.sparkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -134,7 +123,7 @@ public class FeelSomething extends ParameterPattern {
     setColors(LXColor.BLACK);
     final double baseHue = LXColor.h(getColor());
     final double dtS = Math.max(0.02, getSpeed()) * deltaMs; // time step
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, dtS, baseHue);
     }

--- a/src/main/java/apotheneum/piemonte/FeelSomething.java
+++ b/src/main/java/apotheneum/piemonte/FeelSomething.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * FeelSomething — colored sticks rain down the surface, and when they strike the
+ * floor they bounce back up, tumbling end over end and throwing off a burst of
+ * bright sparkles. Each bounce loses a little energy until the stick settles and
+ * a fresh one drops from the top.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class FeelSomething extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_STICKS = 64;
+  private static final int MAX_SPARKS = 1500;
+  private static final double GRAV = 0.00010;      // cells / ms^2 (time-scaled by speed)
+  private static final double SPARK_G = 0.00006;
+  private static final double RESTITUTION = 0.68;  // bounce energy kept
+  private static final double MIN_IMPACT = 0.010;  // below this a stick settles + relaunches
+  private static final double HUE_SPREAD = 90;     // per-stick hue variety (degrees)
+
+  public final DiscreteParameter sticks =
+    new DiscreteParameter("Sticks", 24, 4, MAX_STICKS)
+    .setDescription("How many sticks are falling at once");
+
+  public final CompoundParameter sparkle =
+    new CompoundParameter("Sparkle", 0.5, 0, 1)
+    .setDescription("How many sparkles fly off on each bounce");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    // sticks
+    final double[] kx = new double[MAX_STICKS];
+    final double[] ky = new double[MAX_STICKS];
+    final double[] kvy = new double[MAX_STICKS];
+    final double[] klf = new double[MAX_STICKS];   // per-stick length factor
+    final double[] kang = new double[MAX_STICKS];
+    final double[] kav = new double[MAX_STICKS];    // angular velocity
+    final double[] khue = new double[MAX_STICKS];   // 0..1 hue offset
+    final boolean[] kbounced = new boolean[MAX_STICKS];
+    // sparks
+    final double[] spx = new double[MAX_SPARKS];
+    final double[] spy = new double[MAX_SPARKS];
+    final double[] spvx = new double[MAX_SPARKS];
+    final double[] spvy = new double[MAX_SPARKS];
+    final double[] splife = new double[MAX_SPARKS];
+    final double[] spmax = new double[MAX_SPARKS];
+    final boolean[] spAlive = new boolean[MAX_SPARKS];
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      for (int i = 0; i < MAX_STICKS; ++i) {
+        launch(i, true);
+      }
+      for (int i = 0; i < MAX_SPARKS; ++i) {
+        this.spAlive[i] = false;
+      }
+    }
+
+    void launch(int i, boolean scatter) {
+      this.kx[i] = Math.random() * this.w;
+      this.ky[i] = scatter ? Math.random() * this.h * 0.6 : -(Math.random() * this.h * 0.4) - 4;
+      this.kvy[i] = 0;
+      this.klf[i] = 0.7 + Math.random() * 0.6;
+      this.kang[i] = 0;
+      this.kav[i] = (Math.random() - 0.5) * 0.006; // gentle pre-bounce tumble
+      this.khue[i] = Math.random();
+      this.kbounced[i] = false;
+    }
+
+    /** Emit sparks from (x,y) flung outward along (ox,oy) — used for the stick's ends. */
+    void sparkFrom(double x, double y, double ox, double oy, int count) {
+      for (int c = 0; c < count; ++c) {
+        int idx = -1;
+        for (int k = 0; k < MAX_SPARKS; ++k) {
+          if (!this.spAlive[k]) { idx = k; break; }
+        }
+        if (idx < 0) return;
+        this.spx[idx] = x;
+        this.spy[idx] = y;
+        double eject = 0.02 + Math.random() * 0.045;
+        this.spvx[idx] = ox * eject + (Math.random() - 0.5) * 0.03;
+        this.spvy[idx] = oy * eject - (0.006 + Math.random() * 0.02); // slight upward arc
+        this.spmax[idx] = 300 + Math.random() * 520;
+        this.splife[idx] = this.spmax[idx];
+        this.spAlive[idx] = true;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public FeelSomething(LX lx) {
+    // Base registers color (base hue), speed (time scale), size (stick length).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("sticks", this.sticks);
+    addParameter("sparkle", this.sparkle);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final double baseHue = LXColor.h(getColor());
+    final double dtS = Math.max(0.02, getSpeed()) * deltaMs; // time step
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, dtS, baseHue);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, dtS, baseHue);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double dtS, double baseHue) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final int count = this.sticks.getValuei();
+    final double len = 3 + getSize() * 10;
+    final double bottom = h - 1;
+    final double wow = getWow();
+    // Wow turns each bounce into a burst storm: more sparks, more shedding.
+    final double sparkAmt = this.sparkle.getValue();
+
+    // --- sticks ---
+    for (int i = 0; i < count; ++i) {
+      s.kvy[i] += GRAV * dtS;
+      s.ky[i] += s.kvy[i] * dtS;
+      s.kang[i] += s.kav[i] * dtS;
+      boolean justBounced = false;
+      double impact = 0;
+      if (s.ky[i] >= bottom) {
+        s.ky[i] = bottom;
+        impact = Math.abs(s.kvy[i]);
+        if (impact < MIN_IMPACT && s.kbounced[i]) {
+          s.launch(i, false); // settled -> drop a fresh one
+        } else {
+          s.kvy[i] = -impact * RESTITUTION;   // bounce up
+          s.kbounced[i] = true;
+          s.kav[i] = (Math.random() - 0.5) * 0.03; // tumble
+          justBounced = true;
+        }
+      }
+
+      final double dirx = Math.sin(s.kang[i]);
+      final double diry = Math.cos(s.kang[i]);
+      final double half = 0.5 * len * s.klf[i];
+      final double ax = s.kx[i] - dirx * half, ay = s.ky[i] - diry * half;
+      final double bx = s.kx[i] + dirx * half, by = s.ky[i] + diry * half;
+
+      // sparkles fly out of the stick's two ends
+      if (justBounced) {
+        int n = LXUtils.constrain(
+          (int) (impact * 1000 * (0.35 + sparkAmt) * (1.0 + wow * 4.0)), 2, (int) (32 + wow * 70));
+        s.sparkFrom(ax, ay, -dirx, -diry, n);
+        s.sparkFrom(bx, by, dirx, diry, n);
+      } else if (s.kbounced[i]) {
+        double rate = 0.20 + sparkAmt * 1.0 + wow * 0.6; // keep shedding off the ends while tumbling
+        int shed = 1 + (int) (wow * 3);
+        if (Math.random() < rate) s.sparkFrom(ax, ay, -dirx, -diry, shed);
+        if (Math.random() < rate) s.sparkFrom(bx, by, dirx, diry, shed);
+      }
+
+      // draw the stick between its two ends, with white-hot tips
+      final int col = LXColor.hsb(
+        (float) (((baseHue + (s.khue[i] - 0.5) * HUE_SPREAD) % 360 + 360) % 360), 90, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.5f);
+      final int steps = (int) Math.ceil(len);
+      for (int k = 0; k <= steps; ++k) {
+        double f = (steps == 0) ? 0 : (double) k / steps;
+        int col2 = (f < 0.15 || f > 0.85) ? hot : col;
+        final double px = ax + (bx - ax) * f;
+        final double py = ay + (by - ay) * f;
+        splat(o, w, h, px, py, 2.3, 0.35, col);   // soft aura around the rod
+        splat(o, w, h, px, py, 1.4, 1.0, col2);   // bold core
+      }
+    }
+
+    // --- sparkles: born white-hot, cooling toward the base hue as they fade ---
+    final int ember = LXColor.hsb((float) baseHue, 90, 100);
+    for (int i = 0; i < MAX_SPARKS; ++i) {
+      if (!s.spAlive[i]) continue;
+      s.splife[i] -= dtS;
+      if (s.splife[i] <= 0) { s.spAlive[i] = false; continue; }
+      s.spvy[i] += SPARK_G * dtS;
+      s.spx[i] += s.spvx[i] * dtS;
+      s.spy[i] += s.spvy[i] * dtS;
+      if (s.spy[i] >= bottom && s.spvy[i] > 0) { s.spAlive[i] = false; continue; }
+      double fade = s.splife[i] / s.spmax[i];
+      double twinkle = 0.55 + 0.45 * Math.random(); // shimmer
+      int sc = LXColor.lerp(ember, LXColor.WHITE, (float) fade);
+      splat(o, w, h, s.spx[i], s.spy[i], 1.05, Math.pow(fade, 1.5) * (0.55 + 0.65 * twinkle), sc);
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/LockedIn.java
+++ b/src/main/java/apotheneum/piemonte/LockedIn.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * LockedIn — sets of thick bars lock into the center of the canvas, one color
+ * at a time. Each bar is a solid column anchored to its entry edge, growing
+ * toward the middle with the UFOAbduction feel — fast travel, decelerating on
+ * approach — then bouncing on the same velocity model, each bar on its own
+ * clock and reach, before freezing in place. Sets alternate bottom and top
+ * entries, each at a new horizontal offset, cycling through five colors and
+ * layering endlessly: the stack never fades — new sets keep locking in over
+ * the old, and only when a color comes back around does its previous layer
+ * yield to the fresh one rising from the edge. Beats punch the bounces; Wow
+ * adds bounce reach and shimmer.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class LockedIn extends StrandPattern {
+
+  private static final int N_COLORS = 5;    // hues cycled across sets
+  private static final int MAX_LAYERS = 10; // frozen sets kept on the canvas
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_DECAY = 0.78; // per-bounce settle
+  private static final double RELAUNCH_MS = 450;   // breath between sets
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // layered set state (normalized; shared across surfaces)
+  private final double[][] layX = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layLen = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layYc = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] lenVar = new double[MAX_LAYERS][MAX_BARS];
+  private final int[] layerHue = new int[MAX_LAYERS];
+  private final boolean[] layerFromTop = new boolean[MAX_LAYERS];
+  private final boolean[] layerLive = new boolean[MAX_LAYERS];
+
+  private int gen = 0;           // total sets launched
+  private int activeLayer = -1;  // layer currently animating, -1 = between sets
+  private double pauseMs = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  // per-bar independent motion within the active set
+  private final int[] barPhase = new int[MAX_BARS];  // 0 enter, 1 bounce, 2 frozen
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barBopPh = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];   // current bounce target
+  private final int[] barBounce = new int[MAX_BARS];      // reversals remaining
+
+  public LockedIn(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int l, int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(l * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Launch the next set: claim a layer (recycling the oldest) and arm bars. */
+  private void launchSet() {
+    final int l = this.gen % MAX_LAYERS;
+    this.activeLayer = l;
+    this.layerHue[l] = this.gen % N_COLORS;
+    this.layerFromTop[l] = (this.gen & 1) == 1; // alternate bottom / top
+    this.layerLive[l] = true;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.layX[l][b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.layLen[l][b] = 0.14 + Math.random() * 0.30; // varied reach
+      this.layYc[l][b] = 0.42 + Math.random() * 0.16;  // tips around center
+      this.lenVar[l][b] = 0.8 + Math.random() * 0.4;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.layerFromTop[l] ? -1 : 1)
+        * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barBopPh[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    if (this.activeLayer < 0) { // between sets: breathe, then launch the next
+      this.pauseMs -= dt;
+      if (this.pauseMs <= 0) {
+        launchSet();
+      }
+      return;
+    }
+
+    final int l = this.activeLayer;
+    final int nBars = this.bars.getValuei();
+    boolean allFrozen = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allFrozen = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            // momentum carries into the first bounce, past the rest point
+            this.barBounce[b] = 3 + (int) (this.barBopPh[b] * 3);
+            this.barTgt[b] = (this.layerFromTop[l] ? 1 : -1) * bounceAmp(l, b);
+          }
+          allFrozen = false;
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            if (--this.barBounce[b] <= 0) {
+              // ease home and freeze
+              if (Math.abs(this.barPos[b]) < 0.008) {
+                this.barPos[b] = 0;
+                this.barPhase[b] = 2;
+              } else {
+                this.barTgt[b] = 0;
+                this.barBounce[b] = 1;
+              }
+            } else {
+              // reverse, each bounce a little smaller
+              this.barTgt[b] = -Math.signum(this.barTgt[b])
+                * bounceAmp(l, b)
+                * Math.pow(BOUNCE_DECAY, 6 - this.barBounce[b]);
+            }
+          }
+          allFrozen = false;
+          break;
+        }
+      }
+    }
+    if (allFrozen) { // set locked; the stack stays — queue the next set
+      ++this.gen;
+      this.activeLayer = -1;
+      this.pauseMs = RELAUNCH_MS;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double hueShift = LXColor.h(getColor());
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int l = 0; l < MAX_LAYERS; ++l) {
+      if (!this.layerLive[l]) continue;
+      final boolean active = (l == this.activeLayer);
+      final boolean fromTop = this.layerFromTop[l];
+      final int col = LXColor.hsb(
+        (float) (((hueShift + HUE_STEPS[this.layerHue[l]]) % 360) + 360) % 360, 92, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+      final double genB = active ? 1.0 : 0.82;
+
+      for (int b = 0; b < nBars; ++b) {
+        final double xN = this.layX[l][b];
+        final double len = this.layLen[l][b] * this.lenVar[l][b];
+        double yc = this.layYc[l][b];
+        boolean entering = false;
+        if (active) {
+          if (this.barPhase[b] == 0) {
+            if (this.barDelay[b] > 0) continue; // not launched yet
+            yc += this.barPos[b]; // still traveling in
+            entering = true;
+          } else if (this.barPhase[b] == 1) {
+            yc += this.barPos[b]; // bouncing on the entry velocity model
+          }
+        }
+        // solid column anchored to its entry edge, reaching to its lead end:
+        // bottom-entering bars fill floor-to-lead, top-entering sky-to-lead
+        final double leadF = fromTop
+          ? (yc + len / 2) * (h - 1)   // lead end grows downward from the sky
+          : (yc - len / 2) * (h - 1);  // lead end grows upward from the floor
+        if (fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+        final int x0 = (int) Math.round(xN * w);
+        final int bw = (int) thickC;
+        final double span = fromTop
+          ? Math.max(1, leadF)
+          : Math.max(1, (h - 1) - leadF);
+
+        for (int dx = 0; dx < bw; ++dx) {
+          final int x = x0 + dx;
+          final int yStart = fromTop ? 0 : (int) Math.floor(leadF);
+          final int yEnd = fromTop ? (int) Math.ceil(leadF) : h - 1;
+          for (int yy = yStart; yy <= yEnd; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final double dOut = fromTop ? (yy - leadF) : (leadF - yy);
+            final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+            if (cov <= 0.02) continue;
+            // brightest at the lead end, easing back toward the anchor edge
+            final double back = Math.abs(yy - leadF) / span;
+            int c = col;
+            double bb = genB * cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+              * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + (active ? tq : 0)));
+            if (entering && Math.abs(yy - leadF) < 1.5) {
+              c = hot;
+              bb = Math.min(1, bb * 1.5);
+            }
+            addPix(o, x, yy, c, bb);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -33,9 +33,22 @@ package apotheneum.piemonte;
 import apotheneum.ApotheneumPattern;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
 
 public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Shared render-target selector: both structures, cube only, or cylinder only. */
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  /** Created by addTargetParameter(); null when a pattern doesn't opt in. */
+  public EnumParameter<Target> target;
 
   /** Primary hue (degrees) — the single dial that steers pattern color. */
   public final CompoundParameter hue =
@@ -53,6 +66,36 @@ public abstract class ParameterPattern extends ApotheneumPattern {
   public final CompoundParameter wow =
     new CompoundParameter("Wow", 0, 0, 1)
     .setDescription("Extra flourish / special-effect intensity");
+
+  /**
+   * External audio inputs. Nothing in these patterns samples the LX audio
+   * meter — installation volume is expected to change, which would rescale
+   * every internally-analyzed level. Instead the envelope-follower step runs
+   * in the audio program (e.g. Ableton feeding the show-control M4L device),
+   * which sends a volume-stable signal here over OSC/MIDI modulation.
+   */
+  public final CompoundParameter level =
+    new CompoundParameter("Level", 0, 0, 1)
+    .setDescription("Audio level input — map an external envelope follower (OSC/MIDI)");
+
+  public final BooleanParameter pulse =
+    new BooleanParameter("Pulse", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Beat trigger input — map an external beat source (OSC/MIDI)");
+
+  // --- audio state derived from the external inputs, once per frame ---
+  private boolean prevPulse;
+  private double prevLevel, sinceBeatMs = 1e9;
+  /** Slow-average of the level input; useful for contrast ratios. */
+  protected double levelAvg;
+  /** True on the frame a beat fires (Pulse edge, or a Level onset). */
+  protected boolean beat;
+  /** Normalized beat strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Level input shaped by a 25ms attack / 220ms release envelope. */
+  protected double levelEnv;
+  /** Accumulated pattern time in ms. */
+  protected double timeMs = 0;
 
   /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
   protected ParameterPattern(LX lx) {
@@ -82,6 +125,94 @@ public abstract class ParameterPattern extends ApotheneumPattern {
     addParameter("speed", this.speed);
     addParameter("size", this.size);
     addParameter("wow", this.wow);
+    addParameter("level", this.level);
+    addParameter("pulse", this.pulse);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addTargetParameter(Target.BOTH);
+  }
+
+  /** Target with a pattern-specific default. */
+  protected void addTargetParameter(Target def) {
+    this.target = new EnumParameter<Target>("Target", def)
+      .setDescription("Which structures to render to");
+    addParameter("target", this.target);
+  }
+
+  /** Current target; BOTH when the pattern doesn't expose the selector. */
+  protected Target getTarget() {
+    return (this.target != null) ? this.target.getEnum() : Target.BOTH;
+  }
+
+  /** Beat threshold multiplier for Level onsets; override to wire a Sens param. */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  /**
+   * Advance the derived audio state from the external Level/Pulse inputs.
+   * StrandPattern calls this automatically each frame; patterns that extend
+   * ParameterPattern directly call it at the top of render().
+   */
+  protected void stepAudio(double deltaMs) {
+    this.timeMs += deltaMs;
+    final double lvl = this.level.getValue();
+
+    // attack/release envelope + slow average for contrast ratios
+    final double alpha = (lvl > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (lvl - this.levelEnv) * alpha;
+    this.levelAvg += (lvl - this.levelAvg) * (1 - Math.exp(-deltaMs / 2000.0));
+
+    // beats: a Pulse edge always fires; Level onsets fire when it climbs
+    // clear of its own slow average (volume-stable, since the follower is
+    // upstream of any installation volume changes)
+    this.sinceBeatMs += deltaMs;
+    final boolean p = this.pulse.isOn();
+    final boolean pulseEdge = p && !this.prevPulse;
+    this.prevPulse = p;
+    final boolean onset = (lvl > this.levelAvg * beatThreshold())
+      && (lvl > this.prevLevel)
+      && (this.sinceBeatMs >= 130)
+      && (lvl > 0.01);
+    this.prevLevel = lvl;
+    this.beat = pulseEdge || onset;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = pulseEdge ? 1.0
+      : LXUtils.clamp((lvl / Math.max(1e-4, this.levelAvg) - 1.0) / 1.5, 0, 1);
+  }
+
+  /**
+   * Pseudo-spectrum: the level envelope spread across n bands with slow
+   * per-band drift, so band-indexed visuals keep independent motion without
+   * sampling the internal meter.
+   */
+  protected double band(int i, int n) {
+    final double drift = 0.5 + 0.5 * Math.sin(
+      this.timeMs * (0.0009 + 0.0008 * phash(i * 31 + n * 7)) + i * 2.1);
+    return this.levelEnv * (0.45 + 0.55 * drift);
+  }
+
+  private boolean prevPulseLocal;
+
+  /** True exactly once per Pulse press; for patterns running bespoke detectors. */
+  protected boolean pulseHit() {
+    final boolean p = this.pulse.isOn();
+    final boolean edge = p && !this.prevPulseLocal;
+    this.prevPulseLocal = p;
+    return edge;
+  }
+
+  private static double phash(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
   }
 
   // Convenience getters. Subclasses can also tweak the

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2026- Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * Created by patrick piemonte
+ *
+ * ParameterPattern — an intermediate base (ApotheneumPattern → ParameterPattern
+ * → your pattern) that fixes a consistent leading parameter order: hue,
+ * speed, size, wow. Every pattern that extends it gets those four controls in
+ * the same place. Subclasses extend this, then add their own parameters (and
+ * any extra colors) after super(...). Kept self-contained so
+ * last-minute changes don't ripple across other authors' content.
+ *
+ * "Wow" is a shared performance macro in the spirit of LXStudio-TE's WOW knobs:
+ * a 0..1 "extra flourish" each pattern interprets in its own way. It defaults to
+ * 0 (inert), so a pattern that ignores it is unaffected and its resting look is
+ * unchanged; patterns that read getWow() add a special-effect layer as it rises.
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.ApotheneumPattern;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+
+public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Primary hue (degrees) — the single dial that steers pattern color. */
+  public final CompoundParameter hue =
+    new CompoundParameter("Hue", 0, 0, 360)
+    .setDescription("Primary hue")
+    .setWrappable(true);
+
+  /** Animation speed. Range/polarity set per-subclass via the constructor. */
+  public final CompoundParameter speed;
+
+  /** Element size. Range set per-subclass via the constructor. */
+  public final CompoundParameter size;
+
+  /** Shared "wow" performance macro (0..1). Defaults to 0 (inert). */
+  public final CompoundParameter wow =
+    new CompoundParameter("Wow", 0, 0, 1)
+    .setDescription("Extra flourish / special-effect intensity");
+
+  /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
+  protected ParameterPattern(LX lx) {
+    this(lx, 0.4, -1, 1, 0.5, 0, 1);
+  }
+
+  /**
+   * CompoundParameter ranges are immutable after construction, so subclasses
+   * pass their desired speed/size ranges here. Speed becomes bipolar when its
+   * minimum is negative.
+   */
+  protected ParameterPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx);
+
+    this.speed = new CompoundParameter("Speed", speedDef, speedMin, speedMax)
+      .setDescription("Animation speed");
+    if (speedMin < 0) {
+      this.speed.setPolarity(CompoundParameter.Polarity.BIPOLAR);
+    }
+    this.size = new CompoundParameter("Size", sizeDef, sizeMin, sizeMax)
+      .setDescription("Element size");
+
+    // Canonical leading order: hue, speed, size, wow. Subclasses add the rest.
+    addParameter("hue", this.hue);
+    addParameter("speed", this.speed);
+    addParameter("size", this.size);
+    addParameter("wow", this.wow);
+  }
+
+  // Convenience getters. Subclasses can also tweak the
+  // inherited params directly, e.g. this.speed.setExponent(2) or
+  // this.size.setUnits(LXParameter.Units.INTEGER), in their constructor.
+
+  /** Resolved primary color for this frame — the Hue knob at full strength. */
+  protected int getColor() {
+    return LXColor.hsb(this.hue.getValuef() % 360, 100, 100);
+  }
+
+  /** Current speed value (bipolar when the configured minimum is negative). */
+  protected double getSpeed() {
+    return this.speed.getValue();
+  }
+
+  /** Current size value. */
+  protected double getSize() {
+    return this.size.getValue();
+  }
+
+  /** Current "wow" macro value (0..1); 0 means the flourish is off. */
+  protected double getWow() {
+    return this.wow.getValue();
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Pressure.java
+++ b/src/main/java/apotheneum/piemonte/Pressure.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Pressure — a two-channel color organ on the strand curtains: the columns
+ * gate hard between near-black and saturated washes, each column committed to
+ * either red or green, identities re-rolled with every major pulse. Fast
+ * attack, slow release — the whole rig breathes dark-bright-dark like a
+ * warehouse PA. Where red columns overdrive they bleed amber, and everything
+ * pools on the floor line. Modeled on the holotrigger red/green pulse program.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Pressure extends StrandPattern {
+
+  private static final int MAX_GROUPS = 32;
+
+  public final DiscreteParameter columns =
+    new DiscreteParameter("Columns", 7, 3, 16)
+    .setDescription("Curtain panels around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of the gate");
+
+  // per-group state, shared across surfaces so cube and cylinder pulse together
+  private final double[] energy = new double[MAX_GROUPS];
+  private final boolean[] isRed = new boolean[MAX_GROUPS];
+  private final boolean[] firing = new boolean[MAX_GROUPS];
+  private int beatCount = 0;
+  private int lastIdlePulse = -1;
+  private double rotPhase = 0; // slow orbit of the curtain wall around the gravity axis
+  private boolean inited = false;
+
+  public Pressure(LX lx) {
+    // Base registers color (hue shift), speed (idle breathe tempo), size (unused softness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("columns", this.columns);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.inited) {
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(i * 17 + 3) < 0.4;
+        this.firing[i] = true;
+        this.energy[i] = 0.4;
+      }
+      this.inited = true;
+    }
+
+    final double wow = getWow();
+    // the whole curtain wall slowly orbits the vertical axis; Wow spins it up,
+    // and each hit gives the drum a small extra shove
+    final double speedR = Math.max(0.05, getSpeed());
+    this.rotPhase += deltaMs * speedR * 2 * 0.00003 * (1 + wow * 2);
+    if (this.beat) {
+      this.rotPhase += 0.004 * this.beatLevel;
+    }
+    this.rotPhase -= Math.floor(this.rotPhase);
+    if (this.beat) {
+      ++this.beatCount;
+      // green is home; a red minority coexists, re-rolled per pulse; rare all-red wall
+      double redFrac = 0.25 + this.beatLevel * 0.15 + wow * 0.1;
+      if (hashd(this.beatCount * 13 + 5) < 0.12) {
+        redFrac = 0.85;
+      }
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(this.beatCount * 977 + i * 31) < redFrac;
+        this.firing[i] = true; // the gate is temporal (whole field), not spatial
+      }
+    }
+
+    // idle gate in silence: hard on/off square at the reference's ~0.7s cadence
+    final double speed = Math.max(0.05, getSpeed());
+    final boolean quiet = this.levelEnv < 0.05;
+    final double idleCycle = this.timeMs * speed * 2 / 700.0;
+    final int idlePulse = (int) idleCycle;
+    if (quiet && idlePulse != this.lastIdlePulse) {
+      this.lastIdlePulse = idlePulse;
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(idlePulse * 977 + i * 31) < 0.30;
+        this.firing[i] = true;
+      }
+    }
+    final double idleGate = ((idleCycle - idlePulse) < 0.55) ? 0.95 : 0.04;
+
+    // whole-field gate: fast attack, ~250ms release into a held near-black trough
+    final double aAtk = 1 - Math.exp(-deltaMs / 30.0);
+    final double target = quiet
+      ? idleGate
+      : LXUtils.clamp(0.20 + this.levelEnv * 1.0 + this.beatLevel * 0.5 + wow * 0.2, 0, 1.3);
+    for (int i = 0; i < MAX_GROUPS; ++i) {
+      // tiny per-curtain release offset so transitions show a lagging curtain or two
+      final double aRel = 1 - Math.exp(-deltaMs / ((270.0 - wow * 90) * (1.0 + 0.15 * hashd(i * 7))));
+      double a = (target > this.energy[i]) ? aAtk : aRel;
+      this.energy[i] += (target - this.energy[i]) * a;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int n = this.columns.getValuei();
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((112 + hueShift) % 360)), 98, 100);
+    final int yellow = LXColor.hsb((float) (((78 + hueShift) % 360)), 95, 100);
+    final int red = LXColor.hsb((float) (((2 + hueShift) % 360)), 100, 100);
+    final int amber = LXColor.hsb((float) (((30 + hueShift) % 360)), 92, 100);
+    final int ember = LXColor.hsb((float) (((24 + hueShift) % 360)), 90, 100);
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int x = 0; x < w; ++x) {
+      // panel coordinates rotate around the gravity axis
+      final double xr = (((double) x / w + this.rotPhase) % 1.0) * n;
+      final int g = Math.min(n - 1, (int) xr);
+      final double e = this.energy[g];
+      // dark wall gap between discrete curtain panels
+      final double gpos = xr - g;
+      if (gpos < 0.10 || gpos > 0.90) continue;
+      if (e > 0.01) {
+        final double shim = 0.90 + 0.10 * hashd(x * 131 + tq * 7);
+        int c = this.isRed[g] ? red : green;
+        // overdrive bleeds: red toward amber, green toward yellow-green
+        if (e > 0.85) {
+          final float od = (float) LXUtils.clamp((e - 0.85) * 4, 0, 1);
+          c = this.isRed[g] ? LXColor.lerp(red, amber, od) : LXColor.lerp(green, yellow, od);
+        }
+        final int hot = LXColor.lerp(c, LXColor.WHITE, 0.35f);
+        for (int y = 0; y < h; ++y) {
+          double b = e * drip(y, h) * shim;
+          b += e * pool(y, h);
+          if (b <= 0.01) continue;
+          // the hottest point is the floor, not the truss
+          addPix(o, x, y, (e > 1.0 && y >= h - 3) ? hot : c, b);
+        }
+      }
+    }
+
+    // persistent warm floor ember: alive even in the blackest troughs
+    for (int x = 0; x < w; ++x) {
+      final double fb = 0.14 * (0.7 + 0.3 * hashd(x * 37 + tq));
+      addPix(o, x, h - 1, ember, fb);
+      addPix(o, x, h - 2, ember, fb * 0.45);
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * StrandPattern — shared engine for the "hanging light-strand curtain" family of
+ * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
+ * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
+ * vertical strands of light with a top-lit drip gradient, glowing floor pools,
+ * comet rain, and heavy audio reactivity. Subclasses implement one "program"
+ * each; this base provides the column/drip/pool math, a comet renderer,
+ * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
+ * attack/release envelope, coarse FFT bins).
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+public abstract class StrandPattern extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  // --- audio state, computed once per frame ---
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  /** True on the frame a bass onset fires. */
+  protected boolean beat;
+  /** Normalized bass onset strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Broadband level envelope: 25ms attack / 220ms release. */
+  protected double levelEnv;
+  protected double timeMs = 0;
+
+  protected StrandPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addParameter("target", this.target);
+  }
+
+  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  private void stepAudio(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    this.beat = (bass > this.bassAvg * beatThreshold())
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 130)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+  }
+
+  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
+  protected double band(int i, int n) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    int lo = i * nb / n;
+    int hi = Math.max(lo + 1, (i + 1) * nb / n);
+    return m.getAveragef(lo, hi - lo);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+    stepAudio(deltaMs);
+    advance(deltaMs);
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      renderStrands(Apotheneum.cube.exterior, deltaMs, true);
+    }
+    if (t != Target.CUBE) {
+      renderStrands(Apotheneum.cylinder.exterior, deltaMs, false);
+    }
+    copyExterior();
+  }
+
+  /** Per-frame global state update before surfaces render. */
+  protected void advance(double deltaMs) {}
+
+  /** Draw one surface's strand program. Called for cube and/or cylinder exterior. */
+  protected abstract void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube);
+
+  // ------------------------------------------------------------------
+  // strand look utilities
+
+  /** Top-lit drip gradient: strands are brightest at the hang point. */
+  protected static double drip(int y, int h) {
+    return 1.0 - 0.35 * (double) y / Math.max(1, h - 1);
+  }
+
+  /** Additive floor-pool boost for the bottom rows (strand puddles glowing). */
+  protected static double pool(int y, int h) {
+    int fromBottom = (h - 1) - y;
+    if (fromBottom >= 4) return 0;
+    return 0.35 * (1.0 - fromBottom / 4.0);
+  }
+
+  /**
+   * Mirror the rows above the floor line into the bottom rows at reduced gain —
+   * the reflective-floor signature. Call AFTER drawing surface content.
+   */
+  protected void mirrorFloor(Apotheneum.Orientation o, int rows, float gain) {
+    final int w = o.width();
+    final int h = o.height();
+    final int axis = h - rows;
+    for (int x = 0; x < w; ++x) {
+      for (int y = axis; y < h; ++y) {
+        int src = 2 * axis - 1 - y;
+        if (src < 0) continue;
+        int c = this.colors[o.point(x, src).index];
+        int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, gain));
+      }
+    }
+  }
+
+  /** Additive pixel write with wrapped x; y outside the surface is dropped. */
+  protected void addPix(Apotheneum.Orientation o, int x, int y, int color, double b) {
+    if (b <= 0.004) return;
+    final int h = o.height();
+    if (y < 0 || y >= h) return;
+    final int w = o.width();
+    final int xi = ((x % w) + w) % w;
+    final int idx = o.point(xi, y).index;
+    this.colors[idx] = LXColor.lightest(this.colors[idx],
+      LXColor.scaleBrightness(color, (float) LXUtils.clamp(b, 0, 1)));
+  }
+
+  /**
+   * Falling comet: sub-pixel head at (x, y) with an exponential tail rising
+   * above it. White-hot head when hot is true.
+   */
+  protected void comet(Apotheneum.Orientation o, double x, double y, double tail,
+      int color, double bright, boolean hot) {
+    final int xi = (int) Math.round(x);
+    final int head = (int) Math.floor(y);
+    final double hf = y - head;
+    final int n = Math.max(1, (int) tail);
+    final int headColor = hot ? LXColor.lerp(color, LXColor.WHITE, 0.55f) : color;
+    for (int k = 0; k <= n; ++k) {
+      double b = bright * Math.exp(-2.2 * k / tail);
+      addPix(o, xi, head - k, (k == 0) ? headColor : color, (k == 0) ? b * (0.4 + 0.6 * hf) : b);
+    }
+    addPix(o, xi, head + 1, headColor, bright * hf * 0.5);
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -7,10 +7,10 @@
  * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
  * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
  * vertical strands of light with a top-lit drip gradient, glowing floor pools,
- * comet rain, and heavy audio reactivity. Subclasses implement one "program"
- * each; this base provides the column/drip/pool math, a comet renderer,
- * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
- * attack/release envelope, coarse FFT bins).
+ * comet rain, and audio reactivity driven by the external Level/Pulse inputs
+ * on ParameterPattern. Subclasses implement one "program" each; this base
+ * provides the column/drip/pool math, a comet renderer, and wrapped-x pixel
+ * writes.
  */
 
 package apotheneum.piemonte;
@@ -18,30 +18,9 @@ package apotheneum.piemonte;
 import apotheneum.Apotheneum;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 public abstract class StrandPattern extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
-
-  // --- audio state, computed once per frame ---
-  private double bassAvg, prevBass, sinceBeatMs = 1e9;
-  /** True on the frame a bass onset fires. */
-  protected boolean beat;
-  /** Normalized bass onset strength 0..1 for the current frame. */
-  protected double beatLevel;
-  /** Broadband level envelope: 25ms attack / 220ms release. */
-  protected double levelEnv;
-  protected double timeMs = 0;
 
   protected StrandPattern(LX lx,
       double speedDef, double speedMin, double speedMax,
@@ -49,56 +28,13 @@ public abstract class StrandPattern extends ParameterPattern {
     super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
   }
 
-  /** Subclasses call this LAST in their constructor to keep Target at the end. */
-  protected void addTargetParameter() {
-    addParameter("target", this.target);
-  }
-
-  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
-  protected double beatThreshold() {
-    return 1.4;
-  }
-
-  private void stepAudio(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
-    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
-    this.sinceBeatMs += deltaMs;
-    this.beat = (bass > this.bassAvg * beatThreshold())
-      && (bass > this.prevBass)
-      && (this.sinceBeatMs >= 130)
-      && (bass > 0.01);
-    this.prevBass = bass;
-    if (this.beat) {
-      this.sinceBeatMs = 0;
-    }
-    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
-
-    double level = m.getAveragef(0, nb);
-    double alpha = (level > this.levelEnv)
-      ? 1 - Math.exp(-deltaMs / 25.0)
-      : 1 - Math.exp(-deltaMs / 220.0);
-    this.levelEnv += (level - this.levelEnv) * alpha;
-  }
-
-  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
-  protected double band(int i, int n) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    int lo = i * nb / n;
-    int hi = Math.max(lo + 1, (i + 1) * nb / n);
-    return m.getAveragef(lo, hi - lo);
-  }
-
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
-    this.timeMs += deltaMs;
     stepAudio(deltaMs);
     advance(deltaMs);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       renderStrands(Apotheneum.cube.exterior, deltaMs, true);
     }

--- a/src/main/java/apotheneum/piemonte/TheHumanRace.java
+++ b/src/main/java/apotheneum/piemonte/TheHumanRace.java
@@ -20,18 +20,11 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class TheHumanRace extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int NUM = 2600;         // figure pool
   private static final int CLUSTERS = 44;
@@ -60,10 +53,6 @@ public class TheHumanRace extends ParameterPattern {
   public final CompoundParameter horizon =
     new CompoundParameter("Horizon", 0.14, 0.02, 0.45)
     .setDescription("Where the horizon sits (lower = more landscape, less sky)");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -96,7 +85,7 @@ public class TheHumanRace extends ParameterPattern {
     addParameter("terrain", this.terrain);
     addParameter("specks", this.specks);
     addParameter("horizon", this.horizon);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildCrowd() {
@@ -170,7 +159,7 @@ public class TheHumanRace extends ParameterPattern {
     if (!this.crowdBuilt) {
       buildCrowd();
     }
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/TheHumanRace.java
+++ b/src/main/java/apotheneum/piemonte/TheHumanRace.java
@@ -1,0 +1,301 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * TheHumanRace — a vast landscape scattered with little glowing stick figures,
+ * gathered in loose bunches and stretching to a horizon. A slow camera drifts
+ * and pans across them, and because each face of the sculpture looks out in its
+ * own direction the crowd wraps around you in a 360 degree panorama. Most figures
+ * glow pale blue-white; a few are vivid specks. They sway as if walking.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class TheHumanRace extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int NUM = 2600;         // figure pool
+  private static final int CLUSTERS = 44;
+  private static final double AREA = 70;       // half-size of the field (world units)
+  private static final double PERIOD = 2 * AREA; // toroidal wrap so the camera glides forever
+  private static final double NEAR = 1.0;
+  private static final double H_EYE = 2.6;     // camera height above the ground
+  private static final double GLIDE = 0.005;   // world units / ms at speed 1
+  private static final double FAR = 46;        // distance where the crowd fogs out
+  private static final double TERR_FREQ = 0.055; // terrain feature scale
+  private static final double TERR_MAXH = 4.5;   // max hill/mountain height (world units)
+  private static final float PALE_SAT = 22;
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 2200, 200, NUM)
+    .setDescription("How many figures are drawn");
+
+  public final CompoundParameter terrain =
+    new CompoundParameter("Terrain", 0.6, 0, 1)
+    .setDescription("Height of the hills and mountains");
+
+  public final CompoundParameter specks =
+    new CompoundParameter("Specks", 0.15, 0, 1)
+    .setDescription("Fraction of figures that are vivid colored specks");
+
+  public final CompoundParameter horizon =
+    new CompoundParameter("Horizon", 0.14, 0.02, 0.45)
+    .setDescription("Where the horizon sits (lower = more landscape, less sky)");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final double facing; // world yaw this panel looks toward
+    Panel(int[][] idx, int w, int h, double facing) {
+      this.idx = idx; this.w = w; this.h = h; this.facing = facing;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  // crowd (built once)
+  private final double[] fx = new double[NUM];
+  private final double[] fz = new double[NUM];
+  private final double[] speckHue = new double[NUM];
+  private final double[] speckRand = new double[NUM];
+  private final double[] wphase = new double[NUM];
+  private final double[] wspeed = new double[NUM];
+  private final double[] fh = new double[NUM]; // terrain height under each figure
+  private boolean crowdBuilt = false;
+
+  private double camX = 0, camZ = 0, timeMs = 0;
+
+  public TheHumanRace(LX lx) {
+    // Base registers color (crowd tint), speed (camera + walk), size (figure size).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("terrain", this.terrain);
+    addParameter("specks", this.specks);
+    addParameter("horizon", this.horizon);
+    addParameter("target", this.target);
+  }
+
+  private void buildCrowd() {
+    double[] cxs = new double[CLUSTERS];
+    double[] czs = new double[CLUSTERS];
+    for (int c = 0; c < CLUSTERS; ++c) {
+      cxs[c] = (Math.random() * 2 - 1) * AREA;
+      czs[c] = (Math.random() * 2 - 1) * AREA;
+    }
+    for (int i = 0; i < NUM; ++i) {
+      if (Math.random() < 0.8) {
+        int c = (int) (Math.random() * CLUSTERS);
+        double sigma = 4 + Math.random() * 8;
+        this.fx[i] = cxs[c] + (Math.random() - Math.random()) * sigma;
+        this.fz[i] = czs[c] + (Math.random() - Math.random()) * sigma;
+      } else {
+        this.fx[i] = (Math.random() * 2 - 1) * AREA;
+        this.fz[i] = (Math.random() * 2 - 1) * AREA;
+      }
+      this.fh[i] = Noise.stb_perlin_fbm_noise3(
+        (float) (this.fx[i] * TERR_FREQ), (float) (this.fz[i] * TERR_FREQ), 0f, 2f, 0.5f, 4);
+      this.speckHue[i] = Math.random();
+      this.speckRand[i] = Math.random();
+      this.wphase[i] = Math.random() * Math.PI * 2;
+      this.wspeed[i] = 0.002 + Math.random() * 0.004;
+    }
+    this.crowdBuilt = true;
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      Apotheneum.Cube.Face[] faces = Apotheneum.cube.exterior.faces;
+      for (int f = 0; f < faces.length; ++f) {
+        int w = faces[f].columns.length;
+        int h = faces[f].columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = faces[f].columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, f * Math.PI / 2));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h, seg * Math.PI / 2));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double wrap(double d) {
+    return d - PERIOD * Math.rint(d / PERIOD);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    if (!this.crowdBuilt) {
+      buildCrowd();
+    }
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    // Wow = festival: the crowd dances harder, more vivid figures light up,
+    // and the camera sweeps faster through them
+    final double wow = getWow();
+    final double dtS = speed * deltaMs * (1 + wow * 0.6);
+    this.timeMs += deltaMs;
+    this.camZ += GLIDE * dtS * (1 + wow);           // glide forward
+    this.camX = 18 * Math.sin(this.timeMs * 0.00005 * (1 + wow)); // side drift
+    final double baseYaw = 0.35 * Math.sin(this.timeMs * 0.00008); // gentle pan
+
+    // advance the walk cycle
+    final int count = this.density.getValuei();
+    for (int i = 0; i < count; ++i) {
+      this.wphase[i] += this.wspeed[i] * dtS;
+    }
+
+    final double baseHue = LXColor.h(getColor());
+    final double specksFrac = Math.min(1, this.specks.getValue() * (1 + wow * 3));
+    final double sizeF = 0.5 + getSize() * 1.5;
+    final double terrScale = this.terrain.getValue() * TERR_MAXH;
+
+    for (Panel p : this.panels) {
+      final double yaw = p.facing + baseYaw;
+      final double cyaw = Math.cos(yaw), syaw = Math.sin(yaw);
+      final double horizon = p.h * this.horizon.getValue();
+      final double focV = p.h * 0.6;
+      // dim cool glow line along the horizon (figures draw over it)
+      int hy = (int) horizon;
+      for (int gy = Math.max(0, hy - 2); gy <= Math.min(p.h - 1, hy + 2); ++gy) {
+        double gg = Math.exp(-((gy - horizon) * (gy - horizon)) / (2 * 1.2 * 1.2));
+        int gc = LXColor.hsb(225, 30, (float) (16 * gg));
+        for (int gx = 0; gx < p.w; ++gx) {
+          this.colors[p.idx[gx][gy]] = LXColor.lightest(this.colors[p.idx[gx][gy]], gc);
+        }
+      }
+      for (int i = 0; i < count; ++i) {
+        double dx = wrap(this.fx[i] - this.camX);
+        double dz = wrap(this.fz[i] - this.camZ);
+        double fwd = dx * syaw + dz * cyaw;
+        if (fwd <= NEAR || fwd > FAR) continue; // fog cull the far crowd
+        double rightRatio = (dx * cyaw - dz * syaw) / fwd;
+        if (rightRatio < -1.05 || rightRatio > 1.05) continue;
+
+        double px = (0.5 + 0.5 * rightRatio) * p.w;
+        // figures stand on terrain: hills lift them toward/over the horizon, valleys drop them
+        double pyBase = horizon + ((H_EYE - this.fh[i] * terrScale) / fwd) * focV;
+        double figH = (1.7 / fwd) * focV * sizeF;
+        if (pyBase - figH > p.h - 1 || pyBase < -figH) continue; // off panel
+        // distance fog: near figures full, fading out toward FAR (no bright horizon bunch)
+        double fogT = LXUtils.clamp((FAR - fwd) / (FAR - NEAR) * 1.3, 0, 1);
+        double bright = Math.pow(fogT, 1.8) * (0.75 + 0.5 * this.speckRand[i]);
+
+        boolean speck = this.speckRand[i] < specksFrac;
+        int color;
+        if (speck) {
+          color = LXColor.hsb((float) (this.speckHue[i] * 360), 85, 100);
+        } else {
+          color = LXColor.hsb((float) baseHue, PALE_SAT, 100);
+          // cool-grade the distant crowd toward a hazy blue
+          double far = 1.0 - fogT;
+          color = LXColor.lerp(color, LXColor.hsb(225, 40, 70), (float) (0.6 * far));
+        }
+
+        drawFigure(p, px, pyBase, figH, bright, color, this.wphase[i]);
+      }
+    }
+
+    copyExterior();
+  }
+
+  private void drawFigure(Panel p, double px, double py, double h,
+      double bright, int color, double wphase) {
+    if (h < 2.5) {
+      splat(p, px, py - 0.4, 0.55 + h * 0.22, bright, color);
+      return;
+    }
+    final double r = Math.max(0.55, h * 0.05);
+    final double headR = h * 0.16;
+    final double headCy = py - h * 0.86;
+    final double hipY = py - h * 0.40;
+    final double shoulderY = headCy + headR + h * 0.06;
+    final double sway = Math.sin(wphase) * h * (0.13 + getWow() * 0.14); // dancing at high Wow
+
+    splat(p, px, headCy, headR, bright, color);                       // head
+    line(p, px, headCy + headR, px, hipY, r, bright, color);          // torso
+    line(p, px, hipY, px - h * 0.14 + sway, py, r, bright, color);    // left leg
+    line(p, px, hipY, px + h * 0.14 - sway, py, r, bright, color);    // right leg
+    line(p, px, shoulderY, px - h * 0.20 - sway, shoulderY + h * 0.16, r, bright, color); // left arm
+    line(p, px, shoulderY, px + h * 0.20 + sway, shoulderY + h * 0.16, r, bright, color); // right arm
+  }
+
+  private void line(Panel p, double x0, double y0, double x1, double y1,
+      double r, double bright, int color) {
+    double dx = x1 - x0, dy = y1 - y0;
+    int steps = (int) Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)));
+    if (steps < 1) steps = 1;
+    for (int k = 0; k <= steps; ++k) {
+      double t = (double) k / steps;
+      splat(p, x0 + dx * t, y0 + dy * t, r, bright, color);
+    }
+  }
+
+  private void splat(Panel p, double x, double y, double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(p.h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.max(0, Math.floor(x - r));
+    int x1 = (int) Math.min(p.w - 1, Math.ceil(x + r));
+    for (int yy = y0; yy <= y1; ++yy) {
+      double ddy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double ddx = xx - x;
+        double dd = Math.sqrt(ddx * ddx + ddy * ddy);
+        if (dd > r) continue;
+        double f = (1.0 - dd / r) * bright;
+        if (f <= 0) continue;
+        int idx = p.idx[xx][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -209,6 +209,9 @@ public class UFOAbduction extends StrandPattern {
         this.collapseT = -1;
         this.cube.reset();
         this.cylinder.reset();
+        // drop queued staggered spawns too, so a wave launched just before
+        // the collapse can't fire into the clean relaunch
+        java.util.Arrays.fill(this.pendAlive, false);
         this.relaunchQueued = true;
       }
     } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
@@ -226,8 +229,15 @@ public class UFOAbduction extends StrandPattern {
       final double strength = this.relaunchQueued ? 1.0
         : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
       final int n = this.lanes.getValuei();
-      launchWave(this.cube, true, n, strength, this.relaunchQueued);
-      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      // only feed the surfaces actually being rendered — a hidden target
+      // would otherwise pile up frozen heads at their spawn points
+      final Target t = getTarget();
+      if (t != Target.CYLINDER) {
+        launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      }
+      if (t != Target.CUBE) {
+        launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      }
       this.relaunchQueued = false;
     }
     this.launchFlash *= Math.exp(-deltaMs / 160.0);

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -1,0 +1,373 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * UFOAbduction — beat-locked counter-propagating waves on strand lanes. On every
+ * beat, green blocks launch upward from the floor at full speed, decelerate
+ * as they pass through the center — slowing to a crawl but never stopping,
+ * fattening into chunky bright slabs — then accelerate back to launch speed
+ * as they exit the top, like waves passing through a dense medium. Red
+ * streaks run the other way, top to floor, threading through the risers.
+ * Tails stretch with speed: long streamers at the edges, short stubs through
+ * the slow center; white-hot cores at speed. Lanes fire in synchronized
+ * clusters, the palette snaps between green-dominant, red-dominant, and
+ * mixed sections, and a big drop collapses the field to black before
+ * slamming a fresh wave up every lane. Modeled on the wave.mov reference.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class UFOAbduction extends StrandPattern {
+
+  private static final int MAX_HEADS = 96;
+  private static final double GREEN_HUE = 120;
+  private static final double RED_HUE = 10;
+  // calibrated from wave.mov: 800ms transit = 165ms entry + 565ms center stall
+  // + 65ms exit burst; stall:exit velocity ratio ~1:36; 900ms launch cadence
+  private static final double V_ENTRY = 0.00135;  // heights/ms, bottom leg
+  private static final double V_STALL = 0.00024;  // crawl through the center
+  private static final double V_EXIT = 0.0075;    // explosive top exit
+  private static final double V_RED = 0.0011;     // ~0.9s full-height descent
+  private static final double STALL_LO = 0.60;    // stall band (y, 0 = top)
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;     // full burst above here
+  private static final double IDLE_WAVE_MS = 900; // measured launch cadence
+  private static final double SECTION_MS = 4500;  // palette section length
+  private static final double COLLAPSE_MS = 450;
+
+  public final DiscreteParameter lanes =
+    new DiscreteParameter("Lanes", 14, 6, 24)
+    .setDescription("Strand lanes around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of launches and drops");
+
+  public final CompoundParameter glow =
+    new CompoundParameter("Glow", 0.6, 0, 1)
+    .setDescription("How far the blocks radiate light");
+
+  public final CompoundParameter trail =
+    new CompoundParameter("Trail", 0.5, 0, 1)
+    .setDescription("How long the gradient tails stream behind");
+
+  private final class Surface {
+    boolean inited;
+    final int[] lane = new int[MAX_HEADS];
+    final double[] y = new double[MAX_HEADS];     // normalized 0..1, 0 = top
+    final double[] v = new double[MAX_HEADS];     // heights/ms, +down -up
+    final boolean[] isRed = new boolean[MAX_HEADS];
+    final boolean[] thin = new boolean[MAX_HEADS]; // single-line red beams
+    final boolean[] waveR = new boolean[MAX_HEADS]; // reds riding the stall profile
+    final boolean[] alive = new boolean[MAX_HEADS];
+    void reset() {
+      for (int i = 0; i < MAX_HEADS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void spawn(int lane, boolean red) {
+      for (int i = 0; i < MAX_HEADS; ++i) {
+        if (this.alive[i]) continue;
+        this.lane[i] = lane;
+        this.isRed[i] = red;
+        this.thin[i] = red && Math.random() < 0.5;
+        // half the single lines mirror the risers' stall trajectory downward;
+        // the rest plummet straight to the floor
+        this.waveR[i] = red && this.thin[i] && Math.random() < 0.5;
+        if (red) {
+          this.y[i] = -0.02 - Math.random() * 0.08;
+          this.v[i] = this.waveR[i]
+            ? (0.9 + Math.random() * 0.2) // variance factor for the profile
+            : V_RED * (0.9 + Math.random() * 0.25) * (this.thin[i] ? 1.25 : 1.0);
+        } else {
+          this.y[i] = 1.02 + Math.random() * 0.10;
+          this.v[i] = -(0.75 + Math.random() * 0.5); // wide variance staggers the field
+        }
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double waveTimer = 0;
+  private double launchFlash = 0;
+  private double collapseT = -1;
+  private boolean relaunchQueued = false;
+  private int section = 0;
+
+  public UFOAbduction(LX lx) {
+    // Base registers color (hue shift), speed (cadence + velocity), size (block thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("lanes", this.lanes);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("glow", this.glow);
+    addParameter("trail", this.trail);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  /** Measured rise profile: brisk entry, long center stall, explosive exit. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Section palette mode: 0 = green-dominant, 1 = red-dominant, 2 = mixed. */
+  private int sectionMode() {
+    final double r = hashd(this.section * 613 + 29);
+    return (r < 0.42) ? 0 : (r < 0.68 ? 1 : 2);
+  }
+
+  // pending staggered spawns for launch wipes (lane, color, delay)
+  private final int[] pendLane = new int[MAX_HEADS];
+  private final boolean[] pendRed = new boolean[MAX_HEADS];
+  private final double[] pendMs = new double[MAX_HEADS];
+  private final boolean[] pendCube = new boolean[MAX_HEADS];
+  private final boolean[] pendAlive = new boolean[MAX_HEADS];
+
+  private void launchWave(Surface s, boolean isCube, int nLanes, double strength, boolean forceAll) {
+    final int mode = sectionMode();
+    final double redFrac = (mode == 0) ? 0.20 : (mode == 1 ? 0.75 : 0.5);
+    // per-event wipe: 0 = global, 1 = left->right, 2 = right->left, 3 = edges->center
+    final int wipe = (int) (hashd((int) (this.timeMs * 7) + 31) * 4);
+    for (int l = 0; l < nLanes; ++l) {
+      final int cluster = l / 3;
+      final double on = hashd(this.section * 977 + cluster * 131 + (int) (this.timeMs / 400));
+      if (!forceAll && on > 0.40 + strength * 0.55) continue;
+      final boolean red = hashd(this.section * 313 + cluster * 53) < redFrac;
+      double delay = 0;
+      final double u = (double) l / Math.max(1, nLanes - 1);
+      if (wipe == 1) delay = u * 370;
+      else if (wipe == 2) delay = (1 - u) * 370;
+      else if (wipe == 3) delay = (1.0 - Math.abs(u - 0.5) * 2) * 200; // edges first
+      // per-lane scatter on every wave so blocks never march in one big group
+      delay += hashd(l * 641 + (int) (this.timeMs * 3)) * 280;
+      queueSpawn(s, isCube, l, red, delay);
+      if (mode == 2 && hashd(l * 97 + (int) this.timeMs) < 0.3) {
+        queueSpawn(s, isCube, l, !red, delay + 60);
+      }
+    }
+  }
+
+  private void queueSpawn(Surface s, boolean isCube, int lane, boolean red, double delay) {
+    if (delay <= 0) {
+      s.spawn(lane, red);
+      return;
+    }
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) {
+        this.pendLane[i] = lane;
+        this.pendRed[i] = red;
+        this.pendMs[i] = delay;
+        this.pendCube[i] = isCube;
+        this.pendAlive[i] = true;
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    this.section = (int) (this.timeMs / SECTION_MS);
+
+    // collapse-to-black then hard re-drop on big hits
+    if (this.collapseT >= 0) {
+      this.collapseT += deltaMs;
+      if (this.collapseT >= COLLAPSE_MS) {
+        this.collapseT = -1;
+        this.cube.reset();
+        this.cylinder.reset();
+        this.relaunchQueued = true;
+      }
+    } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
+      this.collapseT = 0;
+    }
+
+    // beat-locked launches, with an idle subdivision cadence as fallback
+    this.waveTimer += deltaMs * speed * 2;
+    final boolean waveDue = this.waveTimer >= IDLE_WAVE_MS;
+    final boolean launch = this.relaunchQueued
+      || (this.collapseT < 0 && ((this.beat && this.beatLevel > 0.15) || waveDue));
+    if (launch) {
+      this.waveTimer = 0;
+      this.launchFlash = 1;
+      final double strength = this.relaunchQueued ? 1.0
+        : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
+      final int n = this.lanes.getValuei();
+      launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      this.relaunchQueued = false;
+    }
+    this.launchFlash *= Math.exp(-deltaMs / 160.0);
+
+    // fire staggered wipe spawns as their delays elapse
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) continue;
+      this.pendMs[i] -= deltaMs;
+      if (this.pendMs[i] <= 0) {
+        (this.pendCube[i] ? this.cube : this.cylinder).spawn(this.pendLane[i], this.pendRed[i]);
+        this.pendAlive[i] = false;
+      }
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((GREEN_HUE + hueShift) % 360)), 96, 100);
+    final int red = LXColor.hsb((float) (((RED_HUE + hueShift) % 360)), 98, 100);
+    final int nLanes = this.lanes.getValuei();
+    final double laneW = (double) w / nLanes;
+    // collapse envelope dims everything toward black before the re-drop
+    final double collapse = (this.collapseT >= 0)
+      ? 1.0 - this.collapseT / COLLAPSE_MS : 1.0;
+
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!s.alive[i]) continue;
+
+      // --- velocity field: green decelerates through the center and accelerates
+      // back out — waves passing through a dense medium, never stopping ---
+      final double vScale = speed * 2; // default Speed 0.5 == measured reference speed
+      if (s.isRed[i]) {
+        if (s.waveR[i]) {
+          // mirrored riser trajectory: zoom in from the top, slow-motion crawl
+          // through the center, burst out the floor
+          s.y[i] += s.v[i] * riseProfile(1.0 - s.y[i]) * vScale * deltaMs;
+        } else {
+          s.y[i] += s.v[i] * vScale * deltaMs; // straight plummet
+        }
+        if (s.y[i] >= 1.05) { s.alive[i] = false; continue; }
+      } else {
+        s.y[i] += s.v[i] * riseProfile(s.y[i]) * vScale * deltaMs;
+        if (s.y[i] <= -0.08) { s.alive[i] = false; continue; } // bursts out the top
+      }
+
+      // --- geometry: thick through the slow center, thin at speed; tail follows ---
+      double vNorm;
+      if (s.isRed[i] && !s.waveR[i]) {
+        vNorm = LXUtils.clamp(Math.abs(s.v[i]) / V_ENTRY, 0, 1.2);
+      } else {
+        final double yp = s.isRed[i] ? 1.0 - s.y[i] : s.y[i];
+        vNorm = LXUtils.clamp(riseProfile(yp) / V_ENTRY, 0, 1.2);
+      }
+      final double thickN = LXUtils.lerp(0.11 * (0.6 + getSize() * 0.9), 0.045, Math.min(1, vNorm));
+      final int thick = Math.max(2, (int) Math.round(thickN * h));
+      // Trail dial: 0.5 == 2x the original length; up to ~4x at full
+      final double trailK = 0.7 + this.trail.getValue() * 2.6;
+      final double tailN = LXUtils.clamp(vNorm * 0.85 * trailK, 0.16 * trailK, 1.9);
+      final int tail = (int) Math.round(tailN * h);
+      double bright = collapse;
+      if (bright <= 0.01) continue;
+
+      final int base = s.isRed[i] ? red : green;
+      // white-hot core at launch speed and on the beat flash
+      final double hot = LXUtils.clamp(vNorm * 0.7 + this.launchFlash * 0.4, 0, 0.85);
+      final int headC = LXColor.lerp(base, LXColor.WHITE, (float) hot);
+
+      int x0 = (int) (s.lane[i] * laneW);
+      int x1 = Math.min(w - 1, (int) ((s.lane[i] + 1) * laneW) - 2); // 1-col dark seam
+      if (s.isRed[i]) {
+        // red runs thin down the lane: some 2-wide strands, some single lines
+        final int cxr = (x0 + x1) / 2;
+        x0 = cxr;
+        x1 = s.thin[i] ? cxr : Math.min(w - 1, cxr + 1);
+      }
+      // strictly monotonic travel: the slow-motion crawl through the center is
+      // pure velocity — no positional oscillation (it read as shaking at LED scale)
+      final double ycF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final int yc = (int) Math.round(ycF);
+      final int dir = s.isRed[i] ? 1 : -1; // travel direction (+down)
+      // red pulses as it descends: a throb riding the moving packet
+      final double throb = s.isRed[i]
+        ? 0.55 + 0.45 * Math.sin(2 * Math.PI * this.timeMs / 1000.0 + i * 0.4) : 1.0;
+
+      final int headThick = s.isRed[i] ? Math.max(2, thick / 2) : thick; // compact red pulse
+
+      // radiant aura: soft gradient bloom bleeding off the block (ComeUp-style),
+      // strongest around the slow heavy slabs; the Glow dial sets reach + intensity
+      final double glowV = this.glow.getValue();
+      final int auraR = (s.isRed[i] ? 1 : 2) + (int) Math.round(glowV * 4);
+      final double auraB = bright * throb * (s.isRed[i] ? 0.5 : 1.0)
+        * (0.08 + glowV * 0.50) * (1.0 - 0.4 * Math.min(1, vNorm));
+      if (auraB > 0.02) {
+        final int byTop = Math.min(yc, yc - dir * (headThick - 1));
+        final int byBot = Math.max(yc, yc - dir * (headThick - 1));
+        for (int x = x0 - auraR; x <= x1 + auraR; ++x) {
+          final int dxo = (x < x0) ? (x0 - x) : ((x > x1) ? (x - x1) : 0);
+          for (int yy = byTop - auraR; yy <= byBot + auraR; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final int dyo = (yy < byTop) ? (byTop - yy) : ((yy > byBot) ? (yy - byBot) : 0);
+            final int dout = dxo + dyo;
+            if (dout == 0) continue; // inside the block
+            addPix(o, x, yy, base, auraB * Math.exp(-dout * (1.4 - glowV * 0.7)));
+          }
+        }
+      }
+
+      // continuous block span with sub-pixel feathered edges — glides, no snapping
+      final double leadF = ycF;
+      final double trailF = ycF - dir * (headThick - 1);
+      final double topF = Math.min(leadF, trailF);
+      final double botF = Math.max(leadF, trailF);
+      for (int x = x0; x <= x1; ++x) {
+        for (int yy = (int) Math.floor(topF) - 1; yy <= (int) Math.ceil(botF) + 1; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = (yy < topF) ? (topF - yy) : ((yy > botF) ? (yy - botF) : 0);
+          final double cov = LXUtils.clamp(1.0 - dOut, 0, 1); // edge feather
+          if (cov <= 0.02) continue;
+          final double u = LXUtils.clamp(1.0 - Math.abs(leadF - yy) / headThick, 0, 1);
+          addPix(o, x, yy, (u > 0.5) ? headC : base, bright * throb * (0.55 + 0.45 * u) * cov);
+        }
+        // tail streams behind, sub-pixel anchored to the trailing edge
+        for (int k = 1; k <= tail; ++k) {
+          final double yyF = trailF - dir * k;
+          final double fFall = Math.exp(-1.8 * k / tail);
+          if (fFall < 0.02) break;
+          final int yy0 = (int) Math.floor(yyF);
+          final double frac = yyF - yy0;
+          final double tb = bright * throb * fFall * 0.8;
+          if (yy0 >= 0 && yy0 < h) addPix(o, x, yy0, base, tb * (1 - frac));
+          if (yy0 + 1 >= 0 && yy0 + 1 < h) addPix(o, x, yy0 + 1, base, tb * frac);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
adds the next batch of piemonte patterns. all files live flat in apotheneum/piemonte/.

patterns:
- cope: the structure's vertical edges lit as thick glowing bars: the four corners of the cube and a set of evenly spaced lines around the cylinder. the bars breathe with the music, swelling thicker as the sound gets louder, and on a bass drop a bright radial glow...
- drip: standing strands of light hang from the rim to the floor like a beaded curtain in a cathedral dome, each one scintillating downward so the light seems to pour without ever falling. at the base every strand bends into a hook and trails outward along the...
- pressure: a two-channel color organ on the strand curtains: the columns gate hard between near-black and saturated washes, each column committed to either red or green, identities re-rolled with every major pulse. fast attack, slow release — the whole rig breathes...
- comeup: a glass of water filling up. on the cylinder and/or cube (target; interior and exterior, two independent glasses out of lockstep) a liquid tide rises bottom-to-top with a crisp, turbulent, foamy waterline.
- feelsomething: colored sticks rain down the surface, and when they strike the floor they bounce back up, tumbling end over end and throwing off a burst of bright sparkles. each bounce loses a little energy until the stick settles and a fresh one drops from the top.
- thehumanrace: a vast landscape scattered with little glowing stick figures, gathered in loose bunches and stretching to a horizon. a slow camera drifts and pans across them, and because each face of the sculpture looks out in its own direction the crowd wraps around you...

depends on #44

will attach video