### PR TITLE
add piemonte patterns: graphic set

### DIFF
--- a/src/main/java/apotheneum/piemonte/Bruh.java
+++ b/src/main/java/apotheneum/piemonte/Bruh.java
@@ -18,17 +18,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Bruh extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_DROPS = 160;
   private static final int MAX_SPLASH = 600;
@@ -46,10 +39,6 @@ public class Bruh extends ParameterPattern {
   public final CompoundParameter trail =
     new CompoundParameter("Trail", 0.5, 0, 1)
     .setDescription("How long the rain streaks trail behind each drop");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     int w, h;
@@ -117,14 +106,14 @@ public class Bruh extends ParameterPattern {
     addParameter("drops", this.drops);
     addParameter("splash", this.splash);
     addParameter("trail", this.trail);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
     final int base = getColor();
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, deltaMs, base);
     }

--- a/src/main/java/apotheneum/piemonte/Bruh.java
+++ b/src/main/java/apotheneum/piemonte/Bruh.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Bruh — a heavy downpour of vertical streaks falling through the piece like rain
+ * in a bamboo forest. Where each drop strikes the floor, water splashes upward in
+ * a small arc and falls back. Dense, continuous, elemental.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Bruh extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_DROPS = 160;
+  private static final int MAX_SPLASH = 600;
+  private static final double FALL = 0.045;      // cells / ms at speed 1
+  private static final double GRAVITY = 0.00018; // splash gravity, cells / ms^2
+
+  public final DiscreteParameter drops =
+    new DiscreteParameter("Drops", 60, 10, MAX_DROPS)
+    .setDescription("How many raindrops are falling at once");
+
+  public final CompoundParameter splash =
+    new CompoundParameter("Splash", 0.5, 0, 1)
+    .setDescription("How much water splashes up on impact");
+
+  public final CompoundParameter trail =
+    new CompoundParameter("Trail", 0.5, 0, 1)
+    .setDescription("How long the rain streaks trail behind each drop");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    // drops
+    final double[] dx = new double[MAX_DROPS];
+    final double[] dy = new double[MAX_DROPS];
+    final double[] dvy = new double[MAX_DROPS]; // per-drop speed factor
+    final double[] dlen = new double[MAX_DROPS];
+    // splash particles
+    final double[] sx = new double[MAX_SPLASH];
+    final double[] sy = new double[MAX_SPLASH];
+    final double[] svx = new double[MAX_SPLASH];
+    final double[] svy = new double[MAX_SPLASH];
+    final double[] slife = new double[MAX_SPLASH];
+    final double[] smax = new double[MAX_SPLASH];
+    final boolean[] salive = new boolean[MAX_SPLASH];
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      for (int i = 0; i < MAX_DROPS; ++i) {
+        respawnDrop(i, true);
+      }
+      for (int i = 0; i < MAX_SPLASH; ++i) {
+        this.salive[i] = false;
+      }
+    }
+
+    void respawnDrop(int i, boolean scatter) {
+      this.dx[i] = Math.random() * this.w;
+      this.dy[i] = scatter ? Math.random() * this.h : -(Math.random() * 12);
+      this.dvy[i] = 0.7 + Math.random() * 0.6;
+      this.dlen[i] = 1; // set at render from Size
+    }
+
+    void spawnSplash(double x, int count, double energy) {
+      for (int c = 0; c < count; ++c) {
+        int idx = -1;
+        for (int k = 0; k < MAX_SPLASH; ++k) {
+          if (!this.salive[k]) { idx = k; break; }
+        }
+        if (idx < 0) return;
+        this.sx[idx] = x;
+        this.sy[idx] = this.h - 1;
+        this.svx[idx] = (Math.random() - 0.5) * 0.03;
+        this.svy[idx] = -(0.015 + Math.random() * 0.03) * (0.5 + energy); // upward
+        this.smax[idx] = 350 + Math.random() * 450;
+        this.slife[idx] = this.smax[idx];
+        this.salive[idx] = true;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public Bruh(LX lx) {
+    // Base registers color, speed, size; speed = fall speed, size = streak/splash size.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("drops", this.drops);
+    addParameter("splash", this.splash);
+    addParameter("trail", this.trail);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final int base = getColor();
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, base);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, base);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs, int base) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double size = getSize();
+    final double wow = getWow();
+    // Wow = downpour surge: more drops falling faster, eruptive splashes
+    final int count = Math.min(MAX_DROPS, (int) (this.drops.getValuei() * (1 + wow * 1.5)));
+    final double fall = FALL * speed * deltaMs * (1 + wow * 0.8);
+    // Trail dial: 0.5 == the original streak length, up to ~3.3x at full
+    final double streak = (2 + size * 9) * (0.7 + this.trail.getValue() * 2.6);
+    // Wow makes impacts erupt: many more droplets, more upward energy, whiter foam.
+    final double splashAmt = this.splash.getValue();
+    final double splashEnergy = splashAmt + wow;
+    final int splashCount = (int) (1 + splashAmt * 14 + wow * 14);
+    final int splashColor = LXColor.lerp(base, LXColor.WHITE, (float) LXUtils.clamp(0.6 + wow * 0.4, 0, 1));
+    final int headColor = LXColor.lerp(base, LXColor.WHITE, 0.5f); // hot bead at the drop head
+
+    // --- drops ---
+    for (int i = 0; i < count; ++i) {
+      s.dy[i] += fall * s.dvy[i];
+      if (s.dy[i] >= h - 1) {
+        if (splashEnergy > 0) {
+          s.spawnSplash(s.dx[i], splashCount, splashEnergy);
+        }
+        s.respawnDrop(i, false);
+      }
+      // render vertical streak: head at dy, trail above, fading up
+      int xi = (((int) Math.round(s.dx[i])) % w + w) % w;
+      int head = (int) s.dy[i];
+      double hf = s.dy[i] - Math.floor(s.dy[i]); // sub-pixel head fraction
+      for (int k = 0; k <= (int) streak; ++k) {
+        int row = head - k;
+        if (row < 0 || row >= h) continue;
+        double b = Math.exp(-2.2 * k / (streak + 1)); // reads along the full trail
+        int c = base;
+        if (k == 0) {
+          b *= (0.4 + 0.6 * hf);
+          c = headColor;
+        }
+        int idx = o.point(xi, row).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(c, (float) b));
+      }
+      // smooth falling bead: light the row below the head at the leftover fraction
+      int below = head + 1;
+      if (below >= 0 && below < h) {
+        int idx = o.point(xi, below).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(base, (float) (hf * 0.5)));
+      }
+    }
+
+    // --- splashes ---
+    final double r = 0.9 + size * 0.9 + splashAmt * 1.3 + wow * 1.5;
+    for (int i = 0; i < MAX_SPLASH; ++i) {
+      if (!s.salive[i]) continue;
+      s.slife[i] -= deltaMs;
+      if (s.slife[i] <= 0) { s.salive[i] = false; continue; }
+      s.svy[i] += GRAVITY * deltaMs;          // gravity pulls back down
+      s.sy[i] += s.svy[i] * speed * deltaMs;
+      s.sx[i] += s.svx[i] * speed * deltaMs;
+      if (s.sy[i] >= h - 1 && s.svy[i] > 0) { s.salive[i] = false; continue; } // fell back
+      double fade = s.slife[i] / s.smax[i];
+      splat(o, w, h, s.sx[i], s.sy[i], r, Math.pow(fade, 1.5) * (0.55 + 0.65 * splashAmt + wow * 0.4), splashColor);
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/CandyFlip.java
+++ b/src/main/java/apotheneum/piemonte/CandyFlip.java
@@ -18,17 +18,10 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class CandyFlip extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_P = 256;
   private static final double BASE_VEL = 0.03;   // grid cells / ms at speed 1
@@ -46,10 +39,6 @@ public class CandyFlip extends ParameterPattern {
   public final DiscreteParameter generations =
     new DiscreteParameter("Gens", 4, 1, 6)
     .setDescription("How many generations the cascade goes");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** A 2D cascade field on one orientation (wraps in X, bounces in Y). */
   private final class Surface {
@@ -115,7 +104,7 @@ public class CandyFlip extends ParameterPattern {
     super(lx, 0.4, 0, 1, 0.5, 0, 1);
     addParameter("density", this.density);
     addParameter("generations", this.generations);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -123,7 +112,7 @@ public class CandyFlip extends ParameterPattern {
     setColors(LXColor.BLACK);
     this.timeMs += deltaMs;
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     final double baseHue = LXColor.h(getColor());
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, deltaMs, baseHue);

--- a/src/main/java/apotheneum/piemonte/CandyFlip.java
+++ b/src/main/java/apotheneum/piemonte/CandyFlip.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * CandyFlip — rainbow comets roam the surface; each lives briefly then bursts
+ * into a fresh generation of comets flying outward, cascading until the energy
+ * runs out. White-hot heads trail fading rainbow gradients that shift hue with
+ * each generation. An Apotheneum take on a vertex-to-vertex cascade.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class CandyFlip extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_P = 256;
+  private static final double BASE_VEL = 0.03;   // grid cells / ms at speed 1
+  private static final double BURST_CYCLE = 2400; // ms (speed-scaled) between gen-0 bursts
+  private static final double BASE_AGE = 1100;    // ms (speed-scaled) particle life
+  private static final int FAN = 3;               // children per burst
+  private static final double GEN_HUE = 95;       // hue shift per generation
+  private static final double TRAIL_HUE = 26;     // hue shift along the trail (rainbow streak)
+  private static final double HUE_DRIFT = 0.03;   // hue drift per ms
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 5, 1, 16)
+    .setDescription("Gen-0 comets spawned per burst");
+
+  public final DiscreteParameter generations =
+    new DiscreteParameter("Gens", 4, 1, 6)
+    .setDescription("How many generations the cascade goes");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** A 2D cascade field on one orientation (wraps in X, bounces in Y). */
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    final double[] px = new double[MAX_P];
+    final double[] py = new double[MAX_P];
+    final double[] vx = new double[MAX_P];
+    final double[] vy = new double[MAX_P];
+    final int[] gen = new int[MAX_P];
+    final double[] age = new double[MAX_P];
+    final double[] maxAge = new double[MAX_P];
+    final boolean[] alive = new boolean[MAX_P];
+    double spawnAcc;
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      this.spawnAcc = 0;
+      for (int i = 0; i < MAX_P; ++i) {
+        this.alive[i] = false;
+      }
+    }
+
+    int freeSlot() {
+      for (int i = 0; i < MAX_P; ++i) {
+        if (!this.alive[i]) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    void spawn(double x, double y, int generation) {
+      int i = freeSlot();
+      if (i < 0) {
+        return;
+      }
+      this.px[i] = x;
+      this.py[i] = y;
+      double theta = Math.random() * Math.PI * 2;
+      double mag = 0.6 + 0.7 * Math.random();
+      this.vx[i] = Math.cos(theta) * mag;
+      this.vy[i] = Math.sin(theta) * mag;
+      this.gen[i] = generation;
+      // negative age staggers each particle's start so bursts don't pop in lockstep
+      this.age[i] = -Math.random() * 200;
+      this.maxAge[i] = BASE_AGE * (0.7 + 0.6 * Math.random());
+      this.alive[i] = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double timeMs = 0;
+
+  public CandyFlip(LX lx) {
+    // Base registers color (base hue), speed, size; speed is a magnitude here.
+    super(lx, 0.4, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("generations", this.generations);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    final Target t = this.target.getEnum();
+    final double baseHue = LXColor.h(getColor());
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, baseHue);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, baseHue);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs, double baseHue) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double size = getSize();
+    final double wow = getWow();
+    final double move = speed * BASE_VEL * deltaMs;
+    final int maxGen = this.generations.getValuei();
+    // Wow makes the cascade explosive: more children per burst, hotter heads.
+    final int fan = FAN + (int) Math.round(wow * 5);
+
+    // --- seed gen-0 bursts on a timer ---
+    s.spawnAcc += deltaMs * speed;
+    if (s.spawnAcc >= BURST_CYCLE) {
+      s.spawnAcc -= BURST_CYCLE;
+      int n = this.density.getValuei();
+      for (int k = 0; k < n; ++k) {
+        s.spawn(Math.random() * w, Math.random() * h, 0);
+      }
+    }
+
+    // --- update: move, age, burst into next generation ---
+    for (int i = 0; i < MAX_P; ++i) {
+      if (!s.alive[i]) continue;
+      double x = s.px[i] + s.vx[i] * move;
+      double y = s.py[i] + s.vy[i] * move;
+      x = ((x % w) + w) % w;
+      if (y < 0) { y = -y; s.vy[i] = -s.vy[i]; }
+      else if (y > h - 1) { y = 2 * (h - 1) - y; s.vy[i] = -s.vy[i]; }
+      s.px[i] = x;
+      s.py[i] = LXUtils.clamp(y, 0, h - 1);
+
+      s.age[i] += deltaMs * speed;
+      if (s.age[i] >= s.maxAge[i]) {
+        if (s.gen[i] + 1 < maxGen) {
+          for (int c = 0; c < fan; ++c) {
+            s.spawn(s.px[i], s.py[i], s.gen[i] + 1);
+          }
+        }
+        s.alive[i] = false;
+      }
+    }
+
+    // --- render: white-hot heads + fading rainbow trails ---
+    final double headR = (0.8 + size * 1.5) * (1.0 + wow * 1.2); // wow -> bigger, hotter heads
+    final int tailCells = (int) (16 + size * 90);
+    for (int i = 0; i < MAX_P; ++i) {
+      if (!s.alive[i]) continue;
+      // fade out over the particle's life so bursts feel like they spend energy,
+      // with a brief birth pop that flares then settles
+      double lifeFade = Math.min(1.6,
+        (1.0 - 0.6 * (s.age[i] / s.maxAge[i])) * (1.0 + 0.8 * Math.exp(-s.age[i] / 120.0)));
+      splat(s, o, s.px[i], s.py[i], headR, LXUtils.clamp(lifeFade, 0, 1), LXColor.WHITE);
+
+      double vlen = Math.sqrt(s.vx[i] * s.vx[i] + s.vy[i] * s.vy[i]);
+      if (vlen < 1e-4) continue;
+      double ux = s.vx[i] / vlen, uy = s.vy[i] / vlen;
+      for (int k = 1; k <= tailCells; ++k) {
+        double f = Math.exp(-2.5 * k / tailCells) * lifeFade;
+        if (f <= 0) break;
+        double hue = baseHue + s.gen[i] * GEN_HUE + k * TRAIL_HUE + this.timeMs * HUE_DRIFT;
+        hue = ((hue % 360) + 360) % 360;
+        // trail emerges white from the head and blooms into color
+        float sat = (float) (100.0 * Math.min(1.0, k / (0.25 * tailCells)));
+        int col = LXColor.hsb((float) hue, sat, 100);
+        splat(s, o, s.px[i] - ux * k * 0.9, s.py[i] - uy * k * 0.9, 0.9, LXUtils.clamp(f, 0, 1), col);
+      }
+    }
+  }
+
+  /** Draw a soft round dab at (x,y); x wraps, y is clamped to the surface. */
+  private void splat(Surface s, Apotheneum.Orientation o, double x, double y,
+      double r, double bright, int color) {
+    final int w = s.w, h = s.h;
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double f = (1.0 - dd / r) * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ComeUp.java
+++ b/src/main/java/apotheneum/piemonte/ComeUp.java
@@ -22,18 +22,11 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class ComeUp extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double RISE_RATE_PER_MS = 1.0 / 6000.0; // full rise in ~6s at speed 1
   private static final double MAX_HOLD_MS = 2500.0;
@@ -142,10 +135,6 @@ public class ComeUp extends ParameterPattern {
     }
   }
 
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures the glass fills");
-
   private final Tide exterior = new Tide(0.0, 0.0, 0.0);
   // Interior seeded out of lockstep (height + time) and in a different hue.
   private final Tide interior = new Tide(0.4, 4000.0, INTERIOR_HUE_OFFSET);
@@ -158,7 +147,7 @@ public class ComeUp extends ParameterPattern {
     addParameter("hold", this.hold);
     addParameter("bubbles", this.bubbles);
     addParameter("sparkle", this.sparkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -174,7 +163,7 @@ public class ComeUp extends ParameterPattern {
     final double wow = getWow();
     final int base = getColor();
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     this.exterior.advance(deltaMs, speed, holdAmt);
     this.exterior.updateBubbles(deltaMs, speed, bubbleCount);
     if (Apotheneum.hasInterior) {

--- a/src/main/java/apotheneum/piemonte/ComeUp.java
+++ b/src/main/java/apotheneum/piemonte/ComeUp.java
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * ComeUp — a glass of water filling up. On the cylinder and/or cube (Target;
+ * interior and exterior,
+ * two independent glasses out of lockstep) a liquid tide rises bottom-to-top with
+ * a crisp, turbulent, foamy waterline. The body below the surface teems with
+ * rising bubbles and scintillating sparkles. Each time the glass fills, the flood
+ * color rotates to a new hue, so the piece cycles color with every fill.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class ComeUp extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double RISE_RATE_PER_MS = 1.0 / 6000.0; // full rise in ~6s at speed 1
+  private static final double MAX_HOLD_MS = 2500.0;
+  private static final double TEMPORAL_HZ = 0.5;
+  private static final double EDGE_BAND = 0.02;                // crisp waterline
+  private static final double INV_BAND = 1.0 / EDGE_BAND;
+  private static final int MAX_BUBBLES = 96;
+  private static final double BUBBLE_RISE = 0.00010;           // normalized rise / ms at speed 1
+  private static final double HUE_STEP = 43.0;                 // hue advance per fill (deg)
+  private static final double INTERIOR_HUE_OFFSET = 137.0;     // interior glass differs
+
+  public final DiscreteParameter detail =
+    new DiscreteParameter("Detail", 3, 1, 11)
+    .setDescription("Spatial frequency of the surface noise");
+
+  public final CompoundParameter chop =
+    new CompoundParameter("Chop", 0.35, 0, 1)
+    .setDescription("Turbulent whitewater chop (dreamy roll to full storm)");
+
+  public final CompoundParameter hold =
+    new CompoundParameter("Hold", 0.30, 0, 1)
+    .setDescription("How long the tide rests at the crest before the next surge");
+
+  public final DiscreteParameter bubbles =
+    new DiscreteParameter("Bubbles", 40, 0, MAX_BUBBLES)
+    .setDescription("Bubbles rising through each tide");
+
+  public final CompoundParameter sparkle =
+    new CompoundParameter("Sparkle", 0.4, 0, 1)
+    .setDescription("Sparse scintillating glints suspended in the liquid");
+
+  private enum Phase {
+    RISING,
+    HOLD
+  }
+
+  /** Per-surface animation state, so interior/exterior are fully independent. */
+  private static final class Tide {
+    double fillLevel;
+    double holdElapsedMs;
+    double timeMs;
+    double currOffsetDeg;   // hue offset of the flood currently rising
+    double prevOffsetDeg;   // hue offset of the receding flood above it
+    Phase phase = Phase.RISING;
+
+    // bubbles (normalized: bx 0..1 wraps, by 0=bottom..1=top)
+    final double[] bx = new double[MAX_BUBBLES];
+    final double[] by = new double[MAX_BUBBLES];
+    final double[] bsize = new double[MAX_BUBBLES];
+    final double[] bspeed = new double[MAX_BUBBLES];
+    final double[] bphase = new double[MAX_BUBBLES];
+    final boolean[] binit = new boolean[MAX_BUBBLES];
+
+    Tide(double fillLevel, double timeMs, double hueSeedDeg) {
+      this.fillLevel = fillLevel;
+      this.timeMs = timeMs;
+      this.currOffsetDeg = hueSeedDeg;
+      this.prevOffsetDeg = hueSeedDeg;
+    }
+
+    void advance(double deltaMs, double speed, double holdAmt) {
+      this.timeMs += deltaMs;
+      if (this.phase == Phase.RISING) {
+        this.fillLevel += deltaMs * speed * RISE_RATE_PER_MS;
+        if (this.fillLevel >= 1.0) {
+          this.fillLevel = 1.0;
+          this.holdElapsedMs = 0.0;
+          this.phase = Phase.HOLD;
+        }
+      } else {
+        this.holdElapsedMs += deltaMs;
+        if (this.holdElapsedMs >= holdAmt * MAX_HOLD_MS) {
+          // next glass fills with a fresh hue rising over the previous color
+          this.prevOffsetDeg = this.currOffsetDeg;
+          this.currOffsetDeg = (this.currOffsetDeg + HUE_STEP) % 360.0;
+          this.fillLevel = 0.0;
+          this.phase = Phase.RISING;
+        }
+      }
+    }
+
+    private void spawnBubble(int i) {
+      this.bx[i] = Math.random();
+      this.by[i] = 0;
+      this.bsize[i] = 0.6 + Math.random() * 1.2;
+      this.bspeed[i] = 0.6 + Math.random() * 0.9;
+      this.bphase[i] = Math.random() * Math.PI * 2;
+      this.binit[i] = true;
+    }
+
+    void updateBubbles(double deltaMs, double speed, int count) {
+      for (int i = 0; i < count; ++i) {
+        if (!this.binit[i]) {
+          spawnBubble(i);
+          // stagger initial heights so they don't all start at the floor
+          this.by[i] = Math.random() * Math.max(0.01, this.fillLevel);
+        }
+        this.by[i] += BUBBLE_RISE * speed * this.bspeed[i] * deltaMs;
+        this.bx[i] += Math.sin(this.timeMs * 0.002 + this.bphase[i]) * 0.00003 * deltaMs;
+        this.bx[i] -= Math.floor(this.bx[i]);
+        // pop at the surface, respawn at the floor
+        if (this.by[i] >= this.fillLevel || this.by[i] > 1.0) {
+          spawnBubble(i);
+        }
+      }
+    }
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures the glass fills");
+
+  private final Tide exterior = new Tide(0.0, 0.0, 0.0);
+  // Interior seeded out of lockstep (height + time) and in a different hue.
+  private final Tide interior = new Tide(0.4, 4000.0, INTERIOR_HUE_OFFSET);
+
+  public ComeUp(LX lx) {
+    // Base registers color (starting hue), speed (rise rate), size (surface amplitude), wow.
+    super(lx, 1, 0.1, 4, 0.1, 0, 0.3);
+    addParameter("detail", this.detail);
+    addParameter("chop", this.chop);
+    addParameter("hold", this.hold);
+    addParameter("bubbles", this.bubbles);
+    addParameter("sparkle", this.sparkle);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    // power curve: default (1.0) unchanged, but the ends bite — crawl at the
+    // bottom of the knob, ~9x fill rate at the top
+    final double speed = Math.pow(getSpeed(), 1.6);
+    final double holdAmt = this.hold.getValue();
+    final int bubbleCount = this.bubbles.getValuei();
+    final double sparkleAmt = this.sparkle.getValue();
+    final double wow = getWow();
+    final int base = getColor();
+
+    final Target t = this.target.getEnum();
+    this.exterior.advance(deltaMs, speed, holdAmt);
+    this.exterior.updateBubbles(deltaMs, speed, bubbleCount);
+    if (Apotheneum.hasInterior) {
+      this.interior.advance(deltaMs, speed, holdAmt);
+      this.interior.updateBubbles(deltaMs, speed, bubbleCount);
+    }
+
+    // one shared fluid state per surface pair: cube and cylinder fill in step
+    if (t != Target.CUBE) {
+      renderTide(this.exterior, Apotheneum.cylinder.exterior, base, bubbleCount, sparkleAmt, wow);
+      if (Apotheneum.hasInterior) {
+        renderTide(this.interior, Apotheneum.cylinder.interior, base, bubbleCount, sparkleAmt, wow);
+      }
+    }
+    if (t != Target.CYLINDER) {
+      renderTide(this.exterior, Apotheneum.cube.exterior, base, bubbleCount, sparkleAmt, wow);
+      if (Apotheneum.hasInterior) {
+        renderTide(this.interior, Apotheneum.cube.interior, base, bubbleCount, sparkleAmt, wow);
+      }
+    }
+
+    // Intentionally no copyExterior(): the two surfaces render independently.
+  }
+
+  private void renderTide(Tide tide, Apotheneum.Orientation o, int baseColor,
+      int bubbleCount, double sparkleAmt, double wow) {
+    // Rotate hue only; keep the palette color's saturation/brightness.
+    final float baseHue = LXColor.h(baseColor);
+    final float baseSat = LXColor.s(baseColor);
+    final float baseBri = LXColor.b(baseColor);
+    final int curr = LXColor.hsb((float) ((baseHue + tide.currOffsetDeg) % 360.0), baseSat, baseBri);
+    final int prev = LXColor.hsb((float) ((baseHue + tide.prevOffsetDeg) % 360.0), baseSat, baseBri);
+
+    final double amp = getSize();
+    final double chopAmt = this.chop.getValue();
+    final float freq = Math.max(1, this.detail.getValuei());
+    final float t = (float) (tide.timeMs * 0.001 * TEMPORAL_HZ);
+    final float driftX = t * 0.3f;
+    final float driftZ = t * 0.17f;
+    final double level = tide.fillLevel;
+
+    final double foamW = 0.012 + 0.020 * chopAmt;
+    final double foamGain = (0.55 + 0.45 * chopAmt) * (1.0 + wow * 0.8);
+    final double sTime = tide.timeMs * 0.004;
+    final int tq = (int) sTime;
+    final double tf = sTime - tq;
+    final double twEnv = Math.sin(tf * Math.PI);
+    final float glint = (float) (twEnv * twEnv);
+    final double sparkThresh = 1.0 - sparkleAmt * (0.05 + wow * 0.08);
+
+    // --- liquid body + churning surface + foam + sparkles ---
+    for (Apotheneum.Column column : o.columns()) {
+      final LXPoint[] points = column.points;
+      final int len = points.length;
+      final int last = len - 1;
+      for (int j = 0; j < len; ++j) {
+        final LXPoint p = points[j];
+        final float nx = (p.xn + driftX) * freq;
+        final float nz = (p.zn + driftZ) * freq;
+        final float base = Noise.stb_perlin_fbm_noise3(nx, nz, t, 2.0f, 0.5f, 3);
+        final float chopRaw =
+          Noise.stb_perlin_turbulence_noise3(nx * 2.3f, nz * 2.3f, t * 1.7f, 2.2f, 0.5f, 4);
+        final float chopN = (chopRaw - 0.5f) * 2.0f;
+        final double n = base + chopN * chopAmt * 1.2;
+
+        // Y=0 is the top of the column, so invert the index for a bottom-up fill.
+        final double vBottom = (last == 0) ? 0.0 : (double) (last - j) / last;
+        final double localLevel = level + n * amp;
+        final double d = localLevel - vBottom; // >0 below the surface (in the liquid)
+        final double mix = LXUtils.clamp(0.5 + 0.5 * d * INV_BAND, 0, 1);
+
+        int c;
+        if (mix <= 0.0) {
+          c = prev;
+        } else if (mix >= 1.0) {
+          c = curr;
+        } else {
+          c = LXColor.lerp(prev, curr, (float) mix);
+        }
+
+        // depth-shade the liquid body: brightest at the waterline, noise-modulated below
+        if (d > 0) {
+          double glow = 0.62 + 0.23 * LXUtils.clamp(1.0 - d * 2.0, 0, 1) + 0.15 * (base * 0.5 + 0.5);
+          c = LXColor.scaleBrightness(c, (float) Math.min(1.0, glow));
+        }
+
+        // whitewater foam riding the turbulent surface
+        final double fd = Math.abs(d) / foamW;
+        if (fd < 1.0) {
+          double foam = (1.0 - fd) * LXUtils.clamp((chopRaw - 0.35) * 3.0, 0, 1) * foamGain;
+          if (foam > 0) {
+            foam = LXUtils.clamp(foam, 0, 1);
+            foam = foam * foam * (3 - 2 * foam);
+            c = LXColor.lerp(c, LXColor.WHITE, (float) foam);
+          }
+        }
+
+        // sparse scintillating glints suspended below the surface
+        if (sparkleAmt > 0 && d > 0) {
+          int hs = p.index * 374761393 + tq * 668265263;
+          hs = (hs ^ (hs >>> 13)) * 1274126177;
+          double r = ((hs >>> 8) & 0xFFFF) / 65535.0;
+          if (r > sparkThresh) {
+            c = LXColor.lightest(c, LXColor.scaleBrightness(LXColor.WHITE, glint));
+          }
+        }
+
+        this.colors[p.index] = c;
+      }
+    }
+
+    // --- bubbles rising through the liquid ---
+    if (bubbleCount > 0 && level > 0.02) {
+      final int w = o.width();
+      final int h = o.height();
+      final int bubbleColor = LXColor.lerp(curr, LXColor.WHITE, 0.7f);
+      for (int i = 0; i < bubbleCount; ++i) {
+        if (!tide.binit[i] || tide.by[i] >= level) {
+          continue; // only visible within the liquid body
+        }
+        double gx = tide.bx[i] * w;
+        double gy = (h - 1) * (1.0 - tide.by[i]); // by=0 bottom -> y=h-1
+        // brighter deep down, fading as it nears the surface
+        double depth = (level - tide.by[i]) / level;
+        double b = 0.35 + 0.65 * LXUtils.clamp(depth * 1.8, 0, 1);
+        splat(o, w, h, gx, gy, 1.0 + tide.bsize[i], b, bubbleColor);
+      }
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Cope.java
+++ b/src/main/java/apotheneum/piemonte/Cope.java
@@ -20,17 +20,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Cope extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_PULSE = 8;
   private static final double MIN_BEAT_MS = 110;
@@ -48,10 +41,6 @@ public class Cope extends ParameterPattern {
   public final DiscreteParameter lines =
     new DiscreteParameter("Lines", 6, 1, 24)
     .setDescription("Number of vertical lines around the cylinder");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** A surface's edge columns + a pool of expanding glow pulses. */
   private final class Surface {
@@ -119,19 +108,17 @@ public class Cope extends ParameterPattern {
     addParameter("reactivity", this.reactivity);
     addParameter("sensitivity", this.sensitivity);
     addParameter("lines", this.lines);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private boolean detectBeat(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
     this.sinceBeatMs += deltaMs;
 
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= MIN_BEAT_MS)
       && (bass > 0.01);
@@ -144,8 +131,7 @@ public class Cope extends ParameterPattern {
   }
 
   private double broadband() {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    return m.getAveragef(0, Math.max(1, m.numBands));
+    return this.level.getValue();
   }
 
   @Override
@@ -169,7 +155,7 @@ public class Cope extends ParameterPattern {
     this.beatKick *= Math.exp(-deltaMs / 250.0);
     final double norm = LXUtils.clamp((ratio - 0.55) * 1.6, 0, 1.2)
       + this.beatKick * 0.6;
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     final int nLines = this.lines.getValuei();
 
     if (t != Target.CYLINDER) {

--- a/src/main/java/apotheneum/piemonte/Cope.java
+++ b/src/main/java/apotheneum/piemonte/Cope.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Cope — the structure's vertical edges lit as thick glowing bars: the four
+ * corners of the cube and a set of evenly spaced lines around the cylinder. The
+ * bars breathe with the music, swelling thicker as the sound gets louder, and on
+ * a bass drop a bright radial glow erupts from an edge and blooms outward across
+ * the surface. Audio-reactive architecture.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Cope extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_PULSE = 8;
+  private static final double MIN_BEAT_MS = 110;
+  private static final double GLOW_BASE = 0.055;   // bloom growth, cells / ms at speed 1
+  private static final double MAXAGE_BASE = 1400;  // pulse lifetime (ms) at speed 1
+
+  public final CompoundParameter reactivity =
+    new CompoundParameter("Reactivity", 0.6, 0, 1)
+    .setDescription("How strongly audio thickens the edge bars");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Bass-drop trigger sensitivity for the radial glow");
+
+  public final DiscreteParameter lines =
+    new DiscreteParameter("Lines", 6, 1, 24)
+    .setDescription("Number of vertical lines around the cylinder");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** A surface's edge columns + a pool of expanding glow pulses. */
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    boolean isCube;
+    int builtLines = -1;
+    int[] edgeX = new int[0];
+    final double[] ox = new double[MAX_PULSE];
+    final double[] oy = new double[MAX_PULSE];
+    final double[] age = new double[MAX_PULSE];
+    final boolean[] alive = new boolean[MAX_PULSE];
+
+    void ensure(int w, int h, boolean isCube, int nLines) {
+      if (this.inited && this.w == w && this.h == h
+          && (isCube || this.builtLines == nLines)) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.isCube = isCube;
+      this.inited = true;
+      if (isCube) {
+        this.edgeX = new int[] { 0, 50, 100, 150 }; // the four vertical corners
+        this.builtLines = -1;
+      } else {
+        this.edgeX = new int[nLines];
+        for (int k = 0; k < nLines; ++k) {
+          this.edgeX[k] = (int) Math.round((double) k * w / nLines);
+        }
+        this.builtLines = nLines;
+      }
+      for (int i = 0; i < MAX_PULSE; ++i) {
+        this.alive[i] = false;
+      }
+    }
+
+    void spawnPulse(double x, double y) {
+      for (int i = 0; i < MAX_PULSE; ++i) {
+        if (!this.alive[i]) {
+          this.ox[i] = x;
+          this.oy[i] = y;
+          this.age[i] = 0;
+          this.alive[i] = true;
+          return;
+        }
+      }
+      // pool full -> drop the request (oldest keeps blooming)
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  // shared bass-onset state (computed once per frame)
+  private double bassAvg, prevBass, sinceBeatMs, beatLevel;
+  private double levelEnv = 0;
+  private double levelAvg = 0; // slow auto-gain reference
+  private double beatKick = 0; // bars snap wide on each hit
+
+  public Cope(LX lx) {
+    // Base registers color (edge/glow tint), speed (glow expand/decay), size (base
+    // thickness), wow (glow intensity). We add audio + geometry controls.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("reactivity", this.reactivity);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("lines", this.lines);
+    addParameter("target", this.target);
+  }
+
+  private boolean detectBeat(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
+    this.sinceBeatMs += deltaMs;
+
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= MIN_BEAT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    return beat;
+  }
+
+  private double broadband() {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    return m.getAveragef(0, Math.max(1, m.numBands));
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final boolean beat = detectBeat(deltaMs);
+    final double level = broadband();
+    // attack/release envelope so the bars snap up quickly and relax smoothly
+    double aAtk = 1 - Math.exp(-deltaMs / 25.0);
+    double aRel = 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * (level > this.levelEnv ? aAtk : aRel);
+    // auto-gain drive: the envelope/average RATIO carries the dynamics (steady
+    // music sits ~0.9-1.0; hits spike it, gaps drop it). Expand the contrast
+    // around that resting point and snap on beats so the bars actually pump.
+    this.levelAvg += (level - this.levelAvg) * (1 - Math.exp(-deltaMs / 2500.0));
+    final double ratio = this.levelEnv / Math.max(1e-4, this.levelAvg);
+    if (beat) {
+      this.beatKick = 1;
+    }
+    this.beatKick *= Math.exp(-deltaMs / 250.0);
+    final double norm = LXUtils.clamp((ratio - 0.55) * 1.6, 0, 1.2)
+      + this.beatKick * 0.6;
+    final Target t = this.target.getEnum();
+    final int nLines = this.lines.getValuei();
+
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, beat, norm, true, 0);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, beat, norm, false, nLines);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs,
+      boolean beat, double level, boolean isCube, int nLines) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h, isCube, nLines);
+
+    final double wow = getWow();
+    final int base = getColor();
+
+    // --- thick vertical edge bars, thickness breathes with audio ---
+    final double baseR = 0.5 + getSize() * 4.0 + wow * 2.0;
+    final double thickMax = isCube ? w * 0.25 : 0.45 * (double) w / Math.max(1, nLines);
+    final double thick = LXUtils.clamp(
+      baseR + this.reactivity.getValue() * level * (thickMax - baseR) * 0.85, 0.5, thickMax);
+    final double barBright = 0.50 + 0.50 * LXUtils.clamp(level * 0.8, 0, 1);
+    for (int ex : s.edgeX) {
+      for (int y = 0; y < h; ++y) {
+        vbar(o, w, h, ex, y, thick, barBright, base);
+      }
+    }
+
+    // --- bass drop spawns a radial glow from a random edge ---
+    if (beat && s.edgeX.length > 0) {
+      double x0 = s.edgeX[(int) (Math.random() * s.edgeX.length)];
+      double y0 = (0.2 + 0.6 * Math.random()) * h;
+      s.spawnPulse(x0, y0);
+    }
+
+    // --- advance + draw glow pulses (bounded bbox, X-wrapped) ---
+    final double speed = getSpeed();
+    final double glowSpeed = GLOW_BASE * (0.5 + speed);
+    final double maxAge = MAXAGE_BASE / (0.5 + speed);
+    for (int i = 0; i < MAX_PULSE; ++i) {
+      if (!s.alive[i]) continue;
+      s.age[i] += deltaMs;
+      if (s.age[i] >= maxAge) {
+        s.alive[i] = false;
+        continue;
+      }
+      double R = glowSpeed * s.age[i] * (1.0 + wow * 0.5);
+      if (R < 0.5) continue;
+      double fade = LXUtils.clamp((1.0 - s.age[i] / maxAge) * (1.0 + wow), 0, 1.5);
+      double cx = s.ox[i], cy = s.oy[i];
+      int y0 = (int) Math.max(0, Math.floor(cy - R));
+      int y1 = (int) Math.min(h - 1, Math.ceil(cy + R));
+      int x0 = (int) Math.floor(cx - R);
+      int x1 = (int) Math.ceil(cx + R);
+      for (int yy = y0; yy <= y1; ++yy) {
+        double dy = yy - cy;
+        for (int xx = x0; xx <= x1; ++xx) {
+          double dx = xx - cx;
+          dx = dx - w * Math.rint(dx / w); // X-wrap distance
+          double d = Math.sqrt(dx * dx + dy * dy);
+          if (d > R) continue;
+          // traveling shock ring: Gaussian shell near the wavefront
+          double sigma = Math.max(1.0, 0.18 * R);
+          double rd = d - 0.85 * R;
+          double ring = Math.exp(-(rd * rd) / (2 * sigma * sigma));
+          double b = LXUtils.clamp(ring * fade * fade, 0, 1);
+          if (b <= 0) continue;
+          // white flash core, only during the pulse's early life
+          double core = (s.age[i] < 150) ? LXUtils.clamp(1.0 - d / (R * 0.4), 0, 1) : 0;
+          int c = LXColor.lerp(base, LXColor.WHITE, (float) core);
+          int xi = ((xx % w) + w) % w;
+          int idx = o.point(xi, yy).index;
+          this.colors[idx] = LXColor.lightest(this.colors[idx],
+            LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+        }
+      }
+    }
+  }
+
+  /** A thick vertical bar segment: 1-D horizontal falloff, X-wrapped (corner spill). */
+  private void vbar(Apotheneum.Orientation o, int w, int h, double cx, int y,
+      double r, double bright, int color) {
+    int x0 = (int) Math.floor(cx - r);
+    int x1 = (int) Math.ceil(cx + r);
+    for (int xx = x0; xx <= x1; ++xx) {
+      double u = 1.0 - Math.abs(xx - cx) / r;
+      if (u <= 0) continue;
+      double f = u * u * bright; // gamma falloff for a tighter profile
+      int cc = color;
+      if (u > 0.8) {
+        cc = LXColor.lerp(color, LXColor.WHITE, (float) ((u - 0.8) / 0.2 * 0.6)); // hot core
+      }
+      int xi = ((xx % w) + w) % w;
+      int idx = o.point(xi, y).index;
+      this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(cc, (float) f));
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/CrashingOut.java
+++ b/src/main/java/apotheneum/piemonte/CrashingOut.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * CrashingOut — LockedIn's restless sibling. A set of thick bars beams in
+ * from an edge as solid columns, each on its own clock — fast travel,
+ * decelerating approach, bounces on the entry velocity model — and locks
+ * into the center. But nothing stays locked: the bars keep bouncing, restless,
+ * until the whole set crashes back out — each bar retreating mid-bounce in
+ * reverse off its entry edge, slow to break loose and accelerating away. Then the next set enters from
+ * the opposite edge at a new horizontal offset and the next of five colors.
+ * Beats punch the bounces; Wow adds bounce reach and speeds the crash.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class CrashingOut extends StrandPattern {
+
+  private static final int N_COLORS = 5;
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_MS = 1800;    // sustained bounce before the crash
+  private static final double GONE = 1.25;         // off-canvas travel distance
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // one set at a time (normalized; shared across surfaces)
+  private final double[] barX = new double[MAX_BARS];
+  private final double[] barLen = new double[MAX_BARS];
+  private final double[] barYc = new double[MAX_BARS];
+  private final int[] barPhase = new int[MAX_BARS]; // 0 enter, 1 bounce, 3 crash
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barRnd = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];
+  private final int[] barBounce = new int[MAX_BARS];
+
+  private int gen = 0;          // total sets launched (drives color + edge)
+  private boolean fromTop = false;
+  private int mode = 0;         // 0 = animating in, 1 = bouncing, 2 = crashing out
+  private double holdT = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  public CrashingOut(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(this.gen * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void launchSet() {
+    this.fromTop = (this.gen & 1) == 1; // alternate bottom / top entries
+    this.mode = 0;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.barX[b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.barLen[b] = (0.14 + Math.random() * 0.30) * (0.8 + Math.random() * 0.4);
+      this.barYc[b] = 0.42 + Math.random() * 0.16;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.fromTop ? -1 : 1) * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barRnd[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    final int nBars = this.bars.getValuei();
+
+    // bars never sit still: they enter, bounce, and bounce until they crash away
+    boolean allArrived = true;
+    boolean allGone = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          allArrived = false;
+          allGone = false;
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            this.barBounce[b] = 0;
+            this.barTgt[b] = (this.fromTop ? 1 : -1) * bounceAmp(b);
+          }
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel, sustained
+          allGone = false;
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            // reverse into a fresh bounce, each with its own reach — no settling
+            ++this.barBounce[b];
+            this.barTgt[b] = -Math.signum(this.barTgt[b]) * bounceAmp(b)
+              * (0.55 + 0.45 * hashd(this.gen * 31 + b * 7 + this.barBounce[b] * 13));
+          }
+          break;
+        }
+        case 3: { // crashing out: the entry run in reverse, off the canvas
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allGone = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          // slow to break loose, accelerating as it pulls away
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1)) * (1 + wow * 0.8);
+          final double dir = this.fromTop ? -1 : 1; // back toward its entry edge
+          this.barPos[b] += dir * v * dt;
+          if (dist < GONE) {
+            allGone = false;
+          }
+          break;
+        }
+      }
+    }
+
+    if (this.mode == 0 && allArrived) { // everyone's in and bouncing
+      this.mode = 1;
+      this.holdT = 0;
+    } else if (this.mode == 1) { // bounce it out, then break for the edges
+      this.holdT += dt;
+      if (this.holdT >= BOUNCE_MS) {
+        this.mode = 2;
+        for (int b = 0; b < MAX_BARS; ++b) {
+          this.barPhase[b] = 3;
+          this.barDelay[b] = Math.random() * 500; // staggered break-loose
+        }
+      }
+    } else if (this.mode == 2 && allGone) { // next color from the opposite edge
+      ++this.gen;
+      launchSet();
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    final int col = LXColor.hsb(
+      (float) (((LXColor.h(getColor()) + HUE_STEPS[this.gen % N_COLORS]) % 360) + 360) % 360,
+      92, 100);
+    final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+
+    for (int b = 0; b < nBars; ++b) {
+      final double len = this.barLen[b];
+      double yc = this.barYc[b];
+      boolean traveling = false;
+      if (this.barPhase[b] == 0 || this.barPhase[b] == 3) {
+        if (this.barPhase[b] == 0 && this.barDelay[b] > 0) continue; // not launched
+        yc += this.barPos[b];
+        traveling = true;
+      } else if (this.barPhase[b] == 1) {
+        yc += this.barPos[b]; // bouncing
+      }
+      // solid column anchored to its entry edge, reaching to its lead end
+      final double leadF = this.fromTop
+        ? (yc + len / 2) * (h - 1)
+        : (yc - len / 2) * (h - 1);
+      if (this.fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+      final int x0 = (int) Math.round(this.barX[b] * w);
+      final int bw = (int) thickC;
+      final double span = this.fromTop
+        ? Math.max(1, leadF)
+        : Math.max(1, (h - 1) - leadF);
+
+      for (int dx = 0; dx < bw; ++dx) {
+        final int x = x0 + dx;
+        final int yStart = this.fromTop ? 0 : (int) Math.floor(leadF);
+        final int yEnd = this.fromTop ? (int) Math.ceil(leadF) : h - 1;
+        for (int yy = yStart; yy <= yEnd; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = this.fromTop ? (yy - leadF) : (leadF - yy);
+          final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+          if (cov <= 0.02) continue;
+          final double back = Math.abs(yy - leadF) / span;
+          int c = col;
+          double bb = cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+            * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + tq));
+          if (traveling && Math.abs(yy - leadF) < 1.5) {
+            c = hot;
+            bb = Math.min(1, bb * 1.5);
+          }
+          addPix(o, x, yy, c, bb);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Digits.java
+++ b/src/main/java/apotheneum/piemonte/Digits.java
@@ -1,0 +1,371 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Digits — a giant terminal readout: a handful of huge white-hot characters
+ * fill the wall nearly top to bottom, swapping as a group on the beat, over a
+ * dim churning field of small blue log-glyphs. On every swap, full-height red
+ * and blue strand flares ignite through the digits — the front/back curtain
+ * parallax — a red underline bar runs behind the readout, cyan and red debris
+ * streaks tangle at the base, and every few seconds the entire room washes
+ * hard red for a heartbeat. Modeled on the holotrigger glyph-display session.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Digits extends StrandPattern {
+
+  // 4×6 block font, hex digits 0-F: 6 rows of 4-bit masks (MSB = left column)
+  private static final int[][] FONT = {
+    {0b0110,0b1001,0b1001,0b1001,0b1001,0b0110}, // 0
+    {0b0010,0b0110,0b0010,0b0010,0b0010,0b0111}, // 1
+    {0b0110,0b1001,0b0001,0b0010,0b0100,0b1111}, // 2
+    {0b1110,0b0001,0b0110,0b0001,0b1001,0b0110}, // 3
+    {0b1001,0b1001,0b1111,0b0001,0b0001,0b0001}, // 4
+    {0b1111,0b1000,0b1110,0b0001,0b1001,0b0110}, // 5
+    {0b0110,0b1000,0b1110,0b1001,0b1001,0b0110}, // 6
+    {0b1111,0b0001,0b0010,0b0010,0b0100,0b0100}, // 7
+    {0b0110,0b1001,0b0110,0b1001,0b1001,0b0110}, // 8
+    {0b0110,0b1001,0b1001,0b0111,0b0001,0b0110}, // 9
+    {0b0110,0b1001,0b1001,0b1111,0b1001,0b1001}, // A
+    {0b1110,0b1001,0b1110,0b1001,0b1001,0b1110}, // B
+    {0b0110,0b1001,0b1000,0b1000,0b1001,0b0110}, // C
+    {0b1110,0b1001,0b1001,0b1001,0b1001,0b1110}, // D
+    {0b1111,0b1000,0b1110,0b1000,0b1000,0b1111}, // E
+    {0b1111,0b1000,0b1110,0b1000,0b1000,0b1000}, // F
+  };
+  private static final int MAX_BIG = 16;
+  private static final int MAX_BG = 200;
+  private static final int MAX_RAIN = 160;
+  private static final int MAX_FLARES = 6;
+  private static final double SWAP_MS = 420;
+  // UFOAbduction velocity signature for drifting digits: fast entry, slow-motion
+  // center stall, explosive exit off-canvas
+  private static final int MAX_DRIFT = 14;
+  private static final double DV_ENTRY = 0.00135;
+  private static final double DV_STALL = 0.00024;
+  private static final double DV_EXIT = 0.0075;
+  private static final double DSTALL_LO = 0.60;
+  private static final double DSTALL_HI = 0.44;
+  private static final double DEXIT_AT = 0.30;
+
+  public final CompoundParameter glitch =
+    new CompoundParameter("Glitch", 0.4, 0, 1)
+    .setDescription("How corrupted the readout gets");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of re-triggers");
+
+  public final heronarts.lx.parameter.DiscreteParameter drifters =
+    new heronarts.lx.parameter.DiscreteParameter("Drifters", 6, 0, MAX_DRIFT)
+    .setDescription("Digits drifting vertically with a slow-motion center stall");
+
+  private final int[] bigChars = new int[MAX_BIG];
+  private final double[] enterT = new double[MAX_BIG]; // 0..1 slide-in progress
+  private final int[] enterDir = new int[MAX_BIG];     // 0 = appear, -1 top, +1 bottom
+  private final int[] bgChars = new int[MAX_BG];
+  private int glitchSeed = 1;
+  private double retrigger = 0;
+  private double flash = 0;
+  private double floodP = 0;
+  private double floodTimer = 0;
+  // full-height strand flares ignited on swaps
+  private final int[] flareX = new int[MAX_FLARES];
+  private final boolean[] flareRed = new boolean[MAX_FLARES];
+  private double flareEnv = 0;
+
+  private final class Surface {
+    boolean inited;
+    // drifting digits riding the UFOAbduction profile
+    final double[] dy = new double[MAX_DRIFT];
+    final double[] dvf = new double[MAX_DRIFT];  // variance factor
+    final int[] dchar = new int[MAX_DRIFT];
+    final int[] dx = new int[MAX_DRIFT];
+    final boolean[] dup = new boolean[MAX_DRIFT]; // true = rising
+    final boolean[] dalive = new boolean[MAX_DRIFT];
+    final double[] rx = new double[MAX_RAIN];
+    final double[] ry = new double[MAX_RAIN];
+    final double[] rv = new double[MAX_RAIN];
+    final boolean[] rc = new boolean[MAX_RAIN]; // true = cyan, false = red
+    final boolean[] alive = new boolean[MAX_RAIN];
+    void reset() {
+      for (int i = 0; i < MAX_RAIN; ++i) this.alive[i] = false;
+      for (int i = 0; i < MAX_DRIFT; ++i) this.dalive[i] = false;
+      this.inited = true;
+    }
+    void spawnDrifter(int w) {
+      for (int i = 0; i < MAX_DRIFT; ++i) {
+        if (this.dalive[i]) continue;
+        this.dup[i] = Math.random() < 0.5;
+        this.dy[i] = this.dup[i] ? 1.05 : -0.05;
+        this.dvf[i] = 0.8 + Math.random() * 0.4;
+        this.dchar[i] = (int) (Math.random() * 16);
+        this.dx[i] = (int) (Math.random() * w);
+        this.dalive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public Digits(LX lx) {
+    // Base registers color (hue shift), speed (swap rate), size (digit scale).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("glitch", this.glitch);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("drifters", this.drifters);
+    addTargetParameter();
+    for (int i = 0; i < MAX_BIG; ++i) this.bigChars[i] = (int) (Math.random() * 16);
+    for (int i = 0; i < MAX_BG; ++i) this.bgChars[i] = (int) (Math.random() * 16);
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  /** UFOAbduction's measured profile: brisk entry, center stall, exit burst. */
+  private static double driftProfile(double y) {
+    if (y > DSTALL_LO) {
+      final double u = LXUtils.clamp((y - DSTALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(DV_STALL, DV_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > DSTALL_HI) {
+      return DV_STALL;
+    }
+    final double u = LXUtils.clamp((DSTALL_HI - y) / (DSTALL_HI - DEXIT_AT), 0, 1);
+    return LXUtils.lerp(DV_STALL, DV_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+
+    // the big readout swaps as a group (~420ms, or on beats)
+    this.retrigger += deltaMs * speed * 2 * (1 + wow * 0.6);
+    if (this.retrigger >= SWAP_MS || (this.beat && this.beatLevel > 0.35)) {
+      this.retrigger = 0;
+      for (int i = 0; i < MAX_BIG; ++i) {
+        this.bigChars[i] = (int) (Math.random() * 16);
+        // some digits just appear; others slide in from the top or bottom
+        final double r = Math.random();
+        if (r < 0.4) {
+          this.enterDir[i] = 0;
+          this.enterT[i] = 1;
+        } else {
+          this.enterDir[i] = (r < 0.7) ? -1 : 1;
+          this.enterT[i] = 0;
+        }
+      }
+      this.glitchSeed = (int) (Math.random() * 100000) + 1;
+      this.flash = 1;
+      // ignite full-height red/blue strand flares through the digits
+      this.flareEnv = 1;
+      for (int i = 0; i < MAX_FLARES; ++i) {
+        this.flareX[i] = (int) (Math.random() * 200);
+        this.flareRed[i] = (i & 1) == 0;
+      }
+    }
+    // background log field churns per-cell, fast
+    final double p = deltaMs / 140.0;
+    for (int i = 0; i < MAX_BG; ++i) {
+      if (Math.random() < p) {
+        this.bgChars[i] = (int) (Math.random() * 16);
+      }
+    }
+    // rare hard red flood, every ~4-5s
+    this.floodTimer += deltaMs;
+    if (this.floodTimer >= 4200 + hashd((int) this.timeMs) * 1200) {
+      this.floodTimer = 0;
+      this.floodP = 1;
+    }
+    for (int i = 0; i < MAX_BIG; ++i) {
+      if (this.enterT[i] < 1) {
+        this.enterT[i] = Math.min(1, this.enterT[i] + deltaMs / 350.0);
+      }
+    }
+    this.flash *= Math.exp(-deltaMs / 150.0);
+    this.floodP *= Math.exp(-deltaMs / 260.0);
+    this.flareEnv *= Math.exp(-deltaMs / 300.0);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+
+    final double wow = getWow();
+    final double gl = this.glitch.getValue() + wow * 0.5;
+    final double hueShift = LXColor.h(getColor());
+    final int blue = LXColor.hsb((float) (((225 + hueShift) % 360)), 95, 100);
+    final int white = LXColor.lerp(blue, LXColor.WHITE, 0.90f); // white-hot, faint cool edge
+    final int red = LXColor.hsb((float) (((0 + hueShift) % 360) + 360) % 360, 100, 100);
+    final int cyan = LXColor.hsb((float) (((187 + hueShift) % 360)), 90, 100);
+
+    // --- background: dim churning field of small blue log-glyphs ---
+    final int cols = w / 5;
+    final int rows = h / 7;
+    for (int cy = 0; cy < rows; ++cy) {
+      for (int cxI = 0; cxI < cols; ++cxI) {
+        final int gi = (cy * cols + cxI) % MAX_BG;
+        final int[] glyph = FONT[this.bgChars[gi]];
+        final int gx = cxI * 5;
+        final int gy = cy * 7 + 1;
+        final double gb = 0.14 + 0.08 * hashd(gi * 31 + (int) (this.timeMs / 200));
+        for (int row = 0; row < 6; ++row) {
+          final int bits = glyph[row];
+          for (int b2 = 0; b2 < 4; ++b2) {
+            if ((bits & (0b1000 >> b2)) == 0) continue;
+            addPix(o, gx + b2, gy + row, blue, gb);
+          }
+        }
+      }
+    }
+
+    // --- red underline bar behind the readout ---
+    final int barY = (int) (h * 0.62);
+    for (int x = 0; x < w; ++x) {
+      addPix(o, x, barY, red, 0.22 + this.flash * 0.3);
+    }
+
+    // --- foreground: giant white-hot characters, near-full height ---
+    // Size drives the digit scale: small readout by default, giant at full
+    final int scaleY = Math.max(1, (int) Math.round(Math.pow(2, getSize() * 2.6)));
+    final int scaleX = Math.max(1, scaleY / 3); // tall/narrow ~1:3
+    final int bigW = 4 * scaleX + scaleX;       // char cell incl gap
+    final int segW = isCube ? 50 : w;
+    final int segs = Math.max(1, w / segW);
+    final int perSeg = Math.max(1, (segW - 2) / bigW);
+    final int y0 = (h - 6 * scaleY) / 2;
+    final double bright = 0.95 + this.flash * 0.5;
+
+    for (int seg = 0; seg < segs; ++seg) {
+      final int xBase = seg * segW + (segW - perSeg * bigW) / 2;
+      for (int ci = 0; ci < perSeg; ++ci) {
+        final int gi = (seg * perSeg + ci) % MAX_BIG;
+        final int[] glyph = FONT[this.bigChars[gi]];
+        final int cx = xBase + ci * bigW;
+        // glitch: occasional dropped column or lateral jitter
+        final int jit = (hashd(this.glitchSeed + gi * 31) < gl * 0.45)
+          ? ((hashd(this.glitchSeed + gi * 77) < 0.5) ? scaleX : -scaleX) : 0;
+        final int dropCol = (hashd(this.glitchSeed + gi * 131) < gl * 0.5)
+          ? (int) (hashd(this.glitchSeed + gi * 7) * 4) : -1;
+        // slide-in entrance: eased offset from off-canvas (0 for pop-ins)
+        final double et = this.enterT[gi];
+        final double ease = et * et * (3 - 2 * et);
+        final int yOff = (int) Math.round(this.enterDir[gi] * (1.0 - ease) * h * 0.85);
+        for (int row = 0; row < 6; ++row) {
+          final int bits = glyph[row];
+          for (int b2 = 0; b2 < 4; ++b2) {
+            if ((bits & (0b1000 >> b2)) == 0 || b2 == dropCol) continue;
+            for (int sx = 0; sx < scaleX; ++sx) {
+              for (int sy = 0; sy < scaleY; ++sy) {
+                addPix(o, cx + b2 * scaleX + sx + jit, y0 + row * scaleY + sy + yOff, white, bright);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // --- full-height red/blue strand flares through the digits on each swap ---
+    if (this.flareEnv > 0.03) {
+      for (int i = 0; i < MAX_FLARES; ++i) {
+        final int fx = this.flareX[i] % w;
+        final int fc = this.flareRed[i] ? red : blue;
+        for (int y = 0; y < h; ++y) {
+          addPix(o, fx, y, fc, this.flareEnv * 0.55);
+        }
+      }
+    }
+
+    // --- drifting digits: rise or fall with the slow-motion center stall ---
+    final int nDrift = this.drifters.getValuei();
+    int aliveD = 0;
+    for (int i = 0; i < MAX_DRIFT; ++i) if (s.dalive[i]) ++aliveD;
+    if (aliveD < nDrift && Math.random() < deltaMs * 0.002) {
+      s.spawnDrifter(w);
+    }
+    final double dScaleY2 = Math.max(2, (h - 6) / 6 / 2); // half the readout scale
+    final double speedD = Math.max(0.05, getSpeed()) * 2;
+    for (int i = 0; i < MAX_DRIFT; ++i) {
+      if (!s.dalive[i]) continue;
+      // profile is defined for rising travel; mirror it for fallers
+      final double yp = s.dup[i] ? s.dy[i] : 1.0 - s.dy[i];
+      final double vh = driftProfile(yp) * s.dvf[i] * speedD;
+      s.dy[i] += s.dup[i] ? -vh * deltaMs : vh * deltaMs;
+      if (s.dy[i] < -0.12 || s.dy[i] > 1.12) { s.dalive[i] = false; continue; }
+      // slow center = brighter, whiter (the slow-motion moment reads hot)
+      final double stall = 1.0 - LXUtils.clamp(Math.abs(yp - 0.52) / 0.16, 0, 1);
+      final int[] glyph = FONT[s.dchar[i]];
+      final int gy = (int) Math.round(s.dy[i] * (h - 1)) - (int) (3 * dScaleY2);
+      final int sc = (int) dScaleY2;
+      final double db = 0.55 + 0.45 * stall;
+      final int dc = LXColor.lerp(blue, LXColor.WHITE, (float) (0.5 + 0.4 * stall));
+      for (int row = 0; row < 6; ++row) {
+        final int bits = glyph[row];
+        for (int b2 = 0; b2 < 4; ++b2) {
+          if ((bits & (0b1000 >> b2)) == 0) continue;
+          for (int sy2 = 0; sy2 < sc; ++sy2) {
+            final int yy = gy + row * sc + sy2;
+            if (yy < 0 || yy >= h) continue;
+            addPix(o, s.dx[i] + b2, yy, dc, db);
+          }
+        }
+      }
+    }
+
+    // --- cyan/red debris streaks tangled at the base ---
+    final double spawnRate = w * 0.0009 * deltaMs * (1 + this.levelEnv + wow);
+    int toSpawn = (int) spawnRate + ((Math.random() < spawnRate % 1) ? 1 : 0);
+    for (int i = 0; i < MAX_RAIN && toSpawn > 0; ++i) {
+      if (s.alive[i]) continue;
+      s.rx[i] = Math.random() * w;
+      s.ry[i] = h - 7 - Math.random() * 3;
+      s.rv[i] = 0.035 + Math.random() * 0.03;
+      s.rc[i] = Math.random() < 0.5;
+      s.alive[i] = true;
+      --toSpawn;
+    }
+    for (int i = 0; i < MAX_RAIN; ++i) {
+      if (!s.alive[i]) continue;
+      s.ry[i] += s.rv[i] * deltaMs;
+      if (s.ry[i] >= h + 3) { s.alive[i] = false; continue; }
+      comet(o, s.rx[i], s.ry[i], 3.5, s.rc[i] ? cyan : red, 0.8, false);
+    }
+
+    // --- the rare hard flood: everything pulled toward red, whites included ---
+    if (this.floodP > 0.02) {
+      final float amt = (float) (this.floodP * 0.85);
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          final int idx = o.point(x, y).index;
+          this.colors[idx] = LXColor.lerp(this.colors[idx], red, amt);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Downlink.java
+++ b/src/main/java/apotheneum/piemonte/Downlink.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Downlink — the strand curtains run a raw machine-room program: emerald
+ * matrix-rain pours down the columns while the whole room washes through slow
+ * color floods — green, then red, then amber — and sparse blocky data-glyphs
+ * flicker on and re-roll with the beat. Cyan service strips glow along the
+ * floor line. Modeled on the holotrigger green/red studio session.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Downlink extends StrandPattern {
+
+  private static final int MAX_DROPS = 400;
+  private static final int GLYPHS = 10;
+  // green <-> red flood; the downward lerp sweeps through amber mid-fade
+  private static final double[] SCENE_HUES = { 125, 4 };
+  private static final double SCENE_MS = 3200;
+  private static final double XFADE_MS = 1500;
+
+  public final CompoundParameter rain =
+    new CompoundParameter("Rain", 0.6, 0, 1)
+    .setDescription("Matrix-rain density");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of floods and glyph re-rolls");
+
+  private final class Surface {
+    boolean inited;
+    final double[] px = new double[MAX_DROPS];
+    final double[] py = new double[MAX_DROPS];
+    final double[] pv = new double[MAX_DROPS];
+    final boolean[] alive = new boolean[MAX_DROPS];
+    // glyph blocks: column-group rectangles that re-roll on beats
+    final int[] gx = new int[GLYPHS];
+    final int[] gy = new int[GLYPHS];
+    final boolean[] gon = new boolean[GLYPHS];
+    void reset(int w, int h) {
+      for (int i = 0; i < MAX_DROPS; ++i) this.alive[i] = false;
+      for (int i = 0; i < GLYPHS; ++i) rollGlyph(this, i, w, h);
+      this.inited = true;
+    }
+  }
+
+  private static void rollGlyph(Surface s, int i, int w, int h) {
+    s.gx[i] = (int) (Math.random() * w);
+    s.gy[i] = (int) (Math.random() * (h - 8)) + 1;
+    s.gon[i] = Math.random() < 0.65;
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double pulse = 0;
+  private double floodLvl = 0; // asymmetric flood envelope: snap up, breathe down
+
+  public Downlink(LX lx) {
+    // Base registers color (hue shift), speed (rain fall rate), size (glyph scale).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("rain", this.rain);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 200.0);
+    // flood breathes: ~250ms attack, ~1.1s release (reference envelope)
+    final double wow = getWow();
+    final double target = LXUtils.clamp(
+      0.04 + 0.85 * this.levelEnv * this.levelEnv * (1 + wow) + this.pulse * 0.18, 0, 0.95);
+    final double tau = (target > this.floodLvl) ? 250.0 : 1100.0;
+    this.floodLvl += (target - this.floodLvl) * (1 - Math.exp(-deltaMs / tau));
+  }
+
+  /** Current flood hue, crossfading between scene hues on a slow cycle. */
+  private double floodHue() {
+    final double t = this.timeMs / SCENE_MS;
+    final int scene = (int) Math.floor(t);
+    final double into = (t - scene) * SCENE_MS;
+    final double f = LXUtils.clamp(into / XFADE_MS, 0, 1);
+    final double a = SCENE_HUES[((scene - 1) % SCENE_HUES.length + SCENE_HUES.length) % SCENE_HUES.length];
+    final double b = SCENE_HUES[(scene % SCENE_HUES.length + SCENE_HUES.length) % SCENE_HUES.length];
+    double d = ((b - a) % 360 + 360) % 360;
+    if (d > 180) d -= 360;
+    return a + d * f;
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    final int w = o.width();
+    final int h = o.height();
+    if (!s.inited) s.reset(w, h);
+
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final double fh = floodHue() + hueShift;
+    final int scene = LXColor.hsb((float) (((fh % 360) + 360) % 360), 92, 100);
+    // the three color identities are hard-separated in the reference: green
+    // rain and red bars persist over whatever the flood is doing
+    final int rainC = LXColor.hsb((float) (((125 + hueShift) % 360) + 360) % 360, 90, 100);
+    final int glyphC = LXColor.hsb((float) (((4 + hueShift) % 360) + 360) % 360, 95, 100);
+    final int glyphHot = LXColor.hsb((float) (((32 + hueShift) % 360) + 360) % 360, 100, 100);
+
+    // global flood wash: dim ambient that surges toward full on swells
+    final double floodB = LXUtils.clamp(this.floodLvl + wow * 0.10, 0, 0.95);
+    final int floodC = LXColor.scaleBrightness(scene, (float) floodB);
+    for (int x = 0; x < w; ++x) {
+      for (int y = 0; y < h; ++y) {
+        final int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], floodC);
+      }
+    }
+
+    // matrix rain
+    final double dens = this.rain.getValue() * (0.5 + 0.5 * this.levelEnv + wow * 0.6);
+    final double spawnRate = dens * w * 0.0007 * deltaMs;
+    int toSpawn = (int) spawnRate + ((Math.random() < spawnRate % 1) ? 1 : 0);
+    for (int i = 0; i < MAX_DROPS && toSpawn > 0; ++i) {
+      if (s.alive[i]) continue;
+      s.px[i] = (int) (Math.random() * w);
+      s.py[i] = -Math.random() * 5;
+      s.pv[i] = (0.08 + Math.random() * 0.05) * speed; // full drop in ~0.7-1.1s at default
+      s.alive[i] = true;
+      --toSpawn;
+    }
+    final double tail = 16 + getSize() * 12; // reaches the longest staircases
+    for (int i = 0; i < MAX_DROPS; ++i) {
+      if (!s.alive[i]) continue;
+      s.py[i] += s.pv[i] * deltaMs;
+      if (s.py[i] >= h + tail) { s.alive[i] = false; continue; }
+      comet(o, s.px[i], s.py[i], tail, rainC, 0.95, true);
+    }
+
+    // data-bars hold position ~1.2s; only their internal dots churn fast
+    final double rollP = deltaMs / 1200.0;
+    for (int i = 0; i < GLYPHS; ++i) {
+      if (Math.random() < rollP || (this.beat && Math.random() < 0.25 + wow * 0.3)) {
+        rollGlyph(s, i, w, h);
+      }
+    }
+    final int gw = 2 + (int) (getSize() * 1.2);
+    final int gh = 8 + (int) (getSize() * 6);
+    final int tq = (int) (this.timeMs / 120);
+    for (int i = 0; i < GLYPHS; ++i) {
+      if (!s.gon[i]) continue;
+      for (int dx = 0; dx < gw; ++dx) {
+        for (int dy = 0; dy < gh; ++dy) {
+          // dot-matrix bit texture churning inside the persistent bar
+          final double bit = hashd(i * 977 + dx * 31 + dy * 7 + tq);
+          if (bit < 0.35) continue;
+          addPix(o, s.gx[i] + dx, s.gy[i] + dy,
+            (bit > 0.82) ? glyphHot : glyphC, 0.85 + this.pulse * 0.3);
+        }
+      }
+    }
+
+    // warm console ring at the floor line (red/amber segments, never cyan)
+    final int ringAmber = LXColor.hsb((float) (((34 + hueShift) % 360) + 360) % 360, 95, 100);
+    for (int x = 0; x < w; ++x) {
+      final double hh = hashd(x * 53 + (isCube ? 1 : 2));
+      if (hh < 0.45) {
+        final int c = (hashd(x * 17 + 3) < 0.5) ? glyphC : ringAmber;
+        addPix(o, x, h - 1, c, 0.45 + 0.30 * hashd(x * 7 + tq));
+        addPix(o, x, h - 2, c, 0.22);
+      }
+    }
+    // green strand-pile puddles glittering on the floor
+    for (int x = 0; x < w; ++x) {
+      if (hashd(x * 29 + (isCube ? 7 : 9)) < 0.30) {
+        final double b = 0.30 + 0.40 * hashd(x * 11 + tq) + 0.25 * this.levelEnv;
+        addPix(o, x, h - 1, rainC, b);
+        addPix(o, x, h - 2, rainC, b * 0.6);
+        addPix(o, x, h - 3, rainC, b * 0.3);
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Drip.java
+++ b/src/main/java/apotheneum/piemonte/Drip.java
@@ -54,6 +54,7 @@ public class Drip extends StrandPattern {
   private double pulse = 0;
   private double sceneClock = 0;
   private int scene = 0;
+  private int prevScene = 0; // the scene actually showing before the last change
 
   public Drip(LX lx) {
     // Base registers color (hue shift), speed (scene pace + shimmer), size (strand weight).
@@ -98,6 +99,7 @@ public class Drip extends StrandPattern {
         while (jump == this.scene) {
           jump = (int) (Math.random() * SCENES.length);
         }
+        this.prevScene = this.scene; // fade from what was actually showing
         this.scene = jump;
         return;
       } else if (this.beatLevel > 0.45 - sens * 0.15) {
@@ -106,6 +108,7 @@ public class Drip extends StrandPattern {
     }
     if (advanceScene) {
       this.sceneClock = 0;
+      this.prevScene = this.scene;
       this.scene = (this.scene + 1) % SCENES.length;
     }
   }
@@ -125,7 +128,7 @@ public class Drip extends StrandPattern {
     final double hueShift = LXColor.h(getColor());
 
     final double[] cur = SCENES[this.scene];
-    final double[] prev = SCENES[((this.scene - 1) % SCENES.length + SCENES.length) % SCENES.length];
+    final double[] prev = SCENES[this.prevScene];
     final double in = sceneIn();
     final double hue = LXUtils.lerp(prev[0], prev[0] + wrapDeg(cur[0] - prev[0]), in) + hueShift;
     final double sat = LXUtils.lerp(prev[1], cur[1], in);

--- a/src/main/java/apotheneum/piemonte/Drip.java
+++ b/src/main/java/apotheneum/piemonte/Drip.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Drip — standing strands of light hang from the rim to the floor like a
+ * beaded curtain in a cathedral dome, each one scintillating downward so the
+ * light seems to pour without ever falling. At the base every strand bends
+ * into a hook and trails outward along the floor, and a bright fountain
+ * cluster glows at the center of each wall. The room moves through scenes —
+ * green with a red heart, full green flood, blue beaded sparkle, violet dusk,
+ * a gold flood, red matrix, a pale white passage, and near-blackout lulls —
+ * some easing in, some snapping. Modeled on the holotrigger rotunda show.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Drip extends StrandPattern {
+
+  private static final int MAX_STREAMS = 40;
+  // scene legs: { perimeterHue, sat, bright, centerHue, holdMs, snap(0/1) }
+  private static final double[][] SCENES = {
+    { 120, 90, 100,   0,  6000, 0 }, // green columns, red center heart
+    { 130, 90, 100, 130,  3500, 1 }, // full green flood (snaps in)
+    { 225, 88,  95, 205,  7000, 0 }, // blue beaded sparkle, cyan center
+    { 275, 80,  80, 350,  4500, 0 }, // violet dusk, rose center
+    {  48, 95, 100,  48,  3500, 1 }, // gold flood
+    {   0, 92, 100, 225,  6000, 0 }, // red matrix, blue center
+    {   0,  0,  85,   0,  3500, 0 }, // white/lavender passage
+    {   0, 60,   8,   0,  2500, 1 }, // near-blackout lull (red embers)
+  };
+  private static final double XFADE_MS = 1200;
+  private static final double SNAP_MS = 180;
+
+  public final DiscreteParameter streams =
+    new DiscreteParameter("Streams", 16, 6, MAX_STREAMS)
+    .setDescription("Standing strands per surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of shimmer surge");
+
+  private double pulse = 0;
+  private double sceneClock = 0;
+  private int scene = 0;
+
+  public Drip(LX lx) {
+    // Base registers color (hue shift), speed (scene pace + shimmer), size (strand weight).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("streams", this.streams);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 220.0);
+    final double speed = Math.max(0.05, getSpeed());
+    this.sceneClock += deltaMs * speed * 2 * (1 + getWow() * 0.5);
+    final double[] cur = SCENES[this.scene];
+    final double sens = this.sensitivity.getValue();
+
+    // the music drives the style: solid hits advance the scene early, and a
+    // hard drop jumps the journey to a random scene — after a minimum dwell
+    // so the room never thrashes
+    boolean advanceScene = this.sceneClock >= cur[4];
+    if (this.beat && this.sceneClock > 1200) {
+      if (this.beatLevel > 0.80 - sens * 0.2) {
+        // drop: leap somewhere unexpected in the journey
+        this.sceneClock = 0;
+        int jump = this.scene;
+        while (jump == this.scene) {
+          jump = (int) (Math.random() * SCENES.length);
+        }
+        this.scene = jump;
+        return;
+      } else if (this.beatLevel > 0.45 - sens * 0.15) {
+        advanceScene = true; // solid hit: move the journey along now
+      }
+    }
+    if (advanceScene) {
+      this.sceneClock = 0;
+      this.scene = (this.scene + 1) % SCENES.length;
+    }
+  }
+
+  /** Eased 0..1 entry progress into the current scene (fast when it snaps). */
+  private double sceneIn() {
+    final double dur = (SCENES[this.scene][5] > 0.5) ? SNAP_MS : XFADE_MS;
+    final double f = LXUtils.clamp(this.sceneClock / dur, 0, 1);
+    return f * f * (3 - 2 * f);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double hueShift = LXColor.h(getColor());
+
+    final double[] cur = SCENES[this.scene];
+    final double[] prev = SCENES[((this.scene - 1) % SCENES.length + SCENES.length) % SCENES.length];
+    final double in = sceneIn();
+    final double hue = LXUtils.lerp(prev[0], prev[0] + wrapDeg(cur[0] - prev[0]), in) + hueShift;
+    final double sat = LXUtils.lerp(prev[1], cur[1], in);
+    final double sceneBright = LXUtils.lerp(prev[2], cur[2], in) / 100.0;
+    final double cHue = LXUtils.lerp(prev[3], prev[3] + wrapDeg(cur[3] - prev[3]), in) + hueShift;
+    final int colPerim = LXColor.hsb((float) (((hue % 360) + 360) % 360), (float) sat, 100);
+    final int colCenter = LXColor.hsb((float) (((cHue % 360) + 360) % 360),
+      (float) Math.max(sat, 60), 100);
+
+    // strand population scales with scene brightness: floods fill the wall,
+    // blackout lulls collapse to a few dim embers
+    final int count = Math.max(2, (int) Math.round(
+      Math.min(MAX_STREAMS, this.streams.getValuei() + wow * 8) * (0.25 + 0.75 * sceneBright)));
+    final boolean glyphScene = (this.scene == 5 || this.scene == 0); // matrix-textured legs
+    final double shimSurge = 1.0 + this.levelEnv * this.sensitivity.getValue() + this.pulse * 0.4;
+    final int floorY = h - 6;
+
+    for (int i = 0; i < count; ++i) {
+      // fixed even spacing with per-strand jitter: a standing curtain
+      final int cx = (int) ((i + 0.5) * w / count + (hashd(i * 31 + 7) - 0.5) * 3);
+      // center/perimeter bicolor split: strands near each wall's center take the accent
+      final double centerDist = Math.abs(((cx % w) + w) % w % (isCube ? 50 : w)
+        - (isCube ? 25 : w / 2)) / (double) (isCube ? 25 : w / 2);
+      final int col = (centerDist < 0.25) ? colCenter : colPerim;
+
+      for (int y = 0; y <= floorY; ++y) {
+        double b;
+        if (glyphScene) {
+          // blocky code-rain segments descending
+          final int seg = (int) Math.floor((y - this.timeMs * 0.010) / 3.0);
+          b = (hashd(cx * 131 + seg * 977) > 0.45) ? 0.85 : 0.08;
+        } else {
+          // beaded scintillation scrolling down a stationary strand
+          final double spark = hashd(cx * 262147 + (int) Math.floor(y - this.timeMs * 0.012) * 8191);
+          b = (spark > 0.55) ? 0.55 + 0.45 * spark : 0.12;
+        }
+        b *= sceneBright * shimSurge * (0.75 + 0.25 * drip(y, h)) * (0.7 + 0.3 * getSize());
+        addPix(o, cx, y, col, b);
+      }
+
+      // persistent floor hook curling outward
+      final int dir = (hashd(i * 53 + 11) < 0.5) ? -1 : 1;
+      for (int k = 1; k <= 6; ++k) {
+        final double wig = Math.sin(this.timeMs * 0.002 + i * 1.7) * 1.0;
+        final int yy = Math.min(h - 1, floorY + (int) Math.round(k * 0.4 + wig * (k / 6.0)));
+        addPix(o, cx + dir * k, yy, col, sceneBright * (1.0 - k / 8.0) * 0.8);
+      }
+    }
+
+    // fountain cluster glowing at the center of each wall
+    final int nWalls = isCube ? 4 : 1;
+    final int wallW = w / nWalls;
+    for (int wi = 0; wi < nWalls; ++wi) {
+      final int cx0 = wi * wallW + wallW / 2;
+      for (int dx = -3; dx <= 3; ++dx) {
+        for (int y = floorY; y < h; ++y) {
+          final double g = Math.exp(-dx * dx / 4.0) * (0.55 + this.pulse * 0.3);
+          addPix(o, cx0 + dx, y, colCenter, g * sceneBright);
+        }
+      }
+    }
+
+    // waterline scrim: only in the blue scenes, at ~43% height
+    if (this.scene == 2) {
+      final int scrimY = (int) (h * 0.43);
+      final int scrim = LXColor.hsb((float) (((215 + hueShift) % 360)), 80, 100);
+      for (int x = 0; x < w; ++x) {
+        addPix(o, x, scrimY, scrim, 0.22 * in);
+        addPix(o, x, scrimY + 1, scrim, 0.10 * in);
+      }
+    }
+  }
+
+  private static double wrapDeg(double d) {
+    d = ((d % 360) + 360) % 360;
+    return (d > 180) ? d - 360 : d;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/FeelSomething.java
+++ b/src/main/java/apotheneum/piemonte/FeelSomething.java
@@ -19,17 +19,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class FeelSomething extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_STICKS = 64;
   private static final int MAX_SPARKS = 1500;
@@ -46,10 +39,6 @@ public class FeelSomething extends ParameterPattern {
   public final CompoundParameter sparkle =
     new CompoundParameter("Sparkle", 0.5, 0, 1)
     .setDescription("How many sparkles fly off on each bounce");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     int w, h;
@@ -126,7 +115,7 @@ public class FeelSomething extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("sticks", this.sticks);
     addParameter("sparkle", this.sparkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -134,7 +123,7 @@ public class FeelSomething extends ParameterPattern {
     setColors(LXColor.BLACK);
     final double baseHue = LXColor.h(getColor());
     final double dtS = Math.max(0.02, getSpeed()) * deltaMs; // time step
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, dtS, baseHue);
     }

--- a/src/main/java/apotheneum/piemonte/FeelSomething.java
+++ b/src/main/java/apotheneum/piemonte/FeelSomething.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * FeelSomething — colored sticks rain down the surface, and when they strike the
+ * floor they bounce back up, tumbling end over end and throwing off a burst of
+ * bright sparkles. Each bounce loses a little energy until the stick settles and
+ * a fresh one drops from the top.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class FeelSomething extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_STICKS = 64;
+  private static final int MAX_SPARKS = 1500;
+  private static final double GRAV = 0.00010;      // cells / ms^2 (time-scaled by speed)
+  private static final double SPARK_G = 0.00006;
+  private static final double RESTITUTION = 0.68;  // bounce energy kept
+  private static final double MIN_IMPACT = 0.010;  // below this a stick settles + relaunches
+  private static final double HUE_SPREAD = 90;     // per-stick hue variety (degrees)
+
+  public final DiscreteParameter sticks =
+    new DiscreteParameter("Sticks", 24, 4, MAX_STICKS)
+    .setDescription("How many sticks are falling at once");
+
+  public final CompoundParameter sparkle =
+    new CompoundParameter("Sparkle", 0.5, 0, 1)
+    .setDescription("How many sparkles fly off on each bounce");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    // sticks
+    final double[] kx = new double[MAX_STICKS];
+    final double[] ky = new double[MAX_STICKS];
+    final double[] kvy = new double[MAX_STICKS];
+    final double[] klf = new double[MAX_STICKS];   // per-stick length factor
+    final double[] kang = new double[MAX_STICKS];
+    final double[] kav = new double[MAX_STICKS];    // angular velocity
+    final double[] khue = new double[MAX_STICKS];   // 0..1 hue offset
+    final boolean[] kbounced = new boolean[MAX_STICKS];
+    // sparks
+    final double[] spx = new double[MAX_SPARKS];
+    final double[] spy = new double[MAX_SPARKS];
+    final double[] spvx = new double[MAX_SPARKS];
+    final double[] spvy = new double[MAX_SPARKS];
+    final double[] splife = new double[MAX_SPARKS];
+    final double[] spmax = new double[MAX_SPARKS];
+    final boolean[] spAlive = new boolean[MAX_SPARKS];
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      for (int i = 0; i < MAX_STICKS; ++i) {
+        launch(i, true);
+      }
+      for (int i = 0; i < MAX_SPARKS; ++i) {
+        this.spAlive[i] = false;
+      }
+    }
+
+    void launch(int i, boolean scatter) {
+      this.kx[i] = Math.random() * this.w;
+      this.ky[i] = scatter ? Math.random() * this.h * 0.6 : -(Math.random() * this.h * 0.4) - 4;
+      this.kvy[i] = 0;
+      this.klf[i] = 0.7 + Math.random() * 0.6;
+      this.kang[i] = 0;
+      this.kav[i] = (Math.random() - 0.5) * 0.006; // gentle pre-bounce tumble
+      this.khue[i] = Math.random();
+      this.kbounced[i] = false;
+    }
+
+    /** Emit sparks from (x,y) flung outward along (ox,oy) — used for the stick's ends. */
+    void sparkFrom(double x, double y, double ox, double oy, int count) {
+      for (int c = 0; c < count; ++c) {
+        int idx = -1;
+        for (int k = 0; k < MAX_SPARKS; ++k) {
+          if (!this.spAlive[k]) { idx = k; break; }
+        }
+        if (idx < 0) return;
+        this.spx[idx] = x;
+        this.spy[idx] = y;
+        double eject = 0.02 + Math.random() * 0.045;
+        this.spvx[idx] = ox * eject + (Math.random() - 0.5) * 0.03;
+        this.spvy[idx] = oy * eject - (0.006 + Math.random() * 0.02); // slight upward arc
+        this.spmax[idx] = 300 + Math.random() * 520;
+        this.splife[idx] = this.spmax[idx];
+        this.spAlive[idx] = true;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public FeelSomething(LX lx) {
+    // Base registers color (base hue), speed (time scale), size (stick length).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("sticks", this.sticks);
+    addParameter("sparkle", this.sparkle);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final double baseHue = LXColor.h(getColor());
+    final double dtS = Math.max(0.02, getSpeed()) * deltaMs; // time step
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, dtS, baseHue);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, dtS, baseHue);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double dtS, double baseHue) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final int count = this.sticks.getValuei();
+    final double len = 3 + getSize() * 10;
+    final double bottom = h - 1;
+    final double wow = getWow();
+    // Wow turns each bounce into a burst storm: more sparks, more shedding.
+    final double sparkAmt = this.sparkle.getValue();
+
+    // --- sticks ---
+    for (int i = 0; i < count; ++i) {
+      s.kvy[i] += GRAV * dtS;
+      s.ky[i] += s.kvy[i] * dtS;
+      s.kang[i] += s.kav[i] * dtS;
+      boolean justBounced = false;
+      double impact = 0;
+      if (s.ky[i] >= bottom) {
+        s.ky[i] = bottom;
+        impact = Math.abs(s.kvy[i]);
+        if (impact < MIN_IMPACT && s.kbounced[i]) {
+          s.launch(i, false); // settled -> drop a fresh one
+        } else {
+          s.kvy[i] = -impact * RESTITUTION;   // bounce up
+          s.kbounced[i] = true;
+          s.kav[i] = (Math.random() - 0.5) * 0.03; // tumble
+          justBounced = true;
+        }
+      }
+
+      final double dirx = Math.sin(s.kang[i]);
+      final double diry = Math.cos(s.kang[i]);
+      final double half = 0.5 * len * s.klf[i];
+      final double ax = s.kx[i] - dirx * half, ay = s.ky[i] - diry * half;
+      final double bx = s.kx[i] + dirx * half, by = s.ky[i] + diry * half;
+
+      // sparkles fly out of the stick's two ends
+      if (justBounced) {
+        int n = LXUtils.constrain(
+          (int) (impact * 1000 * (0.35 + sparkAmt) * (1.0 + wow * 4.0)), 2, (int) (32 + wow * 70));
+        s.sparkFrom(ax, ay, -dirx, -diry, n);
+        s.sparkFrom(bx, by, dirx, diry, n);
+      } else if (s.kbounced[i]) {
+        double rate = 0.20 + sparkAmt * 1.0 + wow * 0.6; // keep shedding off the ends while tumbling
+        int shed = 1 + (int) (wow * 3);
+        if (Math.random() < rate) s.sparkFrom(ax, ay, -dirx, -diry, shed);
+        if (Math.random() < rate) s.sparkFrom(bx, by, dirx, diry, shed);
+      }
+
+      // draw the stick between its two ends, with white-hot tips
+      final int col = LXColor.hsb(
+        (float) (((baseHue + (s.khue[i] - 0.5) * HUE_SPREAD) % 360 + 360) % 360), 90, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.5f);
+      final int steps = (int) Math.ceil(len);
+      for (int k = 0; k <= steps; ++k) {
+        double f = (steps == 0) ? 0 : (double) k / steps;
+        int col2 = (f < 0.15 || f > 0.85) ? hot : col;
+        final double px = ax + (bx - ax) * f;
+        final double py = ay + (by - ay) * f;
+        splat(o, w, h, px, py, 2.3, 0.35, col);   // soft aura around the rod
+        splat(o, w, h, px, py, 1.4, 1.0, col2);   // bold core
+      }
+    }
+
+    // --- sparkles: born white-hot, cooling toward the base hue as they fade ---
+    final int ember = LXColor.hsb((float) baseHue, 90, 100);
+    for (int i = 0; i < MAX_SPARKS; ++i) {
+      if (!s.spAlive[i]) continue;
+      s.splife[i] -= dtS;
+      if (s.splife[i] <= 0) { s.spAlive[i] = false; continue; }
+      s.spvy[i] += SPARK_G * dtS;
+      s.spx[i] += s.spvx[i] * dtS;
+      s.spy[i] += s.spvy[i] * dtS;
+      if (s.spy[i] >= bottom && s.spvy[i] > 0) { s.spAlive[i] = false; continue; }
+      double fade = s.splife[i] / s.spmax[i];
+      double twinkle = 0.55 + 0.45 * Math.random(); // shimmer
+      int sc = LXColor.lerp(ember, LXColor.WHITE, (float) fade);
+      splat(o, w, h, s.spx[i], s.spy[i], 1.05, Math.pow(fade, 1.5) * (0.55 + 0.65 * twinkle), sc);
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Ghosted.java
+++ b/src/main/java/apotheneum/piemonte/Ghosted.java
@@ -135,7 +135,9 @@ public class Ghosted extends StrandPattern {
       // groups of consecutive lines share a color: the sweep fires red packs
       // and blue packs as it circles
       final int chunk = (int) (((this.sweep % 1.0) + 1.0) % 1.0 * 8);
-      final int grp = (hashd(chunk * 53 + (int) this.laps * 97) < 0.5) ? 0 : 1;
+      // red<->blue balance drifts on the hue cycle instead of a fixed 50/50
+      final double cyc = 0.5 + 0.5 * Math.sin(2 * Math.PI * this.timeMs / HUE_CYCLE_MS);
+      final int grp = (hashd(chunk * 53 + (int) this.laps * 97) < 0.25 + 0.5 * cyc) ? 0 : 1;
       final double az = ((this.sweep + jitter) % 1.0 + 1.0) % 1.0;
       this.cube.fire(az, grp);
       this.cylinder.fire(az, grp);
@@ -153,9 +155,7 @@ public class Ghosted extends StrandPattern {
     final double hueShift = LXColor.h(getColor());
     final double env = swellEnv();
 
-    // the color field: hot floor core -> white shockwave band -> azure sky,
-    // with the red<->blue balance cycling slowly
-    final double cyc = 0.5 + 0.5 * Math.sin(2 * Math.PI * this.timeMs / HUE_CYCLE_MS);
+    // the color field: hot floor core -> white shockwave band -> azure sky
     final int red = LXColor.hsb((float) (((8 + hueShift) % 360)), 100, 100);
     final int blue = LXColor.hsb((float) (((214 + hueShift) % 360)), 96, 100);
     final int tq = (int) (this.timeMs / 60);

--- a/src/main/java/apotheneum/piemonte/Ghosted.java
+++ b/src/main/java/apotheneum/piemonte/Ghosted.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Ghosted — a starburst floor unrolled onto the walls. Thin dotted comet
+ * lines fire fast from the floor to the sky, launching in a radar sweep that
+ * marches clockwise around the structure — a new line every tenth of a
+ * second, a full lap every few seconds. Each comet accelerates as it climbs,
+ * dragging a dotted tail through the color field: hot red-orange at the
+ * floor, a white shockwave band mid-height, azure up top, the whole balance
+ * slowly cycling red-blue. The field breathes in swells — build, climax,
+ * near-blackout, re-burst. Bipolar Speed reverses the sweep; Wow deepens the
+ * swells and packs the sky. Modeled frame-by-frame on the wave.mp4 floor
+ * piece.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Ghosted extends StrandPattern {
+
+  private static final int MAX_COMETS = 80;
+  // measured: climax heads cross the field in 0.4-0.6s, dim phase ~0.7 heights/s
+  private static final double V_CLIMAX = 0.0033;  // heights per ms
+  private static final double V_DIM = 0.0013;
+  private static final double LAP_MS = 2300;      // sweep lap
+  private static final double SWELL_MS = 5000;    // build->climax->blackout cycle
+  private static final double HUE_CYCLE_MS = 11500;
+  private static final double DOT_PITCH = 2.6;    // dotted-body spacing
+
+  public final DiscreteParameter lines =
+    new DiscreteParameter("Lines", 36, 12, 60)
+    .setDescription("Comet lines fired per sweep lap");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How much the music drives the swells");
+
+  private final class Surface {
+    boolean inited;
+    final double[] x = new double[MAX_COMETS];
+    final double[] y = new double[MAX_COMETS];   // normalized, 1 = floor, 0 = top
+    final double[] vf = new double[MAX_COMETS];
+    final int[] grp = new int[MAX_COMETS]; // 0 = red group, 1 = blue group
+    final boolean[] alive = new boolean[MAX_COMETS];
+    void reset() {
+      for (int i = 0; i < MAX_COMETS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void fire(double x01, int grp) {
+      for (int i = 0; i < MAX_COMETS; ++i) {
+        if (this.alive[i]) continue;
+        this.grp[i] = grp;
+        this.x[i] = x01;
+        this.y[i] = 1.04 + Math.random() * 0.05;
+        this.vf[i] = 0.8 + Math.random() * 0.4;
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double sweep = 0;     // 0..1 azimuth of the radar sweep
+  private double laps = 0;      // unwrapped lap counter (for group hashing)
+  private double spawnAcc = 0;
+  private double swellT = 0;
+
+  public Ghosted(LX lx) {
+    // Base registers color (hue shift), bipolar speed (climb rate + sweep
+    // direction), size (tail length), wow (swell pressure + density).
+    super(lx, 0.5, -1, 1, 0.5, 0, 1);
+    addParameter("lines", this.lines);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Swell envelope: build -> climax -> collapse -> near-black -> re-burst. */
+  private double swellEnv() {
+    final double p = (this.swellT % SWELL_MS) / SWELL_MS;
+    if (p < 0.50) {
+      final double u = p / 0.50;
+      return 0.25 + 0.75 * u * u; // build
+    } else if (p < 0.80) {
+      return 1.0; // climax hold
+    } else if (p < 0.90) {
+      return 1.0 - (p - 0.80) / 0.10 * 0.95; // collapse
+    }
+    return 0.16; // lull: dim but never dead — scattered life persists
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = getSpeed();
+    final double mag = Math.max(0.05, Math.abs(speed));
+    final double wow = getWow();
+    // music pushes the swell clock so climaxes land with the energy
+    final double push = 1.0 + this.levelEnv * this.sensitivity.getValue() * 1.5
+      + (this.beat ? this.beatLevel * 0.6 : 0);
+    this.swellT += deltaMs * mag * 2 * push * (1 + wow * 0.4);
+
+    // radar sweep marches around the structure; sign of Speed sets direction
+    final double lap = LAP_MS / (mag * 2) / (1 + wow * 0.5);
+    this.sweep += (speed >= 0 ? 1 : -1) * deltaMs / lap;
+    this.sweep -= Math.floor(this.sweep);
+    this.laps += deltaMs / lap;
+
+    // sequential firing at the sweep azimuth (~lap / lines interval)
+    final int nLines = Math.min(MAX_COMETS,
+      this.lines.getValuei() + (int) Math.round(wow * 16));
+    final double env = swellEnv();
+    this.spawnAcc += deltaMs * nLines / lap * (0.45 + 0.55 * env);
+    while (this.spawnAcc >= 1) {
+      this.spawnAcc -= 1;
+      final double jitter = (Math.random() - 0.5) * 0.02;
+      // groups of consecutive lines share a color: the sweep fires red packs
+      // and blue packs as it circles
+      final int chunk = (int) (((this.sweep % 1.0) + 1.0) % 1.0 * 8);
+      final int grp = (hashd(chunk * 53 + (int) this.laps * 97) < 0.5) ? 0 : 1;
+      final double az = ((this.sweep + jitter) % 1.0 + 1.0) % 1.0;
+      this.cube.fire(az, grp);
+      this.cylinder.fire(az, grp);
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double mag = Math.max(0.05, Math.abs(getSpeed()));
+    final double wow = getWow();
+    final double hueShift = LXColor.h(getColor());
+    final double env = swellEnv();
+
+    // the color field: hot floor core -> white shockwave band -> azure sky,
+    // with the red<->blue balance cycling slowly
+    final double cyc = 0.5 + 0.5 * Math.sin(2 * Math.PI * this.timeMs / HUE_CYCLE_MS);
+    final int red = LXColor.hsb((float) (((8 + hueShift) % 360)), 100, 100);
+    final int blue = LXColor.hsb((float) (((214 + hueShift) % 360)), 96, 100);
+    final int tq = (int) (this.timeMs / 60);
+
+    // climb speed rides the swell: dim crawl in lulls, racing at climax
+    final double vClimb = LXUtils.lerp(V_DIM, V_CLIMAX, env) * mag * 2;
+    final double tailN = (0.42 + getSize() * 0.55) * (1 + wow * 0.3); // taller lines
+    final double envB = 0.30 + 0.70 * env;
+
+    for (int i = 0; i < MAX_COMETS; ++i) {
+      if (!s.alive[i]) continue;
+      // outward acceleration: slow near the floor, fast approaching the top
+      final double accel = 0.45 + 1.1 * (1.0 - s.y[i]);
+      s.y[i] -= s.vf[i] * vClimb * accel * deltaMs;
+      if (s.y[i] <= -0.12) { s.alive[i] = false; continue; }
+
+      final int x = (int) Math.round(s.x[i] * w);
+      final double headF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final int headY = (int) Math.round(headF);
+      final int tailLen = (int) (tailN * h);
+
+      for (int k = 0; k <= tailLen; ++k) {
+        final int yy = headY + k; // tail trails below, toward the floor
+        if (yy < 0 || yy >= h) continue;
+        // dotted body: dash every DOT_PITCH cells (the head is always lit)
+        if (k > 1) {
+          final double dphase = (k + tq * 0.35) % DOT_PITCH;
+          if (dphase > DOT_PITCH * 0.55) continue;
+        }
+        final double fall = (k == 0) ? 1.0 : Math.exp(-1.6 * k / Math.max(1, tailLen));
+        if (fall < 0.02) break;
+        // comet body carries its group color (red packs, blue packs), with the
+        // white shockwave band still glowing through mid-height
+        final double yn = (double) yy / (h - 1);
+        final int grpC = (s.grp[i] == 0) ? red : blue;
+        int c;
+        if (k == 0) {
+          c = LXColor.WHITE; // white-hot head
+        } else if (yn > 0.40 && yn < 0.55) {
+          final double m = 1.0 - Math.abs(yn - 0.475) / 0.075;
+          c = LXColor.lerp(grpC, LXColor.WHITE, (float) (m * 0.3));
+        } else {
+          c = grpC;
+        }
+        final double bb = fall * envB * (0.75 + 0.25 * hashd(i * 977 + yy * 131 + tq));
+        addPix(o, x, yy, c, bb);
+        addPix(o, x + 1, yy, c, bb * 0.55); // thicker: two-column body
+      }
+    }
+
+    // --- always alive: concentric dotted rings hugging the floor (the
+    // reference's center rings) and scattered twinkle dots through the lulls ---
+    final int ringC = LXColor.lerp(red, LXColor.WHITE, 0.35f);
+    for (int r2 = 0; r2 < 3; ++r2) {
+      final int ry = h - 2 - r2 * 2;
+      if (ry < 0) continue;
+      final double ringB = (0.20 + 0.30 * env) * (1.0 - r2 * 0.22);
+      final double ringSpin = this.timeMs * 0.004 * (1 + r2 * 0.5);
+      for (int x2 = 0; x2 < w; x2 += 3) {
+        final double dp = ((x2 + ringSpin) % 3.0) / 3.0;
+        if (dp > 0.6) continue;
+        addPix(o, x2, ry, ringC, ringB * (0.6 + 0.4 * hashd(x2 * 31 + r2 * 97 + tq)));
+      }
+    }
+    // white shockwave ring at mid-height, swelling with the climax
+    final int shockY = (int) (h * 0.475);
+    final double shockB = 0.06 + 0.24 * env;
+    for (int x2 = 0; x2 < w; x2 += 2) {
+      addPix(o, x2, shockY, LXColor.WHITE, shockB * (0.5 + 0.5 * hashd(x2 * 53 + tq * 3)));
+    }
+    // lull scatter: random dim dots keep the canvas breathing when the swell dips
+    if (env < 0.5) {
+      final int nScatter = (int) (w * h * 0.006 * (1.0 - env));
+      for (int k2 = 0; k2 < nScatter; ++k2) {
+        final int sx3 = (int) (hashd(k2 * 31 + tq * 977) * w);
+        final int sy3 = (int) (hashd(k2 * 53 + tq * 613) * h);
+        final double tw3 = hashd(k2 * 97 + tq * 131);
+        if (tw3 < 0.5) continue;
+        addPix(o, sx3, sy3, (tw3 > 0.9) ? LXColor.WHITE : blue, 0.2 + 0.5 * tw3);
+      }
+    }
+
+    // --- Wow: a blue gradient rises from the floor, radiating upward ---
+    if (wow > 0.05) {
+      final int gradBlue = LXColor.hsb((float) (((215 + hueShift) % 360)), 88, 100);
+      final double gradH = h * (0.25 + 0.5 * wow);
+      for (int y = h - 1; y >= h - (int) gradH && y >= 0; --y) {
+        final double t = (h - 1 - y) / gradH;
+        // upward-radiating pulse waves ride the gradient
+        final double wave = 0.7 + 0.3 * Math.sin(2 * Math.PI * (t * 2.5 - this.timeMs * 0.0007));
+        final double gb = wow * 0.45 * Math.pow(1.0 - t, 1.5) * wave;
+        if (gb < 0.01) break;
+        for (int x = 0; x < w; ++x) {
+          addPix(o, x, y, gradBlue, gb);
+        }
+      }
+
+      // --- white dotted stars stream from top and bottom, crossing mid-air ---
+      final int nStars = (int) (wow * 22);
+      final double starV = 0.00045 * this.timeMs;
+      for (int i2 = 0; i2 < nStars; ++i2) {
+        final int sx = (int) (hashd(i2 * 31 + 7) * w);
+        final double sp = 0.6 + 0.8 * hashd(i2 * 61 + 3);
+        // falling star
+        final double yd = ((hashd(i2 * 97 + 11) + starV * sp) % 1.0) * h;
+        addPix(o, sx, (int) yd, LXColor.WHITE, 0.55 + 0.35 * hashd(i2 + tq));
+        // rising star, offset column so the streams visibly cross
+        final int sx2 = (int) (hashd(i2 * 43 + 17) * w);
+        final double yu = (1.0 - ((hashd(i2 * 53 + 29) + starV * sp) % 1.0)) * h;
+        addPix(o, sx2, (int) yu, LXColor.WHITE, 0.55 + 0.35 * hashd(i2 * 7 + tq));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/LockedIn.java
+++ b/src/main/java/apotheneum/piemonte/LockedIn.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * LockedIn — sets of thick bars lock into the center of the canvas, one color
+ * at a time. Each bar is a solid column anchored to its entry edge, growing
+ * toward the middle with the UFOAbduction feel — fast travel, decelerating on
+ * approach — then bouncing on the same velocity model, each bar on its own
+ * clock and reach, before freezing in place. Sets alternate bottom and top
+ * entries, each at a new horizontal offset, cycling through five colors and
+ * layering endlessly: the stack never fades — new sets keep locking in over
+ * the old, and only when a color comes back around does its previous layer
+ * yield to the fresh one rising from the edge. Beats punch the bounces; Wow
+ * adds bounce reach and shimmer.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class LockedIn extends StrandPattern {
+
+  private static final int N_COLORS = 5;    // hues cycled across sets
+  private static final int MAX_LAYERS = 10; // frozen sets kept on the canvas
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_DECAY = 0.78; // per-bounce settle
+  private static final double RELAUNCH_MS = 450;   // breath between sets
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // layered set state (normalized; shared across surfaces)
+  private final double[][] layX = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layLen = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layYc = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] lenVar = new double[MAX_LAYERS][MAX_BARS];
+  private final int[] layerHue = new int[MAX_LAYERS];
+  private final boolean[] layerFromTop = new boolean[MAX_LAYERS];
+  private final boolean[] layerLive = new boolean[MAX_LAYERS];
+
+  private int gen = 0;           // total sets launched
+  private int activeLayer = -1;  // layer currently animating, -1 = between sets
+  private double pauseMs = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  // per-bar independent motion within the active set
+  private final int[] barPhase = new int[MAX_BARS];  // 0 enter, 1 bounce, 2 frozen
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barBopPh = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];   // current bounce target
+  private final int[] barBounce = new int[MAX_BARS];      // reversals remaining
+
+  public LockedIn(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int l, int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(l * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Launch the next set: claim a layer (recycling the oldest) and arm bars. */
+  private void launchSet() {
+    final int l = this.gen % MAX_LAYERS;
+    this.activeLayer = l;
+    this.layerHue[l] = this.gen % N_COLORS;
+    this.layerFromTop[l] = (this.gen & 1) == 1; // alternate bottom / top
+    this.layerLive[l] = true;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.layX[l][b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.layLen[l][b] = 0.14 + Math.random() * 0.30; // varied reach
+      this.layYc[l][b] = 0.42 + Math.random() * 0.16;  // tips around center
+      this.lenVar[l][b] = 0.8 + Math.random() * 0.4;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.layerFromTop[l] ? -1 : 1)
+        * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barBopPh[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    if (this.activeLayer < 0) { // between sets: breathe, then launch the next
+      this.pauseMs -= dt;
+      if (this.pauseMs <= 0) {
+        launchSet();
+      }
+      return;
+    }
+
+    final int l = this.activeLayer;
+    final int nBars = this.bars.getValuei();
+    boolean allFrozen = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allFrozen = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            // momentum carries into the first bounce, past the rest point
+            this.barBounce[b] = 3 + (int) (this.barBopPh[b] * 3);
+            this.barTgt[b] = (this.layerFromTop[l] ? 1 : -1) * bounceAmp(l, b);
+          }
+          allFrozen = false;
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            if (--this.barBounce[b] <= 0) {
+              // ease home and freeze
+              if (Math.abs(this.barPos[b]) < 0.008) {
+                this.barPos[b] = 0;
+                this.barPhase[b] = 2;
+              } else {
+                this.barTgt[b] = 0;
+                this.barBounce[b] = 1;
+              }
+            } else {
+              // reverse, each bounce a little smaller
+              this.barTgt[b] = -Math.signum(this.barTgt[b])
+                * bounceAmp(l, b)
+                * Math.pow(BOUNCE_DECAY, 6 - this.barBounce[b]);
+            }
+          }
+          allFrozen = false;
+          break;
+        }
+      }
+    }
+    if (allFrozen) { // set locked; the stack stays — queue the next set
+      ++this.gen;
+      this.activeLayer = -1;
+      this.pauseMs = RELAUNCH_MS;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double hueShift = LXColor.h(getColor());
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int l = 0; l < MAX_LAYERS; ++l) {
+      if (!this.layerLive[l]) continue;
+      final boolean active = (l == this.activeLayer);
+      final boolean fromTop = this.layerFromTop[l];
+      final int col = LXColor.hsb(
+        (float) (((hueShift + HUE_STEPS[this.layerHue[l]]) % 360) + 360) % 360, 92, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+      final double genB = active ? 1.0 : 0.82;
+
+      for (int b = 0; b < nBars; ++b) {
+        final double xN = this.layX[l][b];
+        final double len = this.layLen[l][b] * this.lenVar[l][b];
+        double yc = this.layYc[l][b];
+        boolean entering = false;
+        if (active) {
+          if (this.barPhase[b] == 0) {
+            if (this.barDelay[b] > 0) continue; // not launched yet
+            yc += this.barPos[b]; // still traveling in
+            entering = true;
+          } else if (this.barPhase[b] == 1) {
+            yc += this.barPos[b]; // bouncing on the entry velocity model
+          }
+        }
+        // solid column anchored to its entry edge, reaching to its lead end:
+        // bottom-entering bars fill floor-to-lead, top-entering sky-to-lead
+        final double leadF = fromTop
+          ? (yc + len / 2) * (h - 1)   // lead end grows downward from the sky
+          : (yc - len / 2) * (h - 1);  // lead end grows upward from the floor
+        if (fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+        final int x0 = (int) Math.round(xN * w);
+        final int bw = (int) thickC;
+        final double span = fromTop
+          ? Math.max(1, leadF)
+          : Math.max(1, (h - 1) - leadF);
+
+        for (int dx = 0; dx < bw; ++dx) {
+          final int x = x0 + dx;
+          final int yStart = fromTop ? 0 : (int) Math.floor(leadF);
+          final int yEnd = fromTop ? (int) Math.ceil(leadF) : h - 1;
+          for (int yy = yStart; yy <= yEnd; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final double dOut = fromTop ? (yy - leadF) : (leadF - yy);
+            final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+            if (cov <= 0.02) continue;
+            // brightest at the lead end, easing back toward the anchor edge
+            final double back = Math.abs(yy - leadF) / span;
+            int c = col;
+            double bb = genB * cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+              * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + (active ? tq : 0)));
+            if (entering && Math.abs(yy - leadF) < 1.5) {
+              c = hot;
+              bb = Math.min(1, bb * 1.5);
+            }
+            addPix(o, x, yy, c, bb);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Origami.java
+++ b/src/main/java/apotheneum/piemonte/Origami.java
@@ -22,17 +22,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Origami extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double HUE_STEP = 47;      // per-layer hue advance
   private static final double MIN_REMAIN = 0.13;  // below this, the next fold finishes the layer
@@ -50,10 +43,6 @@ public class Origami extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How dramatic the music shift must be to fold");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -85,7 +74,7 @@ public class Origami extends ParameterPattern {
     addParameter("fold", this.fold);
     addParameter("audio", this.audio);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -146,14 +135,12 @@ public class Origami extends ParameterPattern {
   }
 
   private boolean detectDrop(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.25 + (1 - sens) * 0.9; // demands a real shift, not every beat
-    boolean drop = (bass > this.bassAvg * threshold)
+    boolean drop = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= FOLD_REFRACT_MS)
       && (bass > 0.01);
@@ -197,7 +184,7 @@ public class Origami extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/Origami.java
+++ b/src/main/java/apotheneum/piemonte/Origami.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Origami — the surface is a sheet of paper ruled with drifting diagonal lines
+ * in one color. Hit the Fold button (or let a dramatic swell in the music do
+ * it) and the sheet creases: the remaining area folds in half upon itself,
+ * the flap sweeping over and dissolving to reveal a new layer beneath — a new
+ * color, lines running the other way. Folds keep halving the old layer until
+ * it's gone, then the folding continues on the next layer, a new color with
+ * every crease. Wow makes each fold flash harder and crease brighter.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Origami extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double HUE_STEP = 47;      // per-layer hue advance
+  private static final double MIN_REMAIN = 0.13;  // below this, the next fold finishes the layer
+  private static final double FOLD_REFRACT_MS = 900;
+
+  public final BooleanParameter fold =
+    new BooleanParameter("Fold", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Fold the sheet: collapse half the current layer");
+
+  public final BooleanParameter audio =
+    new BooleanParameter("Audio", true)
+    .setDescription("Let dramatic shifts in the music trigger folds");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How dramatic the music shift must be to fold");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    Panel(int[][] idx, int w, int h) { this.idx = idx; this.w = w; this.h = h; }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  // global fold state, shared by all panels so the whole piece creases together
+  private int layer = 0;
+  private double lo = 0, hi = 1;      // remaining old-layer interval on the fold axis
+  private double foldT = -1;          // <0 idle, else 0..1 animation progress
+  private int foldSide = 0;           // 0: fold left/top half over; 1: right/bottom
+  private double crease = 0.5;
+  private boolean finalFold = false;
+  private double drift = 0;
+  private double timeMs = 0;
+  private boolean foldWasOn = false;
+
+  // bass-onset state (Cope-style detector, longer refractory for "dramatic" shifts)
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+
+  public Origami(LX lx) {
+    // Base registers color (layer-0 tint), speed (drift + fold tempo), size (line
+    // spacing/thickness), wow (fold drama).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("fold", this.fold);
+    addParameter("audio", this.audio);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Stripe angle for a layer: alternating diagonals with per-layer character. */
+  private static double layerAngle(int layer) {
+    double base = ((layer & 1) == 0) ? 45 : -45;
+    return Math.toRadians(base + (hashd(layer * 31 + 7) - 0.5) * 18);
+  }
+
+  private int layerColor(int layer) {
+    float baseHue = LXColor.h(getColor());
+    float hue = (float) (((baseHue + layer * HUE_STEP) % 360 + 360) % 360);
+    return LXColor.hsb(hue, 85, 100);
+  }
+
+  /** True if this layer folds along the horizontal axis (vertical creases). */
+  private static boolean axisHoriz(int layer) {
+    return hashd(layer * 53 + 3) < 0.5;
+  }
+
+  private boolean detectDrop(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.25 + (1 - sens) * 0.9; // demands a real shift, not every beat
+    boolean drop = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= FOLD_REFRACT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (drop) {
+      this.sinceBeatMs = 0;
+    }
+    return drop;
+  }
+
+  private void startFold() {
+    final double remain = this.hi - this.lo;
+    if (remain <= MIN_REMAIN) {
+      // last sliver: fold the whole thing over its far edge and finish the layer
+      this.finalFold = true;
+      this.foldSide = 0;
+      this.crease = this.hi;
+    } else {
+      this.finalFold = false;
+      // alternate which side folds in, tracked by interval midpoint parity
+      this.foldSide = (hashd(this.layer * 97 + (int) (remain * 1000)) < 0.5) ? 0 : 1;
+      this.crease = 0.5 * (this.lo + this.hi);
+    }
+    this.foldT = 0;
+  }
+
+  private void commitFold() {
+    if (this.finalFold) {
+      this.layer++;
+      this.lo = 0;
+      this.hi = 1;
+    } else if (this.foldSide == 0) {
+      this.lo = this.crease;
+    } else {
+      this.hi = this.crease;
+    }
+    this.foldT = -1;
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    this.timeMs += deltaMs;
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    this.drift += deltaMs * speed * 0.0004;
+
+    // --- triggers: UI button edge, or a dramatic musical shift ---
+    final boolean btn = this.fold.isOn();
+    final boolean btnEdge = btn && !this.foldWasOn;
+    this.foldWasOn = btn;
+    final boolean drop = detectDrop(deltaMs) && this.audio.isOn();
+    if (this.foldT < 0 && (btnEdge || drop)) {
+      startFold();
+    }
+
+    // --- advance fold animation ---
+    final double foldDur = 700.0 / ((0.4 + speed * 1.2) * (1.0 + wow * 0.5));
+    if (this.foldT >= 0) {
+      this.foldT += deltaMs / foldDur;
+      if (this.foldT >= 1) {
+        commitFold();
+      }
+    }
+
+    final int colOld = layerColor(this.layer);
+    final int colNew = layerColor(this.layer + 1);
+    final double angOld = layerAngle(this.layer);
+    final double angNew = layerAngle(this.layer + 1);
+    final boolean horiz = axisHoriz(this.layer);
+    final double period = 3 + getSize() * 10;
+    final double duty = 0.32;
+
+    final double ft = this.foldT;
+    final double cosF = (ft >= 0) ? Math.cos(Math.PI * ft) : 1;
+    final double lift = (ft >= 0) ? Math.sin(Math.PI * ft) : 0; // flap catching the light
+    final double flapGlint = lift * (0.45 + wow * 0.75);
+    final double creaseGlow = (ft >= 0) ? (0.6 + wow * 0.9) * Math.sin(Math.PI * Math.min(1, ft * 1.15)) : 0;
+
+    for (Panel p : this.panels) {
+      final double diag = 1.0 / Math.max(1, (horiz ? p.w : p.h) - 1);
+      for (int x = 0; x < p.w; ++x) {
+        for (int y = 0; y < p.h; ++y) {
+          final double a = (horiz ? x : y) * diag; // fold-axis coordinate, 0..1
+          int c;
+          double b;
+          double sampleA = a;      // where on the sheet we sample the old pattern
+          boolean showOld;
+          double glint = 0;
+
+          if (ft < 0) {
+            showOld = (a >= this.lo && a <= this.hi);
+          } else if (this.foldSide == 0) {
+            // flap [lo, crease] folds rightward over the crease
+            final double flapEdge = this.crease - (this.crease - this.lo) * cosF;
+            if (cosF > 0.02 && a >= flapEdge && a < this.crease) {
+              showOld = true; // foreshortened flap still lifting
+              sampleA = this.crease - (this.crease - a) / cosF;
+              glint = flapGlint;
+            } else if (cosF < -0.02 && a >= this.crease && a <= this.crease - (this.crease - this.lo) * cosF) {
+              showOld = true; // mirrored flap landing on the far side
+              sampleA = this.crease - (a - this.crease) / (-cosF);
+              glint = flapGlint;
+            } else {
+              showOld = !this.finalFold && (a >= this.crease && a <= this.hi);
+            }
+          } else {
+            // flap [crease, hi] folds leftward over the crease
+            final double flapEdge = this.crease + (this.hi - this.crease) * cosF;
+            if (cosF > 0.02 && a > this.crease && a <= flapEdge) {
+              showOld = true;
+              sampleA = this.crease + (a - this.crease) / cosF;
+              glint = flapGlint;
+            } else if (cosF < -0.02 && a <= this.crease && a >= this.crease + (this.hi - this.crease) * cosF) {
+              showOld = true;
+              sampleA = this.crease + (this.crease - a) / (-cosF);
+              glint = flapGlint;
+            } else {
+              showOld = (a >= this.lo && a <= this.crease);
+            }
+          }
+
+          // absorb the flap into the sheet at the very end of the fold
+          double flapAlpha = 1;
+          if (glint > 0 && ft > 0.78) {
+            flapAlpha = LXUtils.clamp((1 - ft) / 0.22, 0, 1);
+            if (flapAlpha <= 0) {
+              showOld = false;
+            }
+          }
+
+          // stripes: sample the appropriate layer's ruled sheet
+          final double sx = (horiz ? sampleA / diag : x);
+          final double sy = (horiz ? y : sampleA / diag);
+          if (showOld) {
+            b = sheet(sx, sy, angOld, period, duty, p, 1);
+            c = colOld;
+          } else {
+            b = sheet(x, y, angNew, period, duty, p, -1);
+            c = colNew;
+          }
+
+          if (glint > 0 && showOld) {
+            b = (b + glint) * flapAlpha + (1 - flapAlpha) * b;
+            c = LXColor.lerp(c, LXColor.WHITE, (float) LXUtils.clamp(glint * 0.6, 0, 1));
+          }
+          // white-hot crease line while folding
+          if (creaseGlow > 0) {
+            final double dc = Math.abs(a - this.crease);
+            if (dc < 0.035) {
+              final double g = creaseGlow * (1 - dc / 0.035);
+              b = Math.max(b, g);
+              c = LXColor.lerp(c, LXColor.WHITE, (float) LXUtils.clamp(g, 0, 1));
+            }
+          }
+
+          if (b <= 0.004) continue;
+          final int idx = p.idx[x][y];
+          this.colors[idx] = LXColor.lightest(this.colors[idx],
+            LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+        }
+      }
+    }
+
+    copyExterior();
+  }
+
+  /** Ruled-paper brightness at (x,y): diagonal lines over a soft color-gradient fill. */
+  private double sheet(double x, double y, double angle, double period, double duty,
+      Panel p, int driftDir) {
+    final double s = (x * Math.cos(angle) + y * Math.sin(angle)) / period + this.drift * driftDir;
+    final double v = s - Math.floor(s);
+    // soft gradient fill so the layer reads as a colored sheet, lines on top
+    final double grad = 0.10 + 0.20 * (y / (double) Math.max(1, p.h - 1));
+    if (v < duty) {
+      // gamma-shaped line profile with a bright core
+      final double u = 1 - Math.abs(v / duty * 2 - 1);
+      return Math.max(grad, 0.35 + 0.65 * u * u);
+    }
+    return grad;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Overclock.java
+++ b/src/main/java/apotheneum/piemonte/Overclock.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Overclock — a dense fixed curtain of vertical strands shimmers with light
+ * streaming downward into a bright pool at the floor, while a circuit maze of
+ * horizontal traces and right-angle jogs glows near the hang line, slowly
+ * re-routing itself. The whole room breathes between emerald and azure in long
+ * sustained phases — each handover fading through near-black and blooming back
+ * in the new color, passing through cyan on the way. Modeled on the
+ * holotrigger Shimmer Hammer program.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Overclock extends StrandPattern {
+
+  private static final int MAX_PACKETS = 12;
+  private static final double HUE_A = 125; // emerald
+  private static final double HUE_B = 210; // azure
+  private static final double CYCLE_MS = 8000; // full green->blue->green breath
+  private static final double JOG_INTERVAL_MS = 1500;
+  private static final int STRAND_SPACING = 5; // fixed curtain pitch
+
+  public final DiscreteParameter traces =
+    new DiscreteParameter("Traces", 6, 2, MAX_PACKETS)
+    .setDescription("Circuit traces re-routing in the top maze");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of the swell");
+
+  private final class Surface {
+    boolean inited;
+    // maze traces confined to the hang line
+    final double[] px = new double[MAX_PACKETS];
+    final double[] py = new double[MAX_PACKETS];
+    final double[] pv = new double[MAX_PACKETS];
+    final double[] jogT = new double[MAX_PACKETS];
+    final int[] jx0 = new int[MAX_PACKETS];
+    final int[] jx1 = new int[MAX_PACKETS];
+    final int[] jy = new int[MAX_PACKETS];
+    final double[] jenv = new double[MAX_PACKETS];
+    void reset(int w, int h) {
+      for (int i = 0; i < MAX_PACKETS; ++i) {
+        this.px[i] = Math.random() * w;
+        this.py[i] = Math.random() * h * 0.28;
+        this.pv[i] = (0.002 + Math.random() * 0.0025) * (Math.random() < 0.5 ? 1 : -1);
+        this.jogT[i] = Math.random() * JOG_INTERVAL_MS;
+        this.jenv[i] = 0;
+      }
+      this.inited = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double pulse = 0;
+
+  public Overclock(LX lx) {
+    // Base registers color (hue shift), speed (breath pace), size (shimmer depth).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("traces", this.traces);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 190.0);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    final int w = o.width();
+    final int h = o.height();
+    if (!s.inited) s.reset(w, h);
+
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+
+    // sustained green<->blue breath with plateaus at each pole; handovers pass
+    // through cyan AND through a near-black trough
+    final double cyc = (this.timeMs * speed * 2) % CYCLE_MS / CYCLE_MS;
+    double c = 0.5 - 0.5 * Math.cos(2 * Math.PI * cyc);
+    final double mix = c * c * (3 - 2 * c);
+    final double crossover = 1 - Math.abs(mix - 0.5) * 2;
+    final double breath = LXUtils.lerp(1.0, 0.15, crossover * crossover);
+    final double hue = LXUtils.lerp(HUE_A, HUE_B, mix) + hueShift;
+    final int col = LXColor.hsb((float) (((hue % 360) + 360) % 360), 92, 100);
+    final double gain = breath * (1.0 + this.pulse * 0.15) * (0.6 + 0.4 * this.levelEnv + wow * 0.3);
+    final int tq = (int) (this.timeMs / 70);
+
+    // fixed dense strand curtain: shimmer scrolls downward, draining into the pool
+    final double shimDepth = 0.35 + getSize() * 0.30;
+    for (int bx = STRAND_SPACING / 2; bx < w; bx += STRAND_SPACING) {
+      final int jitter = (int) ((hashd(bx * 31 + 7) - 0.5) * 2);
+      final int x = bx + jitter;
+      for (int y = 0; y < h; ++y) {
+        // downward-scrolling seed: light streams toward the floor
+        final double sh = (1 - shimDepth) + shimDepth * hashd(x * 131 + (y - tq) * 7);
+        double b = 0.30 * gain * sh * drip(y, h);
+        // the base pool drains last: bottom rows lean on pool() with less breath-gating
+        b += (0.5 * pool(y, h)) * sh * (0.4 + 0.6 * breath) * (1.0 + this.pulse * 0.2);
+        addPix(o, x, y, col, b);
+      }
+    }
+
+    // circuit maze near the hang line: slow traces with right-angle re-routes
+    final int count = Math.min(MAX_PACKETS, this.traces.getValuei() + (int) Math.round(wow * 3));
+    final int mazeH = (int) (h * 0.30);
+    for (int i = 0; i < count; ++i) {
+      s.py[i] += s.pv[i] * speed * deltaMs;
+      if (s.py[i] < 0) { s.py[i] = 0; s.pv[i] = -s.pv[i]; }
+      else if (s.py[i] > mazeH) { s.py[i] = mazeH; s.pv[i] = -s.pv[i]; }
+
+      s.jogT[i] -= deltaMs;
+      if (s.jogT[i] <= 0) {
+        s.jogT[i] = JOG_INTERVAL_MS * (0.6 + Math.random()) / (1 + wow);
+        if (Math.random() < 0.6) {
+          final int dx = (3 + (int) (Math.random() * 6)) * (Math.random() < 0.5 ? 1 : -1);
+          s.jx0[i] = (int) s.px[i];
+          s.jx1[i] = (int) s.px[i] + dx;
+          s.jy[i] = (int) s.py[i];
+          s.jenv[i] = 1;
+          s.px[i] = ((s.px[i] + dx) % w + w) % w;
+        }
+      }
+
+      // short vertical trace segment
+      for (int k = 0; k <= 4; ++k) {
+        final double b = gain * 0.9 * Math.exp(-0.5 * k);
+        addPix(o, (int) s.px[i], (int) s.py[i] - k, col, b);
+        addPix(o, (int) s.px[i] + 1, (int) s.py[i] - k, col, b * 0.5);
+      }
+      // glowing right-angle bridge from the last re-route
+      if (s.jenv[i] > 0.02) {
+        final int lo = Math.min(s.jx0[i], s.jx1[i]);
+        final int hi2 = Math.max(s.jx0[i], s.jx1[i]);
+        for (int x = lo; x <= hi2; ++x) {
+          addPix(o, x, s.jy[i], col, s.jenv[i] * gain * 0.85);
+          addPix(o, x, s.jy[i] + 1, col, s.jenv[i] * gain * 0.35);
+        }
+        s.jenv[i] *= Math.exp(-deltaMs / 600.0); // traces linger
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -33,9 +33,22 @@ package apotheneum.piemonte;
 import apotheneum.ApotheneumPattern;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
 
 public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Shared render-target selector: both structures, cube only, or cylinder only. */
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  /** Created by addTargetParameter(); null when a pattern doesn't opt in. */
+  public EnumParameter<Target> target;
 
   /** Primary hue (degrees) — the single dial that steers pattern color. */
   public final CompoundParameter hue =
@@ -53,6 +66,36 @@ public abstract class ParameterPattern extends ApotheneumPattern {
   public final CompoundParameter wow =
     new CompoundParameter("Wow", 0, 0, 1)
     .setDescription("Extra flourish / special-effect intensity");
+
+  /**
+   * External audio inputs. Nothing in these patterns samples the LX audio
+   * meter — installation volume is expected to change, which would rescale
+   * every internally-analyzed level. Instead the envelope-follower step runs
+   * in the audio program (e.g. Ableton feeding the show-control M4L device),
+   * which sends a volume-stable signal here over OSC/MIDI modulation.
+   */
+  public final CompoundParameter level =
+    new CompoundParameter("Level", 0, 0, 1)
+    .setDescription("Audio level input — map an external envelope follower (OSC/MIDI)");
+
+  public final BooleanParameter pulse =
+    new BooleanParameter("Pulse", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Beat trigger input — map an external beat source (OSC/MIDI)");
+
+  // --- audio state derived from the external inputs, once per frame ---
+  private boolean prevPulse;
+  private double prevLevel, sinceBeatMs = 1e9;
+  /** Slow-average of the level input; useful for contrast ratios. */
+  protected double levelAvg;
+  /** True on the frame a beat fires (Pulse edge, or a Level onset). */
+  protected boolean beat;
+  /** Normalized beat strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Level input shaped by a 25ms attack / 220ms release envelope. */
+  protected double levelEnv;
+  /** Accumulated pattern time in ms. */
+  protected double timeMs = 0;
 
   /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
   protected ParameterPattern(LX lx) {
@@ -82,6 +125,94 @@ public abstract class ParameterPattern extends ApotheneumPattern {
     addParameter("speed", this.speed);
     addParameter("size", this.size);
     addParameter("wow", this.wow);
+    addParameter("level", this.level);
+    addParameter("pulse", this.pulse);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addTargetParameter(Target.BOTH);
+  }
+
+  /** Target with a pattern-specific default. */
+  protected void addTargetParameter(Target def) {
+    this.target = new EnumParameter<Target>("Target", def)
+      .setDescription("Which structures to render to");
+    addParameter("target", this.target);
+  }
+
+  /** Current target; BOTH when the pattern doesn't expose the selector. */
+  protected Target getTarget() {
+    return (this.target != null) ? this.target.getEnum() : Target.BOTH;
+  }
+
+  /** Beat threshold multiplier for Level onsets; override to wire a Sens param. */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  /**
+   * Advance the derived audio state from the external Level/Pulse inputs.
+   * StrandPattern calls this automatically each frame; patterns that extend
+   * ParameterPattern directly call it at the top of render().
+   */
+  protected void stepAudio(double deltaMs) {
+    this.timeMs += deltaMs;
+    final double lvl = this.level.getValue();
+
+    // attack/release envelope + slow average for contrast ratios
+    final double alpha = (lvl > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (lvl - this.levelEnv) * alpha;
+    this.levelAvg += (lvl - this.levelAvg) * (1 - Math.exp(-deltaMs / 2000.0));
+
+    // beats: a Pulse edge always fires; Level onsets fire when it climbs
+    // clear of its own slow average (volume-stable, since the follower is
+    // upstream of any installation volume changes)
+    this.sinceBeatMs += deltaMs;
+    final boolean p = this.pulse.isOn();
+    final boolean pulseEdge = p && !this.prevPulse;
+    this.prevPulse = p;
+    final boolean onset = (lvl > this.levelAvg * beatThreshold())
+      && (lvl > this.prevLevel)
+      && (this.sinceBeatMs >= 130)
+      && (lvl > 0.01);
+    this.prevLevel = lvl;
+    this.beat = pulseEdge || onset;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = pulseEdge ? 1.0
+      : LXUtils.clamp((lvl / Math.max(1e-4, this.levelAvg) - 1.0) / 1.5, 0, 1);
+  }
+
+  /**
+   * Pseudo-spectrum: the level envelope spread across n bands with slow
+   * per-band drift, so band-indexed visuals keep independent motion without
+   * sampling the internal meter.
+   */
+  protected double band(int i, int n) {
+    final double drift = 0.5 + 0.5 * Math.sin(
+      this.timeMs * (0.0009 + 0.0008 * phash(i * 31 + n * 7)) + i * 2.1);
+    return this.levelEnv * (0.45 + 0.55 * drift);
+  }
+
+  private boolean prevPulseLocal;
+
+  /** True exactly once per Pulse press; for patterns running bespoke detectors. */
+  protected boolean pulseHit() {
+    final boolean p = this.pulse.isOn();
+    final boolean edge = p && !this.prevPulseLocal;
+    this.prevPulseLocal = p;
+    return edge;
+  }
+
+  private static double phash(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
   }
 
   // Convenience getters. Subclasses can also tweak the

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2026- Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * Created by patrick piemonte
+ *
+ * ParameterPattern — an intermediate base (ApotheneumPattern → ParameterPattern
+ * → your pattern) that fixes a consistent leading parameter order: hue,
+ * speed, size, wow. Every pattern that extends it gets those four controls in
+ * the same place. Subclasses extend this, then add their own parameters (and
+ * any extra colors) after super(...). Kept self-contained so
+ * last-minute changes don't ripple across other authors' content.
+ *
+ * "Wow" is a shared performance macro in the spirit of LXStudio-TE's WOW knobs:
+ * a 0..1 "extra flourish" each pattern interprets in its own way. It defaults to
+ * 0 (inert), so a pattern that ignores it is unaffected and its resting look is
+ * unchanged; patterns that read getWow() add a special-effect layer as it rises.
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.ApotheneumPattern;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+
+public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Primary hue (degrees) — the single dial that steers pattern color. */
+  public final CompoundParameter hue =
+    new CompoundParameter("Hue", 0, 0, 360)
+    .setDescription("Primary hue")
+    .setWrappable(true);
+
+  /** Animation speed. Range/polarity set per-subclass via the constructor. */
+  public final CompoundParameter speed;
+
+  /** Element size. Range set per-subclass via the constructor. */
+  public final CompoundParameter size;
+
+  /** Shared "wow" performance macro (0..1). Defaults to 0 (inert). */
+  public final CompoundParameter wow =
+    new CompoundParameter("Wow", 0, 0, 1)
+    .setDescription("Extra flourish / special-effect intensity");
+
+  /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
+  protected ParameterPattern(LX lx) {
+    this(lx, 0.4, -1, 1, 0.5, 0, 1);
+  }
+
+  /**
+   * CompoundParameter ranges are immutable after construction, so subclasses
+   * pass their desired speed/size ranges here. Speed becomes bipolar when its
+   * minimum is negative.
+   */
+  protected ParameterPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx);
+
+    this.speed = new CompoundParameter("Speed", speedDef, speedMin, speedMax)
+      .setDescription("Animation speed");
+    if (speedMin < 0) {
+      this.speed.setPolarity(CompoundParameter.Polarity.BIPOLAR);
+    }
+    this.size = new CompoundParameter("Size", sizeDef, sizeMin, sizeMax)
+      .setDescription("Element size");
+
+    // Canonical leading order: hue, speed, size, wow. Subclasses add the rest.
+    addParameter("hue", this.hue);
+    addParameter("speed", this.speed);
+    addParameter("size", this.size);
+    addParameter("wow", this.wow);
+  }
+
+  // Convenience getters. Subclasses can also tweak the
+  // inherited params directly, e.g. this.speed.setExponent(2) or
+  // this.size.setUnits(LXParameter.Units.INTEGER), in their constructor.
+
+  /** Resolved primary color for this frame — the Hue knob at full strength. */
+  protected int getColor() {
+    return LXColor.hsb(this.hue.getValuef() % 360, 100, 100);
+  }
+
+  /** Current speed value (bipolar when the configured minimum is negative). */
+  protected double getSpeed() {
+    return this.speed.getValue();
+  }
+
+  /** Current size value. */
+  protected double getSize() {
+    return this.size.getValue();
+  }
+
+  /** Current "wow" macro value (0..1); 0 means the flourish is off. */
+  protected double getWow() {
+    return this.wow.getValue();
+  }
+}

--- a/src/main/java/apotheneum/piemonte/PlayaStrobe.java
+++ b/src/main/java/apotheneum/piemonte/PlayaStrobe.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * PlayaStrobe — UFOAbduction stripped to pure white. Blocks of white light
+ * beam up the lanes with the measured velocity signature — fast entry, a
+ * slow-motion crawl through the center, a burst out the top — and as each
+ * block enters the center of its border it strobes briefly, a hard little
+ * flutter before it glides on. Around them, thin white lines spin
+ * horizontally like a cyclone, shearing faster near the top rim as the vortex
+ * slowly climbs. The operator's Strobe button still fires the full-structure
+ * pulsating white burst that decays away after release. Wow feeds the cyclone
+ * and hardens every strobe.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class PlayaStrobe extends StrandPattern {
+
+  private static final int MAX_HEADS = 64;
+  private static final int MAX_LINES = 16;
+  private static final int WHITE_SOFT = LXColor.hsb(210, 6, 100); // barely-cool white
+  // UFOAbduction's measured rise profile
+  private static final double V_ENTRY = 0.00135;
+  private static final double V_STALL = 0.00024;
+  private static final double V_EXIT = 0.0075;
+  private static final double STALL_LO = 0.60;
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;
+  private static final double IDLE_WAVE_MS = 900;
+  private static final double STALL_STROBE_MS = 320; // brief flutter entering the stall
+  private static final double DECAY_MS = 1500;       // button strobe fade-out
+  private static final double STROBE_DUTY = 0.45;
+  private static final double CYCLONE_REV_S = 0.30;
+
+  public final DiscreteParameter lanes =
+    new DiscreteParameter("Lanes", 12, 6, 24)
+    .setDescription("Lanes the white blocks beam up");
+
+  public final BooleanParameter strobe =
+    new BooleanParameter("Strobe", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Fire a pulsating white strobe burst; hold to sustain");
+
+  public final CompoundParameter rate =
+    new CompoundParameter("Rate", 9, 2, 16)
+    .setDescription("Strobe pulse rate in flashes per second");
+
+  private final class Surface {
+    boolean inited;
+    final int[] lane = new int[MAX_HEADS];
+    final double[] y = new double[MAX_HEADS];
+    final double[] vf = new double[MAX_HEADS];      // variance factor
+    final double[] stallMs = new double[MAX_HEADS]; // time spent in the stall band
+    final boolean[] alive = new boolean[MAX_HEADS];
+    void reset() {
+      for (int i = 0; i < MAX_HEADS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void spawn(int lane) {
+      for (int i = 0; i < MAX_HEADS; ++i) {
+        if (this.alive[i]) continue;
+        this.lane[i] = lane;
+        this.y[i] = 1.02 + Math.random() * 0.10;
+        this.vf[i] = 0.8 + Math.random() * 0.4;
+        this.stallMs[i] = 0;
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double waveTimer = 0;
+  private double strobeEnv = 0;
+  private double cyclone = 0; // shared spin phase
+
+  public PlayaStrobe(LX lx) {
+    // Base registers color (unused: pure white), speed (rise + spin), size (block thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("lanes", this.lanes);
+    addParameter("strobe", this.strobe);
+    addParameter("rate", this.rate);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** UFOAbduction's rise profile: fast entry, center stall, exit burst. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    this.cyclone += deltaMs * 0.001 * CYCLONE_REV_S * speed * 2 * (1 + wow * 0.5);
+    this.cyclone -= Math.floor(this.cyclone);
+
+    // beat-locked launch waves with an idle cadence fallback
+    this.waveTimer += deltaMs * speed * 2;
+    if ((this.beat && this.beatLevel > 0.15) || this.waveTimer >= IDLE_WAVE_MS) {
+      this.waveTimer = 0;
+      final double strength = LXUtils.clamp(
+        this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.2, 1);
+      launchWave(this.cube, strength);
+      launchWave(this.cylinder, strength);
+    }
+
+    // operator strobe: full while held, decaying burst after release
+    if (this.strobe.isOn()) {
+      this.strobeEnv = 1;
+    } else if (this.strobeEnv > 0) {
+      this.strobeEnv = Math.max(0, this.strobeEnv - deltaMs / DECAY_MS);
+    }
+  }
+
+  private void launchWave(Surface s, double strength) {
+    if (!s.inited) s.reset();
+    final int n = this.lanes.getValuei();
+    for (int l = 0; l < n; ++l) {
+      if (hashd(l * 641 + (int) (this.timeMs * 3)) > 0.35 + strength * 0.55) continue;
+      s.spawn(l);
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    final int nLanes = this.lanes.getValuei();
+    final double laneW = (double) w / nLanes;
+    final int tq = (int) (this.timeMs / 70);
+
+    // --- white blocks beaming up, fluttering as they enter the center stall ---
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!s.alive[i]) continue;
+      final double yp = s.y[i];
+      final boolean inStall = (yp <= STALL_LO && yp >= STALL_HI);
+      // Wow = slow-motion: the drops decelerate and stretch into long streaks
+      s.y[i] -= s.vf[i] * riseProfile(yp) * speed * 2 * deltaMs * (1.0 - wow * 0.65);
+      if (s.y[i] <= -0.08) { s.alive[i] = false; continue; }
+      if (inStall) {
+        s.stallMs[i] += deltaMs;
+      }
+
+      final double vNorm = LXUtils.clamp(riseProfile(yp) / V_ENTRY, 0, 1.2);
+      final double thickN = LXUtils.lerp(0.10 * (0.6 + getSize() * 0.9), 0.045, Math.min(1, vNorm))
+        * (1.0 + wow * 0.6); // stretched bodies in slow motion
+      final int thick = Math.max(2, (int) Math.round(thickN * h));
+      final double tailN = LXUtils.clamp(vNorm * 0.8 * (1.0 + wow * 2.0), 0.12, 1.6);
+      final int tail = (int) Math.round(tailN * h);
+
+      // the brief strobe as the block enters its center stall
+      double gate = 1.0;
+      if (inStall && s.stallMs[i] < STALL_STROBE_MS * (1 + wow * 0.8)) {
+        gate = (((int) (this.timeMs / 45)) & 1) == 0 ? 1.35 : 0.12; // ~11Hz flutter
+      }
+
+      final int x0 = (int) (s.lane[i] * laneW);
+      final int x1 = Math.min(w - 1, (int) ((s.lane[i] + 1) * laneW) - 2);
+      final double leadF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final double trailF = leadF + (thick - 1);
+      for (int x = x0; x <= x1; ++x) {
+        for (int yy = (int) Math.floor(leadF) - 1; yy <= (int) Math.ceil(trailF) + 1; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = (yy < leadF) ? (leadF - yy) : ((yy > trailF) ? (yy - trailF) : 0);
+          final double cov = LXUtils.clamp(1.0 - dOut, 0, 1);
+          if (cov <= 0.02) continue;
+          final double u = LXUtils.clamp(1.0 - (yy - leadF) / Math.max(1, thick), 0, 1);
+          addPix(o, x, yy, (u > 0.5) ? LXColor.WHITE : WHITE_SOFT,
+            gate * (0.55 + 0.45 * u) * cov);
+        }
+        // tail streams below the block
+        for (int k = 1; k <= tail; ++k) {
+          final int yy = (int) Math.round(trailF) + k;
+          if (yy >= h) break;
+          final double fFall = Math.exp(-2.0 * k / tail);
+          if (fFall < 0.02) break;
+          addPix(o, x, yy, WHITE_SOFT, gate * fFall * 0.7);
+        }
+      }
+    }
+
+    // --- the cyclone: thin white lines shearing around the canvas ---
+    final int nLines = 8 + (int) Math.round(wow * (MAX_LINES - 8));
+    final double rise = (this.timeMs * 0.00002 * speed) % 1.0;
+    for (int i = 0; i < nLines; ++i) {
+      final double band = hashd(i * 53 + 11); // 0 = top .. 1 = lower
+      final double segLen = 0.18 + 0.22 * hashd(i * 97 + 3);
+      // higher lines spin faster: cyclone shear
+      final double spin = this.cyclone * (1.0 + (1.0 - band) * 1.2) + hashd(i * 31 + 7);
+      final double xc = (spin - Math.floor(spin)) * w;
+      final int x0 = (int) Math.floor(xc);
+      final double xf = xc - x0;
+      final int yTop = (int) ((((band * 0.55 - rise * 0.3) % 1.0) + 1.0) % 1.0 * h);
+      final int yBot = Math.min(h - 1, yTop + (int) (segLen * h));
+      for (int yy = yTop; yy <= yBot; ++yy) {
+        final double tw = 0.55 + 0.45 * hashd(i * 977 + yy * 131 + tq * 3);
+        addPix(o, x0, yy, WHITE_SOFT, 0.8 * tw * (1 - xf));
+        addPix(o, x0 + 1, yy, WHITE_SOFT, 0.8 * tw * xf);
+      }
+    }
+
+    // --- operator strobe: full-structure pulsating burst (original behavior) ---
+    if (this.strobeEnv > 0) {
+      final double hz = this.rate.getValue() * (1.0 + wow * 0.7);
+      if ((this.timeMs * 0.001 * hz) % 1.0 < STROBE_DUTY) {
+        final int flash = LXColor.scaleBrightness(LXColor.WHITE,
+          (float) (this.strobeEnv * this.strobeEnv));
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            final int idx = o.point(x, y).index;
+            this.colors[idx] = LXColor.lightest(this.colors[idx], flash);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Pressure.java
+++ b/src/main/java/apotheneum/piemonte/Pressure.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Pressure — a two-channel color organ on the strand curtains: the columns
+ * gate hard between near-black and saturated washes, each column committed to
+ * either red or green, identities re-rolled with every major pulse. Fast
+ * attack, slow release — the whole rig breathes dark-bright-dark like a
+ * warehouse PA. Where red columns overdrive they bleed amber, and everything
+ * pools on the floor line. Modeled on the holotrigger red/green pulse program.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Pressure extends StrandPattern {
+
+  private static final int MAX_GROUPS = 32;
+
+  public final DiscreteParameter columns =
+    new DiscreteParameter("Columns", 7, 3, 16)
+    .setDescription("Curtain panels around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of the gate");
+
+  // per-group state, shared across surfaces so cube and cylinder pulse together
+  private final double[] energy = new double[MAX_GROUPS];
+  private final boolean[] isRed = new boolean[MAX_GROUPS];
+  private final boolean[] firing = new boolean[MAX_GROUPS];
+  private int beatCount = 0;
+  private int lastIdlePulse = -1;
+  private double rotPhase = 0; // slow orbit of the curtain wall around the gravity axis
+  private boolean inited = false;
+
+  public Pressure(LX lx) {
+    // Base registers color (hue shift), speed (idle breathe tempo), size (unused softness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("columns", this.columns);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.inited) {
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(i * 17 + 3) < 0.4;
+        this.firing[i] = true;
+        this.energy[i] = 0.4;
+      }
+      this.inited = true;
+    }
+
+    final double wow = getWow();
+    // the whole curtain wall slowly orbits the vertical axis; Wow spins it up,
+    // and each hit gives the drum a small extra shove
+    final double speedR = Math.max(0.05, getSpeed());
+    this.rotPhase += deltaMs * speedR * 2 * 0.00003 * (1 + wow * 2);
+    if (this.beat) {
+      this.rotPhase += 0.004 * this.beatLevel;
+    }
+    this.rotPhase -= Math.floor(this.rotPhase);
+    if (this.beat) {
+      ++this.beatCount;
+      // green is home; a red minority coexists, re-rolled per pulse; rare all-red wall
+      double redFrac = 0.25 + this.beatLevel * 0.15 + wow * 0.1;
+      if (hashd(this.beatCount * 13 + 5) < 0.12) {
+        redFrac = 0.85;
+      }
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(this.beatCount * 977 + i * 31) < redFrac;
+        this.firing[i] = true; // the gate is temporal (whole field), not spatial
+      }
+    }
+
+    // idle gate in silence: hard on/off square at the reference's ~0.7s cadence
+    final double speed = Math.max(0.05, getSpeed());
+    final boolean quiet = this.levelEnv < 0.05;
+    final double idleCycle = this.timeMs * speed * 2 / 700.0;
+    final int idlePulse = (int) idleCycle;
+    if (quiet && idlePulse != this.lastIdlePulse) {
+      this.lastIdlePulse = idlePulse;
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(idlePulse * 977 + i * 31) < 0.30;
+        this.firing[i] = true;
+      }
+    }
+    final double idleGate = ((idleCycle - idlePulse) < 0.55) ? 0.95 : 0.04;
+
+    // whole-field gate: fast attack, ~250ms release into a held near-black trough
+    final double aAtk = 1 - Math.exp(-deltaMs / 30.0);
+    final double target = quiet
+      ? idleGate
+      : LXUtils.clamp(0.20 + this.levelEnv * 1.0 + this.beatLevel * 0.5 + wow * 0.2, 0, 1.3);
+    for (int i = 0; i < MAX_GROUPS; ++i) {
+      // tiny per-curtain release offset so transitions show a lagging curtain or two
+      final double aRel = 1 - Math.exp(-deltaMs / ((270.0 - wow * 90) * (1.0 + 0.15 * hashd(i * 7))));
+      double a = (target > this.energy[i]) ? aAtk : aRel;
+      this.energy[i] += (target - this.energy[i]) * a;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int n = this.columns.getValuei();
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((112 + hueShift) % 360)), 98, 100);
+    final int yellow = LXColor.hsb((float) (((78 + hueShift) % 360)), 95, 100);
+    final int red = LXColor.hsb((float) (((2 + hueShift) % 360)), 100, 100);
+    final int amber = LXColor.hsb((float) (((30 + hueShift) % 360)), 92, 100);
+    final int ember = LXColor.hsb((float) (((24 + hueShift) % 360)), 90, 100);
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int x = 0; x < w; ++x) {
+      // panel coordinates rotate around the gravity axis
+      final double xr = (((double) x / w + this.rotPhase) % 1.0) * n;
+      final int g = Math.min(n - 1, (int) xr);
+      final double e = this.energy[g];
+      // dark wall gap between discrete curtain panels
+      final double gpos = xr - g;
+      if (gpos < 0.10 || gpos > 0.90) continue;
+      if (e > 0.01) {
+        final double shim = 0.90 + 0.10 * hashd(x * 131 + tq * 7);
+        int c = this.isRed[g] ? red : green;
+        // overdrive bleeds: red toward amber, green toward yellow-green
+        if (e > 0.85) {
+          final float od = (float) LXUtils.clamp((e - 0.85) * 4, 0, 1);
+          c = this.isRed[g] ? LXColor.lerp(red, amber, od) : LXColor.lerp(green, yellow, od);
+        }
+        final int hot = LXColor.lerp(c, LXColor.WHITE, 0.35f);
+        for (int y = 0; y < h; ++y) {
+          double b = e * drip(y, h) * shim;
+          b += e * pool(y, h);
+          if (b <= 0.01) continue;
+          // the hottest point is the floor, not the truss
+          addPix(o, x, y, (e > 1.0 && y >= h - 3) ? hot : c, b);
+        }
+      }
+    }
+
+    // persistent warm floor ember: alive even in the blackest troughs
+    for (int x = 0; x < w; ++x) {
+      final double fb = 0.14 * (0.7 + 0.3 * hashd(x * 37 + tq));
+      addPix(o, x, h - 1, ember, fb);
+      addPix(o, x, h - 2, ember, fb * 0.45);
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Radiate.java
+++ b/src/main/java/apotheneum/piemonte/Radiate.java
@@ -26,17 +26,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Radiate extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_RAYS = 90;
   private static final double SCENE_MS = 6700;   // per palette scene (~40s arc / 6)
@@ -54,10 +47,6 @@ public class Radiate extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How easily the music blooms and fills the room");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.CYLINDER)
-    .setDescription("Which structures to render to");
 
   // per-ray state
   private final double[] rx = new double[MAX_RAYS];   // column position (fixed)
@@ -81,7 +70,7 @@ public class Radiate extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("rays", this.rays);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter(Target.CYLINDER);
   }
 
   private static double hashd(int n) {
@@ -99,23 +88,14 @@ public class Radiate extends ParameterPattern {
     this.inited = true;
   }
 
-  private double band(int i, int n) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    int lo = i * nb / n;
-    int hi = Math.max(lo + 1, (i + 1) * nb / n);
-    return m.getAveragef(lo, hi - lo);
-  }
 
   private boolean detect(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= 140)
       && (bass > 0.01);
@@ -123,7 +103,7 @@ public class Radiate extends ParameterPattern {
     if (beat) {
       this.sinceBeatMs = 0;
     }
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double aUp = 1 - Math.exp(-deltaMs / 25.0);
     double aDn = 1 - Math.exp(-deltaMs / 220.0);
     this.levelEnv += (level - this.levelEnv) * ((level > this.levelEnv) ? aUp : aDn);
@@ -170,7 +150,7 @@ public class Radiate extends ParameterPattern {
       : 1 - Math.exp(-deltaMs / 2000.0);
     this.floodEnv += (floodTarget - this.floodEnv) * fa;
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CUBE) {
       renderField(Apotheneum.cylinder.exterior, deltaMs);
       copyCylinderExterior();

--- a/src/main/java/apotheneum/piemonte/Radiate.java
+++ b/src/main/java/apotheneum/piemonte/Radiate.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Radiate — you stand where the performer sat, on a floor of
+ * LED dots: dotted rays fan outward all around you — up the walls, since out
+ * on the floor is up on the cylinder — their dot-chains crawling slowly
+ * outward, faster on the bass. Dotted rings hug the center below them, red
+ * against the cool rays. On every hit a wavefront of brightness blooms from
+ * the center to the rim in under half a second; energetic sections keep the
+ * whole room saturated in sustained color, and between sections everything
+ * collapses to a sparse starfield of twinkling white-blue dots. The palette
+ * steps through the reference's arc: red, emerald, teal, blue, a split
+ * red/blue ring, and a magenta haze. Modeled on the ksawerykomputery studio
+ * floor piece.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Radiate extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_RAYS = 90;
+  private static final double SCENE_MS = 6700;   // per palette scene (~40s arc / 6)
+  private static final double SCENE_XFADE = 1500;
+  private static final double DUO = -1000;       // red/blue split ring scene
+  private static final double DOT_SPACING = 2.6; // cells between ray dots
+  private static final double BLOOM_MS = 400;    // center->rim wavefront
+  // scene hues matching the reference arc: red, emerald, teal, blue, duo, magenta
+  private static final double[] SCENES = { 358, 124, 180, 228, DUO, 292 };
+
+  public final DiscreteParameter rays =
+    new DiscreteParameter("Rays", 56, 12, MAX_RAYS)
+    .setDescription("How many dotted rays fan around the cylinder");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How easily the music blooms and fills the room");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.CYLINDER)
+    .setDescription("Which structures to render to");
+
+  // per-ray state
+  private final double[] rx = new double[MAX_RAYS];   // column position (fixed)
+  private final double[] rlen = new double[MAX_RAYS]; // 0.85..1.0 coordinated length
+  private final double[] binMag = new double[MAX_RAYS];
+  private boolean inited = false;
+
+  // audio
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+  private double bassEnv = 0;
+  private double floodEnv = 0;   // sustained section fill (slow release)
+  private double bloomT = -1;    // center->rim wavefront progress, <0 idle
+  private double pulse = 0;
+  private double timeMs = 0;
+  private double dotFlow = 0;    // outward crawl of the dot chains
+  private double ringFlow = 0;
+
+  public Radiate(LX lx) {
+    // Base registers color (global hue shift), speed (crawl rate), size (dot size/spacing).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("rays", this.rays);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void initRays() {
+    for (int i = 0; i < MAX_RAYS; ++i) {
+      this.rx[i] = hashd(i * 7 + 1); // normalized 0..1 around any surface
+      this.rlen[i] = 0.85 + 0.15 * hashd(i * 31 + 11);
+    }
+    this.inited = true;
+  }
+
+  private double band(int i, int n) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    int lo = i * nb / n;
+    int hi = Math.max(lo + 1, (i + 1) * nb / n);
+    return m.getAveragef(lo, hi - lo);
+  }
+
+  private boolean detect(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 140)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    double level = m.getAveragef(0, nb);
+    double aUp = 1 - Math.exp(-deltaMs / 25.0);
+    double aDn = 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * ((level > this.levelEnv) ? aUp : aDn);
+    this.bassEnv += (bass - this.bassEnv) * ((bass > this.bassEnv) ? aUp : aDn);
+    return beat;
+  }
+
+  private double sceneHue(int which) {
+    return SCENES[((which % SCENES.length) + SCENES.length) % SCENES.length];
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    if (!this.inited) {
+      initRays();
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    final boolean beat = detect(deltaMs);
+
+    // outward crawl of dot chains: slow at rest, faster on bass
+    this.dotFlow += deltaMs * speed * (0.004 + this.bassEnv * 0.02) * DOT_SPACING;
+    this.ringFlow += deltaMs * speed * (0.002 + this.bassEnv * 0.012);
+
+    if (beat) {
+      this.pulse = 1;
+      if (this.bloomT < 0) {
+        this.bloomT = 0; // fire a center->rim brightness wavefront
+      }
+    }
+    this.pulse *= Math.exp(-deltaMs / 160.0);
+    if (this.bloomT >= 0) {
+      this.bloomT += deltaMs / BLOOM_MS;
+      if (this.bloomT >= 1.2) this.bloomT = -1;
+    }
+    // sustained section fill: fast attack, ~2s release into the breakdown
+    final double floodTarget = LXUtils.clamp(this.levelEnv * (1.4 + wow * 0.4), 0, 1);
+    final double fa = (floodTarget > this.floodEnv)
+      ? 1 - Math.exp(-deltaMs / 120.0)
+      : 1 - Math.exp(-deltaMs / 2000.0);
+    this.floodEnv += (floodTarget - this.floodEnv) * fa;
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CUBE) {
+      renderField(Apotheneum.cylinder.exterior, deltaMs);
+      copyCylinderExterior();
+    }
+    if (t != Target.CYLINDER) {
+      renderField(Apotheneum.cube.exterior, deltaMs);
+      copyCubeExterior();
+    }
+  }
+
+  private void renderField(Apotheneum.Orientation o, double deltaMs) {
+    final int w = o.width();
+    final int h = o.height();
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+
+    // palette scenes stepping through the reference arc
+    final double hueShift = LXColor.h(getColor());
+    final double sceneT = this.timeMs / SCENE_MS;
+    final int scene = (int) Math.floor(sceneT);
+    final double xfade = LXUtils.clamp((sceneT - scene) * SCENE_MS / SCENE_XFADE, 0, 1);
+    final double huePrev = sceneHue(scene - 1);
+    final double hueCur = sceneHue(scene);
+    final boolean duoNow = (hueCur == DUO);
+    final double resolvedPrev = (huePrev == DUO) ? 228 : huePrev;
+    final double resolvedCur = duoNow ? 228 : hueCur;
+    final double hueMain = LXUtils.lerp(resolvedPrev,
+      resolvedPrev + wrapDeg(resolvedCur - resolvedPrev), xfade) + hueShift;
+    final int col = LXColor.hsb((float) (((hueMain % 360) + 360) % 360), 88, 100);
+    final int hot = LXColor.lerp(col, LXColor.WHITE, 0.6f);
+    final int ringRed = LXColor.hsb((float) (((358 + hueShift) % 360)), 95, 100);
+    final int duoRed = ringRed;
+    final int duoBlue = LXColor.hsb((float) (((222 + hueShift) % 360)), 92, 100);
+
+    final boolean breakdown = this.levelEnv < 0.06;
+    final int count = Math.min(MAX_RAYS, this.rays.getValuei() + (int) Math.round(wow * 20));
+    final int nBins = Math.max(8, count / 3);
+    final double aBin = 1 - Math.exp(-deltaMs / 90.0);
+    final double dotR = 0.5 + getSize() * 0.8;
+    final double spacing = DOT_SPACING + getSize() * 1.5;
+    final double bloomFront = (this.bloomT >= 0) ? (1.0 - this.bloomT) * h : -100;
+    final double fieldB = (0.40 + 0.60 * this.floodEnv) * (1.0 + this.pulse * 0.35);
+
+    if (!breakdown) {
+      // --- dotted radial rays: bottom (center) to top (rim) ---
+      for (int i = 0; i < count; ++i) {
+        this.binMag[i] += (band(i % nBins, nBins) - this.binMag[i]) * aBin;
+        // coordinated length: the field grows and shrinks together
+        final double len = h * LXUtils.clamp(
+          0.30 + 0.65 * this.floodEnv + 0.10 * LXUtils.clamp(this.binMag[i] * 2, 0, 1), 0, 1)
+          * this.rlen[i];
+        final int x = (int) Math.round(this.rx[i] * w);
+        // DUO scene: red/blue opposition split by a slowly rotating boundary
+        int rayCol = col, rayHot = hot;
+        if (duoNow) {
+          final boolean redSide = ((this.rx[i] + this.timeMs * 0.00006) % 1.0) < 0.5;
+          rayCol = redSide ? duoRed : duoBlue;
+          rayHot = LXColor.lerp(rayCol, LXColor.WHITE, 0.6f);
+        }
+        for (int y = h - 1; y >= h - (int) len && y >= 0; --y) {
+          // dotted chain: lit only on the dot cells, crawling outward (upward)
+          final double sdot = ((h - 1 - y) + this.dotFlow) / spacing;
+          final double f = sdot - Math.floor(sdot);
+          if (f > 0.5) continue;
+          double b = fieldB * (0.45 + 0.55 * (1.0 - (double) (h - 1 - y) / Math.max(1, len)));
+          // bloom wavefront sweeping center->rim
+          if (bloomFront > -50) {
+            final double d = y - bloomFront;
+            b *= 1.0 + 1.2 * Math.exp(-d * d / 18.0);
+          }
+          // white-hot core only on the innermost dots
+          final int c = (h - 1 - y < spacing * 2) ? rayHot : rayCol;
+          splat(o, w, h, x, y, dotR, b, c);
+        }
+      }
+
+      // --- dotted concentric rings hugging the center (bottom region) ---
+      final int nRings = 3;
+      final double ringGap = h * 0.055;
+      final double ringB = fieldB * (0.5 + 0.5 * this.floodEnv);
+      final int ringDotStep = 3;
+      final double duoSpin = duoNow ? this.timeMs * 0.004 : 0;
+      for (int r = 0; r < nRings; ++r) {
+        final double ry = (r * ringGap + this.ringFlow * ringGap) % (h * 0.24);
+        final int yy = h - 2 - (int) Math.round(ry);
+        for (int x = 0; x < w; x += ringDotStep) {
+          int c = ringRed;
+          if (duoNow) {
+            c = (((x + (int) duoSpin) / (w / 4)) % 2 == 0) ? duoRed : duoBlue;
+          }
+          splat(o, w, h, x, yy, dotR, ringB * (0.8 - r * 0.18), c);
+        }
+      }
+
+      // --- sustained chromatic section fill (ambient, saturated) ---
+      if (this.floodEnv > 0.05) {
+        final double haze = (hueCur == 292 || huePrev == 292) ? 0.55 : 0.30;
+        final int fc = LXColor.scaleBrightness(
+          LXColor.hsb((float) (((hueMain % 360) + 360) % 360), 75, 100),
+          (float) (this.floodEnv * this.floodEnv * haze));
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            final int idx = o.point(x, y).index;
+            this.colors[idx] = LXColor.lightest(this.colors[idx], fc);
+          }
+        }
+      }
+
+      // --- center bloom at the floor line on hits ---
+      if (this.pulse > 0.05) {
+        for (int y = h - 5; y < h; ++y) {
+          final double g = this.pulse * (0.8 + wow * 0.5) * Math.exp(-(h - 1 - y) / 1.8);
+          for (int x = 0; x < w; ++x) {
+            splat(o, w, h, x, y, 0.8, g * 0.5, hot);
+          }
+        }
+      }
+    } else {
+      // --- starfield breakdown: sparse random white-blue twinkles ---
+      final int star = LXColor.hsb(210, 30, 100);
+      final int tq = (int) (this.timeMs / 180);
+      final int nStars = (int) (w * h * 0.012);
+      for (int k = 0; k < nStars; ++k) {
+        final int sx = (int) (hashd(k * 31 + tq * 977) * w);
+        final int sy = (int) (hashd(k * 53 + tq * 613) * h);
+        final double tw = hashd(k * 97 + tq * 131);
+        if (tw < 0.45) continue;
+        splat(o, w, h, sx, sy, 0.8, 0.25 + 0.75 * tw, (tw > 0.92) ? LXColor.WHITE : star);
+      }
+    }
+
+  }
+
+  private static double wrapDeg(double d) {
+    d = ((d % 360) + 360) % 360;
+    return (d > 180) ? d - 360 : d;
+  }
+
+  /** Soft dot; x wraps, y clips. */
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    if (bright <= 0.004) return;
+    final int y0 = (int) Math.max(0, Math.floor(y - r));
+    final int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    final int x0 = (int) Math.floor(x - r);
+    final int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      final double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        final double dx = xx - x;
+        final double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r + 0.5) continue;
+        final double u = 1.0 - dd / (r + 0.5);
+        final double f = u * u * bright;
+        if (f <= 0.004) continue;
+        final int xi = ((xx % w) + w) % w;
+        final int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(color, (float) LXUtils.clamp(f, 0, 1)));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/SafteyThird.java
+++ b/src/main/java/apotheneum/piemonte/SafteyThird.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * SafteyThird — a bold dead smiley across the whole piece, in the full-facade spirit
+ * of Ex Machina. One huge grinning face per cube facade (two around the
+ * cylinder): a bright disc textured with slow Ex Machina-style radial
+ * shimmer bands, X X eyes cut dark into the glow, and a wide smile arc.
+ * The face tilts gently side to side and pulses on beats. Wow sends it
+ * over the edge: the X eyes flash hot red, the face jitters, and hard
+ * strobe frames drop out of the disc. Hue steers the face color live;
+ * Squiggle waves the smile into a wobbling scrawl and Rotate spins the
+ * whole face.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class SafteyThird extends StrandPattern {
+
+  // face geometry in normalized disc coordinates (r = 1 at the rim)
+  private static final double EYE_X = 0.38, EYE_Y = -0.26;
+  private static final double EYE_R = 0.17;    // reach of each X arm
+  private static final double EYE_W = 0.075;   // X stroke half-width
+  private static final double MOUTH_CY = 0.02; // smile arc circle center (y)
+  private static final double MOUTH_R = 0.55;  // smile arc radius
+  private static final double MOUTH_W = 0.07;  // smile stroke half-width
+  private static final double MOUTH_MIN_Y = 0.30; // only the lower arc shows
+
+  public final CompoundParameter bands =
+    new CompoundParameter("Bands", 2.2, 0.5, 6.0)
+    .setDescription("Radial shimmer band frequency inside the face");
+
+  public final CompoundParameter squiggle =
+    new CompoundParameter("Squiggle", 0, 0, 1)
+    .setDescription("Waves the smile into an animated squiggle");
+
+  public final CompoundParameter rotate =
+    new CompoundParameter("Rotate", 0, -60, 60)
+    .setUnits(CompoundParameter.Units.DEGREES)
+    .setPolarity(CompoundParameter.Polarity.BIPOLAR)
+    .setDescription("Degrees/second the whole face spins; negative reverses");
+
+  private double shimmer = 0;
+  private double tilt = 0;
+  private double spin = 0;
+  private double squigPhase = 0;
+  private double kick = 0;
+
+  public SafteyThird(LX lx) {
+    // Base registers color (face color), speed (shimmer/tilt pace), size (face radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bands", this.bands);
+    addParameter("squiggle", this.squiggle);
+    addParameter("rotate", this.rotate);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    this.shimmer += deltaMs * 0.0005 * speed * 2;
+    this.tilt = 0.10 * Math.sin(this.timeMs * 0.0009 * speed * 2);
+    this.spin += deltaMs * 0.001 * Math.toRadians(this.rotate.getValue());
+    this.spin %= (2 * Math.PI);
+    this.squigPhase += deltaMs * 0.006 * speed * 2;
+    if (this.beat) {
+      this.kick = 1;
+    }
+    this.kick *= Math.exp(-deltaMs / 280.0);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double bandF = this.bands.getValue();
+    final int tq = (int) (this.timeMs / 70);
+
+    final int face = getColor();
+    final int rimC = LXColor.scaleBrightness(face, 0.72f);
+    final int redX = LXColor.hsb(2, 98, 100);
+
+    // Wow chaos: eye flashes, face jitter, strobe dropout frames
+    final boolean eyesHot = wow > 0.15 && ((tq / 3) % 4 == 0 || wow > 0.8);
+    final int jitter = (wow > 0.4 && hashd(tq * 7) < wow * 0.5)
+      ? (int) ((hashd(tq * 13) - 0.5) * wow * 6) : 0;
+    final boolean dropFrame = wow > 0.6 && hashd(tq * 31 + 5) < (wow - 0.6) * 0.6;
+    if (dropFrame) {
+      return; // hard strobe blackout frame
+    }
+
+    final int nFaces = isCube ? 4 : 2; // one per cube facade, two on the cylinder
+    final int half = w / (2 * nFaces);
+    final double R = Math.min(half, h * 0.5) * (0.62 + getSize() * 0.55)
+      * (1 + this.kick * 0.06);
+    final double cy = h * 0.48;
+    final double ang = this.tilt + this.spin;
+    final double cosT = Math.cos(ang), sinT = Math.sin(ang);
+    final double squig = this.squiggle.getValue();
+
+    for (int f = 0; f < nFaces; ++f) {
+      final int cx = (int) ((f + 0.5) * w / (double) nFaces) + jitter;
+      for (int dx = -half; dx < half; ++dx) {
+        final int x = ((cx + dx) % w + w) % w;
+        for (int y = 0; y < h; ++y) {
+          // head-tilt rotation into normalized face coordinates
+          final double rx = (dx * cosT - (y - cy) * sinT) / R;
+          final double ry = (dx * sinT + (y - cy) * cosT) / R;
+          final double r = Math.sqrt(rx * rx + ry * ry);
+          if (r > 1.03) continue;
+          final double edge = LXUtils.clamp((1.0 - r) * R + 1.0, 0, 1);
+
+          // X X eyes: diagonal cross strokes, mirrored left/right
+          final double eu = Math.abs(Math.abs(rx) - EYE_X);
+          final double ev = ry - EYE_Y;
+          final boolean inEyeBox = eu < EYE_R && Math.abs(ev) < EYE_R;
+          final boolean inX = inEyeBox
+            && Math.abs(eu - Math.abs(ev)) < EYE_W;
+
+          // the smile: lower arc of an offset circle; Squiggle waves it
+          final double rm = Math.sqrt(rx * rx + (ry - MOUTH_CY) * (ry - MOUTH_CY));
+          double mouthR = MOUTH_R;
+          if (squig > 0) {
+            final double th = Math.atan2(rx, ry - MOUTH_CY);
+            mouthR += squig * 0.11
+              * Math.sin(th * 9 + this.squigPhase);
+          }
+          final boolean inMouth = ry > MOUTH_MIN_Y
+            && Math.abs(rm - mouthR) < MOUTH_W;
+
+          if (inX) {
+            if (eyesHot) { // Wow: the X eyes burn red
+              addPix(o, x, y, redX, edge);
+            }
+            continue; // otherwise cut dark into the glow
+          }
+          if (inMouth) {
+            continue; // the smile stays dark
+          }
+
+          // the disc: Ex Machina-style radial shimmer bands
+          final double wave = 0.5 + 0.5
+            * Math.cos((r * bandF - this.shimmer) * 2 * Math.PI);
+          final double bb = (0.55 + 0.45 * Math.pow(wave, 1.6))
+            * (0.92 + 0.08 * hashd(x * 131 + y * 7 + tq))
+            * (1 + this.kick * 0.20);
+          addPix(o, x, y, (r > 0.92) ? rimC : face, Math.min(1, bb * edge));
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * StrandPattern — shared engine for the "hanging light-strand curtain" family of
+ * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
+ * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
+ * vertical strands of light with a top-lit drip gradient, glowing floor pools,
+ * comet rain, and heavy audio reactivity. Subclasses implement one "program"
+ * each; this base provides the column/drip/pool math, a comet renderer,
+ * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
+ * attack/release envelope, coarse FFT bins).
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+public abstract class StrandPattern extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  // --- audio state, computed once per frame ---
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  /** True on the frame a bass onset fires. */
+  protected boolean beat;
+  /** Normalized bass onset strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Broadband level envelope: 25ms attack / 220ms release. */
+  protected double levelEnv;
+  protected double timeMs = 0;
+
+  protected StrandPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addParameter("target", this.target);
+  }
+
+  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  private void stepAudio(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    this.beat = (bass > this.bassAvg * beatThreshold())
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 130)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+  }
+
+  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
+  protected double band(int i, int n) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    int lo = i * nb / n;
+    int hi = Math.max(lo + 1, (i + 1) * nb / n);
+    return m.getAveragef(lo, hi - lo);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+    stepAudio(deltaMs);
+    advance(deltaMs);
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      renderStrands(Apotheneum.cube.exterior, deltaMs, true);
+    }
+    if (t != Target.CUBE) {
+      renderStrands(Apotheneum.cylinder.exterior, deltaMs, false);
+    }
+    copyExterior();
+  }
+
+  /** Per-frame global state update before surfaces render. */
+  protected void advance(double deltaMs) {}
+
+  /** Draw one surface's strand program. Called for cube and/or cylinder exterior. */
+  protected abstract void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube);
+
+  // ------------------------------------------------------------------
+  // strand look utilities
+
+  /** Top-lit drip gradient: strands are brightest at the hang point. */
+  protected static double drip(int y, int h) {
+    return 1.0 - 0.35 * (double) y / Math.max(1, h - 1);
+  }
+
+  /** Additive floor-pool boost for the bottom rows (strand puddles glowing). */
+  protected static double pool(int y, int h) {
+    int fromBottom = (h - 1) - y;
+    if (fromBottom >= 4) return 0;
+    return 0.35 * (1.0 - fromBottom / 4.0);
+  }
+
+  /**
+   * Mirror the rows above the floor line into the bottom rows at reduced gain —
+   * the reflective-floor signature. Call AFTER drawing surface content.
+   */
+  protected void mirrorFloor(Apotheneum.Orientation o, int rows, float gain) {
+    final int w = o.width();
+    final int h = o.height();
+    final int axis = h - rows;
+    for (int x = 0; x < w; ++x) {
+      for (int y = axis; y < h; ++y) {
+        int src = 2 * axis - 1 - y;
+        if (src < 0) continue;
+        int c = this.colors[o.point(x, src).index];
+        int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, gain));
+      }
+    }
+  }
+
+  /** Additive pixel write with wrapped x; y outside the surface is dropped. */
+  protected void addPix(Apotheneum.Orientation o, int x, int y, int color, double b) {
+    if (b <= 0.004) return;
+    final int h = o.height();
+    if (y < 0 || y >= h) return;
+    final int w = o.width();
+    final int xi = ((x % w) + w) % w;
+    final int idx = o.point(xi, y).index;
+    this.colors[idx] = LXColor.lightest(this.colors[idx],
+      LXColor.scaleBrightness(color, (float) LXUtils.clamp(b, 0, 1)));
+  }
+
+  /**
+   * Falling comet: sub-pixel head at (x, y) with an exponential tail rising
+   * above it. White-hot head when hot is true.
+   */
+  protected void comet(Apotheneum.Orientation o, double x, double y, double tail,
+      int color, double bright, boolean hot) {
+    final int xi = (int) Math.round(x);
+    final int head = (int) Math.floor(y);
+    final double hf = y - head;
+    final int n = Math.max(1, (int) tail);
+    final int headColor = hot ? LXColor.lerp(color, LXColor.WHITE, 0.55f) : color;
+    for (int k = 0; k <= n; ++k) {
+      double b = bright * Math.exp(-2.2 * k / tail);
+      addPix(o, xi, head - k, (k == 0) ? headColor : color, (k == 0) ? b * (0.4 + 0.6 * hf) : b);
+    }
+    addPix(o, xi, head + 1, headColor, bright * hf * 0.5);
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -7,10 +7,10 @@
  * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
  * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
  * vertical strands of light with a top-lit drip gradient, glowing floor pools,
- * comet rain, and heavy audio reactivity. Subclasses implement one "program"
- * each; this base provides the column/drip/pool math, a comet renderer,
- * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
- * attack/release envelope, coarse FFT bins).
+ * comet rain, and audio reactivity driven by the external Level/Pulse inputs
+ * on ParameterPattern. Subclasses implement one "program" each; this base
+ * provides the column/drip/pool math, a comet renderer, and wrapped-x pixel
+ * writes.
  */
 
 package apotheneum.piemonte;
@@ -18,30 +18,9 @@ package apotheneum.piemonte;
 import apotheneum.Apotheneum;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 public abstract class StrandPattern extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
-
-  // --- audio state, computed once per frame ---
-  private double bassAvg, prevBass, sinceBeatMs = 1e9;
-  /** True on the frame a bass onset fires. */
-  protected boolean beat;
-  /** Normalized bass onset strength 0..1 for the current frame. */
-  protected double beatLevel;
-  /** Broadband level envelope: 25ms attack / 220ms release. */
-  protected double levelEnv;
-  protected double timeMs = 0;
 
   protected StrandPattern(LX lx,
       double speedDef, double speedMin, double speedMax,
@@ -49,56 +28,13 @@ public abstract class StrandPattern extends ParameterPattern {
     super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
   }
 
-  /** Subclasses call this LAST in their constructor to keep Target at the end. */
-  protected void addTargetParameter() {
-    addParameter("target", this.target);
-  }
-
-  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
-  protected double beatThreshold() {
-    return 1.4;
-  }
-
-  private void stepAudio(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
-    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
-    this.sinceBeatMs += deltaMs;
-    this.beat = (bass > this.bassAvg * beatThreshold())
-      && (bass > this.prevBass)
-      && (this.sinceBeatMs >= 130)
-      && (bass > 0.01);
-    this.prevBass = bass;
-    if (this.beat) {
-      this.sinceBeatMs = 0;
-    }
-    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
-
-    double level = m.getAveragef(0, nb);
-    double alpha = (level > this.levelEnv)
-      ? 1 - Math.exp(-deltaMs / 25.0)
-      : 1 - Math.exp(-deltaMs / 220.0);
-    this.levelEnv += (level - this.levelEnv) * alpha;
-  }
-
-  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
-  protected double band(int i, int n) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    int lo = i * nb / n;
-    int hi = Math.max(lo + 1, (i + 1) * nb / n);
-    return m.getAveragef(lo, hi - lo);
-  }
-
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
-    this.timeMs += deltaMs;
     stepAudio(deltaMs);
     advance(deltaMs);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       renderStrands(Apotheneum.cube.exterior, deltaMs, true);
     }

--- a/src/main/java/apotheneum/piemonte/Sunrise.java
+++ b/src/main/java/apotheneum/piemonte/Sunrise.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Sunrise — a sun literally rises from the bottom of each facade. The disc
+ * climbs from below the horizon — huge, molten, all orange and yellow —
+ * radiating thick yellow and orange beams outward at angled directions. The higher the sun climbs, the more beams break out, each one
+ * flaring in from nothing and swaying gently as it burns. At the peak the
+ * day turns and the sun eases back down, beams folding away, before dawn
+ * breaks again. Beats flare the beams; Wow speeds the sway and sharpens the
+ * flare.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Sunrise extends StrandPattern {
+
+  private static final int MAX_BEAMS = 24;
+  private static final double CYCLE_MS = 52000;  // full rise-and-set at speed 0.5
+  private static final double Y_LOW = 1.14;      // start below the horizon
+  private static final double Y_HIGH = 0.28;     // peak height (0 = top)
+
+  public final DiscreteParameter beams =
+    new DiscreteParameter("Beams", 16, 6, MAX_BEAMS)
+    .setDescription("Beams radiating at full rise");
+
+  // per-frame beam table (no per-pixel trig re-derivation)
+  private final double[] beamAng = new double[MAX_BEAMS];
+  private final double[] beamHw = new double[MAX_BEAMS];
+  private final double[] beamVis = new double[MAX_BEAMS];
+  private final boolean[] beamWhite = new boolean[MAX_BEAMS];
+
+  private double phase = 0; // 0..1 around the rise-and-set cycle
+  private double flare = 0; // beat flare envelope
+
+  public Sunrise(LX lx) {
+    // Base registers color (sun hue anchor), speed (day pace), size (sun radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("beams", this.beams);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** How far the sun has risen, 0..1, easing at both horizon and peak. */
+  private double riseAmount() {
+    final double tri = 1.0 - Math.abs(1.0 - 2.0 * this.phase); // rise then set
+    return tri * tri * (3 - 2 * tri);
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    this.phase += deltaMs * speed * 2 / CYCLE_MS;
+    this.phase -= Math.floor(this.phase);
+
+    if (this.beat) {
+      this.flare = 1;
+    }
+    this.flare *= Math.exp(-deltaMs / 300.0);
+
+    // beam table: angles fan the sky, swaying gently; more break out with rise
+    final double rise = riseAmount();
+    final double wow = getWow();
+    final int n = this.beams.getValuei();
+    final double sway = this.timeMs * 0.001 * (0.25 + wow * 1.1);
+    for (int i = 0; i < n; ++i) {
+      // spread over the full circle; low-threshold beams appear first
+      this.beamAng[i] = (double) i / n * 2 * Math.PI
+        + hashd(i * 77 + 5) * 0.5
+        + Math.sin(sway + hashd(i * 31) * 6.28) * (0.05 + wow * 0.10);
+      this.beamHw[i] = Math.toRadians(5 + 7 * hashd(i * 131 + 9)); // thick
+      final double thr = hashd(i * 53 + 3) * 0.8;
+      this.beamVis[i] = LXUtils.clamp((rise - thr) / 0.12, 0, 1);
+      this.beamWhite[i] = (i % 3) == 2; // every third beam burns orange
+    }
+  }
+
+  private static double angDiff(double a, double b) {
+    double d = a - b;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    return d;
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double rise = riseAmount();
+    final double wow = getWow();
+    final int n = this.beams.getValuei();
+    final int tq = (int) (this.timeMs / 90);
+
+    final float hue = (LXColor.h(getColor()) + 46) % 360; // Hue 0 = classic yellow sun
+    final int core = LXColor.hsb(hue, 42, 100);            // molten yellow center
+    final int body = LXColor.hsb(hue, 88, 100);            // yellow
+    final int rim = LXColor.hsb((hue + 22) % 360, 95, 96); // orange edge/halo
+    final int beamY = LXColor.hsb(hue, 80, 100);
+    final int beamW = LXColor.hsb((hue + 24) % 360, 92, 100); // orange beams
+
+    final double R = (0.20 + getSize() * 0.35) * h; // sun radius in rows
+    final double yc = LXUtils.lerp(Y_LOW, Y_HIGH, rise);
+    final double sunY = yc * (h - 1);
+    final double beamGain = (0.75 + 0.25 * this.levelEnv + this.flare * 0.5)
+      * LXUtils.clamp(rise * 3, 0, 1);
+
+    final int nSuns = isCube ? 4 : 2; // one per cube face, two on the cylinder
+    final int half = w / (2 * nSuns);
+
+    for (int s = 0; s < nSuns; ++s) {
+      final int cx = (int) ((s + 0.5) * w / (double) nSuns);
+      for (int dx = -half; dx < half; ++dx) {
+        final int x = ((cx + dx) % w + w) % w;
+        for (int y = 0; y < h; ++y) {
+          final double ddy = sunY - y; // positive above the sun
+          final double r = Math.sqrt(dx * dx + ddy * ddy);
+
+          if (r <= R + 1.5) { // the disc: white core to yellow to orange rim
+            final double u = r / R;
+            final double edge = LXUtils.clamp(R + 1.0 - r, 0, 1);
+            final int c = (u < 0.45) ? core
+              : (u < 0.85) ? LXColor.lerp(body, core,
+                  (float) ((0.85 - u) / 0.40) * 0.5f)
+              : LXColor.lerp(rim, body, (float) LXUtils.clamp((1.0 - u) / 0.15, 0, 1));
+            final double boil = 0.92 + 0.08 * hashd(x * 131 + y * 7 + tq);
+            addPix(o, x, y, c, edge * boil);
+            continue;
+          }
+
+          // warm halo hugging the disc
+          final double halo = Math.exp(-(r - R) / (R * 0.55)) * 0.45;
+          if (halo > 0.02) {
+            addPix(o, x, y, rim, halo);
+          }
+
+          // the beams: thick angled rays, more of them the higher the sun
+          final double ang = Math.atan2(-ddy, dx); // -π/2 = straight up... flip below
+          double bb = 0;
+          boolean white = false;
+          for (int i = 0; i < n; ++i) {
+            if (this.beamVis[i] <= 0) continue;
+            final double d = Math.abs(angDiff(ang, this.beamAng[i]));
+            if (d >= this.beamHw[i]) continue;
+            final double aFall = 1.0 - (d / this.beamHw[i]) * (d / this.beamHw[i]);
+            final double rFall = Math.exp(-1.5 * (r - R) / h);
+            final double v = this.beamVis[i] * aFall * rFall;
+            if (v > bb) {
+              bb = v;
+              white = this.beamWhite[i];
+            }
+          }
+          if (bb > 0.02) {
+            final double tw = 0.85 + 0.15 * hashd(x * 977 + y * 53 + tq * 7);
+            addPix(o, x, y, white ? beamW : beamY,
+              Math.min(1, bb * beamGain * tw * (1 + wow * 0.3)));
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Superbloom.java
+++ b/src/main/java/apotheneum/piemonte/Superbloom.java
@@ -21,17 +21,10 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Superbloom extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_FLOWERS = 12;
   private static final double BUD_MS = 900;
@@ -53,10 +46,6 @@ public class Superbloom extends ParameterPattern {
   public final DiscreteParameter flowers =
     new DiscreteParameter("Flowers", 6, 1, MAX_FLOWERS)
     .setDescription("How many flowers live in the garden at once");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -92,7 +81,7 @@ public class Superbloom extends ParameterPattern {
     // Base registers color (garden hue anchor), speed (tempo), size (bloom radius).
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("flowers", this.flowers);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -177,12 +166,10 @@ public class Superbloom extends ParameterPattern {
   }
 
   private boolean detectBeat(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
-    boolean beat = (bass > this.bassAvg * 1.3)
+    boolean beat = pulseHit() || (bass > this.bassAvg * 1.3)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= MIN_BEAT_MS)
       && (bass > 0.01);
@@ -191,7 +178,7 @@ public class Superbloom extends ParameterPattern {
       this.sinceBeatMs = 0;
     }
     // broadband level envelope: snappy attack, easy release
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0)
       : 1 - Math.exp(-deltaMs / 220.0);
@@ -208,7 +195,7 @@ public class Superbloom extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
       this.inited = false;

--- a/src/main/java/apotheneum/piemonte/Superbloom.java
+++ b/src/main/java/apotheneum/piemonte/Superbloom.java
@@ -1,0 +1,431 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Superbloom — rare rains hit the desert and the whole canvas erupts. Giant
+ * green pixel-chunk buds appear scattered across the surface, swell, then
+ * blossom open into top-down flowers in wild multi-colors all their own: six
+ * species, each with two or three petal colors alternating around the bloom. The open flowers turn with the music — spinning
+ * up as the level swells, pulsing on beats — and after a lifetime each bloom
+ * folds away, its place taken by a fresh bud somewhere new. Wow pushes the
+ * garden into overdrive: harder beat-pulses, shimmering petals, faster unfurl.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Superbloom extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_FLOWERS = 12;
+  private static final double BUD_MS = 900;
+  private static final double UNFURL_MS = 1500;
+  private static final double WILT_MS = 950;
+  private static final double MIN_BEAT_MS = 150;
+  private static final double TAU = Math.PI * 2;
+
+  // --- the six species: petals, petal sharpness, connected-core size, inner
+  // layer (scale, angular offset; 0 = none), palette hue offsets, center size ---
+  private static final int[]      F_PETALS = {  8,    6,   12,    5,   10,    5  };
+  private static final double[]   F_SHARP  = { 1.8,  3.0,  4.0,  1.2,  2.2,  1.6 };
+  private static final double[]   F_CMIN   = { 0.10, 0.12, 0.08, 0.18, 0.10, 0.15 };
+  private static final double[]   F_INNER  = {  0,   0.55,  0,    0,   0.60, 0.50 };
+  private static final double[][] F_HUES   = { {0, 40}, {0, 150, 210}, {0, 25},
+                                               {0, 180}, {0, 90, 320}, {0, 60} };
+  private static final double[]   F_CENTER = { 0.14, 0.12, 0.22, 0.13, 0.12, 0.16 };
+
+  public final DiscreteParameter flowers =
+    new DiscreteParameter("Flowers", 6, 1, MAX_FLOWERS)
+    .setDescription("How many flowers live in the garden at once");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final boolean wrap;
+    Panel(int[][] idx, int w, int h, boolean wrap) {
+      this.idx = idx; this.w = w; this.h = h; this.wrap = wrap;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  private final int[] fpanel = new int[MAX_FLOWERS];
+  private final int[] ftype = new int[MAX_FLOWERS];
+  private final double[] fx = new double[MAX_FLOWERS];
+  private final double[] fy = new double[MAX_FLOWERS];
+  private final double[] fr = new double[MAX_FLOWERS];    // full-bloom radius
+  private final double[] fage = new double[MAX_FLOWERS];
+  private final double[] flife = new double[MAX_FLOWERS]; // bloom hold duration
+  private final double[] frot = new double[MAX_FLOWERS];
+  private final double[] fdir = new double[MAX_FLOWERS];
+  private final double[] fhue = new double[MAX_FLOWERS]; // each flower's own hue
+  private final double[] fpulse = new double[MAX_FLOWERS];
+  private final boolean[] falive = new boolean[MAX_FLOWERS];
+  private boolean inited = false;
+
+  // audio: level envelope spins the garden, beats make it pulse
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+
+  public Superbloom(LX lx) {
+    // Base registers color (garden hue anchor), speed (tempo), size (bloom radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("flowers", this.flowers);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, false));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int w = o.width();
+      int h = o.height();
+      int[][] g = new int[w][h];
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          g[x][y] = o.point(x, y).index;
+        }
+      }
+      list.add(new Panel(g, w, h, true));
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private void spawn(int i, boolean scatterAge) {
+    // panel weighted by width
+    int total = 0;
+    for (Panel p : this.panels) total += p.w;
+    final double radius = (6 + getSize() * 14) * (0.8 + 0.4 * Math.random());
+
+    // a few placement attempts to avoid piling on a living neighbor
+    int bestPanel = 0;
+    double bestX = 0, bestY = 0, bestScore = -1;
+    for (int attempt = 0; attempt < 8; ++attempt) {
+      int pick = (int) (Math.random() * total);
+      int pi = 0;
+      for (int k = 0; k < this.panels.length; ++k) {
+        pick -= this.panels[k].w;
+        if (pick < 0) { pi = k; break; }
+      }
+      final Panel p = this.panels[pi];
+      final double cx = p.wrap ? Math.random() * p.w
+        : radius * 0.5 + Math.random() * (p.w - radius);
+      final double cy = p.h * (0.22 + Math.random() * 0.56);
+      double nearest = 1e9;
+      for (int k = 0; k < MAX_FLOWERS; ++k) {
+        if (!this.falive[k] || k == i || this.fpanel[k] != pi) continue;
+        double dx = Math.abs(this.fx[k] - cx);
+        if (p.wrap) dx = Math.min(dx, p.w - dx);
+        final double dy = this.fy[k] - cy;
+        nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy) - this.fr[k]);
+      }
+      if (nearest > bestScore) {
+        bestScore = nearest;
+        bestPanel = pi;
+        bestX = cx;
+        bestY = cy;
+      }
+    }
+
+    this.fpanel[i] = bestPanel;
+    this.fx[i] = bestX;
+    this.fy[i] = bestY;
+    this.fr[i] = radius;
+    this.ftype[i] = (int) (Math.random() * F_PETALS.length);
+    this.fhue[i] = Math.random() * 360; // wild-type color, independent of the palette
+    this.flife[i] = 7000 + Math.random() * 7000;
+    this.fage[i] = scatterAge ? Math.random() * (BUD_MS + UNFURL_MS + this.flife[i]) : 0;
+    this.frot[i] = Math.random() * TAU;
+    this.fdir[i] = (Math.random() < 0.5) ? 1 : -1;
+    this.fpulse[i] = 0;
+    this.falive[i] = true;
+  }
+
+  private boolean detectBeat(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    boolean beat = (bass > this.bassAvg * 1.3)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= MIN_BEAT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    // broadband level envelope: snappy attack, easy release
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+    return beat;
+  }
+
+  private static double smooth(double u) {
+    u = LXUtils.clamp(u, 0, 1);
+    return u * u * (3 - 2 * u);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+      this.inited = false;
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+    if (!this.inited) {
+      for (int i = 0; i < MAX_FLOWERS; ++i) {
+        this.falive[i] = false;
+      }
+      final int n0 = this.flowers.getValuei();
+      for (int i = 0; i < n0; ++i) {
+        spawn(i, true); // staggered ages so the garden isn't synchronized
+      }
+      this.inited = true;
+    }
+
+    final boolean beat = detectBeat(deltaMs);
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    final double dt = deltaMs * (0.4 + speed * 1.6);
+    final int want = this.flowers.getValuei();
+    // rotation: gentle drift, spun up hard by the music
+    final double spin = deltaMs * speed * 0.00055 * (1.0 + this.levelEnv * 3.0 + wow * 0.5);
+
+    int alive = 0;
+    for (int i = 0; i < MAX_FLOWERS; ++i) {
+      if (this.falive[i]) ++alive;
+    }
+
+    for (int i = 0; i < MAX_FLOWERS; ++i) {
+      if (!this.falive[i]) {
+        if (alive < want) {
+          spawn(i, false);
+          ++alive;
+        } else {
+          continue;
+        }
+      } else if (alive > want && this.fage[i] < BUD_MS) {
+        // thin unopened buds when the Flowers knob comes down
+        this.falive[i] = false;
+        --alive;
+        continue;
+      }
+
+      this.fage[i] += dt;
+      this.frot[i] += spin * this.fdir[i];
+      if (beat) {
+        this.fpulse[i] = 1;
+      }
+      this.fpulse[i] *= Math.exp(-deltaMs / 180.0);
+
+      final double totalLife = BUD_MS + UNFURL_MS + this.flife[i] + WILT_MS;
+      if (this.fage[i] >= totalLife) {
+        this.falive[i] = false;
+        spawn(i, false); // a new bud opens somewhere else
+      }
+
+      draw(i, wow);
+    }
+
+    copyExterior();
+  }
+
+  private void draw(int i, double wow) {
+    final Panel p = this.panels[this.fpanel[i]];
+    final int type = this.ftype[i];
+    final double age = this.fage[i];
+    final double pulse = this.fpulse[i] * (0.5 + wow);
+
+    // lifecycle scales
+    double open;   // 0 = closed bud, 1 = fully open
+    double scale;  // overall size envelope
+    if (age < BUD_MS) {
+      open = 0;
+      scale = smooth(age / BUD_MS);
+    } else if (age < BUD_MS + UNFURL_MS) {
+      open = smooth((age - BUD_MS) / (UNFURL_MS / (1.0 + wow * 0.6)));
+      scale = 1;
+    } else if (age < BUD_MS + UNFURL_MS + this.flife[i]) {
+      open = 1;
+      scale = 1;
+    } else {
+      open = 1;
+      final double wt = (age - BUD_MS - UNFURL_MS - this.flife[i]) / WILT_MS;
+      scale = 1 - smooth(wt);
+    }
+    if (scale <= 0.01) return;
+
+    final double R = this.fr[i] * scale * (1.0 + pulse * 0.07);
+    final int petals = F_PETALS[type];
+    final double sharp = F_SHARP[type];
+    final double cmin = F_CMIN[type];
+    final double inner = F_INNER[type];
+    final double[] hues = F_HUES[type];
+    final double centerR = F_CENTER[type] * R;
+
+    // petal palette: this flower's own wild hue plus its species offsets
+    final float flowerHue = (float) this.fhue[i];
+    final int nc = hues.length;
+    final double rot = this.frot[i];
+    final double petalLen = R * (0.25 + 0.75 * open);
+    final double pulseBright = 1.0 + pulse * 0.45;
+    final int centerCol = LXColor.hsb(48, 70, 100); // golden stamen
+
+    // Wow: continued blooming — once open, an extra ring of large petals keeps
+    // growing outward through the bloom hold, reaching further the higher the dial
+    final double holdT = LXUtils.clamp(
+      (age - BUD_MS - UNFURL_MS) / Math.max(1.0, this.flife[i]), 0, 1);
+    final double expand = (wow > 0.05 && open >= 1)
+      ? smooth(LXUtils.clamp(holdT * (1.2 + wow * 1.4), 0, 1)) * wow : 0;
+    final double Rx = R * (1.0 + 0.85 * expand); // expanded reach
+    final double petalLen2 = Rx;
+
+    final int y0 = (int) Math.max(0, Math.floor(this.fy[i] - Rx - 1));
+    final int y1 = (int) Math.min(p.h - 1, Math.ceil(this.fy[i] + Rx + 1));
+    final int x0 = (int) Math.floor(this.fx[i] - Rx - 1);
+    final int x1 = (int) Math.ceil(this.fx[i] + Rx + 1);
+
+    for (int yy = y0; yy <= y1; ++yy) {
+      final double dy = yy - this.fy[i];
+      for (int xx = x0; xx <= x1; ++xx) {
+        final double dx = xx - this.fx[i];
+
+        int c = 0;
+        double b = 0;
+
+        if (open <= 0) {
+          // --- bud: a giant chunky pixel, quantized into blocks ---
+          final double q = Math.max(2, R * 0.16);
+          final double bxq = Math.floor(dx / q) * q + q * 0.5;
+          final double byq = Math.floor(dy / q) * q + q * 0.5;
+          final double budR = R * 0.30;
+          if (Math.max(Math.abs(bxq), Math.abs(byq)) < budR) {
+            final int bi = (int) Math.floor(dx / q) * 7 + (int) Math.floor(dy / q) * 131;
+            final double v = 0.55 + 0.45 * hashd(bi + i * 977);
+            // young buds are green, in blocky shades like unripe growth
+            c = LXColor.hsb((float) (100 + 32 * hashd(bi * 13 + i * 331)),
+              (float) (78 + 17 * hashd(bi * 29 + 5)), 100);
+            b = scale * v * (0.75 + 0.25 * Math.sin(age * 0.006)); // breathing
+          }
+        } else {
+          final double d = Math.sqrt(dx * dx + dy * dy);
+          if (d <= Rx + 1) {
+            final double theta = Math.atan2(dy, dx) - rot;
+            // continued-bloom ring: large petals growing outward past the flower
+            if (expand > 0.02 && d > R * 0.82) {
+              final double aX = (theta + Math.PI / petals) * petals * 0.5;
+              final double prX = Math.pow(Math.abs(Math.cos(aX)), sharp * 0.7);
+              final double edgeX = petalLen2 * (cmin + (1 - cmin) * prX);
+              if (d < edgeX) {
+                final int pidxX = (int) Math.floor((theta + Math.PI / petals) / (TAU / petals) + 0.5);
+                final int ciX = (((pidxX + 2) % nc) + nc) % nc;
+                final double uX = 1 - (d - R * 0.82) / Math.max(1e-3, edgeX - R * 0.82);
+                c = LXColor.hsb((flowerHue + (float) hues[ciX]) % 360,
+                  (float) (78 - 18 * uX), 100);
+                b = (0.30 + 0.55 * smooth(uX)) * pulseBright * expand;
+              }
+            }
+            // outer petal ring
+            double a = theta * petals * 0.5;
+            final double pr = Math.pow(Math.abs(Math.cos(a)), sharp);
+            final double edge = petalLen * (cmin + (1 - cmin) * pr);
+            if (d < edge) {
+              final int pidx = (int) Math.floor(theta / (TAU / petals) + 0.5);
+              final int ci = ((pidx % nc) + nc) % nc;
+              final double u = 1 - d / Math.max(1e-3, edge);
+              c = LXColor.hsb((flowerHue + (float) hues[ci]) % 360, (float) (88 - 20 * u), 100);
+              b = (0.40 + 0.60 * smooth(u * 1.4)) * pulseBright;
+              // vein highlight down the middle of each petal
+              b *= 1.0 + 0.35 * Math.pow(pr, 6);
+            }
+            // inner petal ring, offset half a petal, layered on top
+            if (inner > 0) {
+              final double thetaI = theta + Math.PI / petals;
+              final double ai = thetaI * petals * 0.5;
+              final double pri = Math.pow(Math.abs(Math.cos(ai)), sharp);
+              final double edgeI = petalLen * inner * (cmin + (1 - cmin) * pri);
+              if (d < edgeI) {
+                final int pidx = (int) Math.floor(thetaI / (TAU / petals) + 0.5);
+                final int ci = ((pidx + 1) % nc + nc) % nc;
+                final double u = 1 - d / Math.max(1e-3, edgeI);
+                c = LXColor.hsb((flowerHue + (float) hues[ci]) % 360, (float) (80 - 25 * u), 100);
+                b = (0.55 + 0.45 * smooth(u)) * pulseBright;
+              }
+            }
+            // stamen: warm bright center disc
+            if (d < centerR * (0.4 + 0.6 * open)) {
+              final double u = 1 - d / Math.max(1e-3, centerR);
+              c = LXColor.lerp(centerCol, LXColor.WHITE, (float) (u * 0.5));
+              b = (0.8 + 0.2 * u) * pulseBright;
+            }
+            // petal shimmer at high wow
+            if (b > 0 && wow > 0.3) {
+              b *= 1.0 + (wow - 0.3) * 0.5 * hashd(xx * 131 + yy * 7 + (int) (age * 0.02));
+            }
+          }
+        }
+
+        if (b <= 0.004) continue;
+        int xi = xx;
+        if (xi < 0 || xi >= p.w) {
+          if (!p.wrap) continue;
+          xi = ((xi % p.w) + p.w) % p.w;
+        }
+        final int idx = p.idx[xi][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+      }
+    }
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/TheHumanRace.java
+++ b/src/main/java/apotheneum/piemonte/TheHumanRace.java
@@ -20,18 +20,11 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class TheHumanRace extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int NUM = 2600;         // figure pool
   private static final int CLUSTERS = 44;
@@ -60,10 +53,6 @@ public class TheHumanRace extends ParameterPattern {
   public final CompoundParameter horizon =
     new CompoundParameter("Horizon", 0.14, 0.02, 0.45)
     .setDescription("Where the horizon sits (lower = more landscape, less sky)");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -96,7 +85,7 @@ public class TheHumanRace extends ParameterPattern {
     addParameter("terrain", this.terrain);
     addParameter("specks", this.specks);
     addParameter("horizon", this.horizon);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildCrowd() {
@@ -170,7 +159,7 @@ public class TheHumanRace extends ParameterPattern {
     if (!this.crowdBuilt) {
       buildCrowd();
     }
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/TheHumanRace.java
+++ b/src/main/java/apotheneum/piemonte/TheHumanRace.java
@@ -1,0 +1,301 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * TheHumanRace — a vast landscape scattered with little glowing stick figures,
+ * gathered in loose bunches and stretching to a horizon. A slow camera drifts
+ * and pans across them, and because each face of the sculpture looks out in its
+ * own direction the crowd wraps around you in a 360 degree panorama. Most figures
+ * glow pale blue-white; a few are vivid specks. They sway as if walking.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class TheHumanRace extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int NUM = 2600;         // figure pool
+  private static final int CLUSTERS = 44;
+  private static final double AREA = 70;       // half-size of the field (world units)
+  private static final double PERIOD = 2 * AREA; // toroidal wrap so the camera glides forever
+  private static final double NEAR = 1.0;
+  private static final double H_EYE = 2.6;     // camera height above the ground
+  private static final double GLIDE = 0.005;   // world units / ms at speed 1
+  private static final double FAR = 46;        // distance where the crowd fogs out
+  private static final double TERR_FREQ = 0.055; // terrain feature scale
+  private static final double TERR_MAXH = 4.5;   // max hill/mountain height (world units)
+  private static final float PALE_SAT = 22;
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 2200, 200, NUM)
+    .setDescription("How many figures are drawn");
+
+  public final CompoundParameter terrain =
+    new CompoundParameter("Terrain", 0.6, 0, 1)
+    .setDescription("Height of the hills and mountains");
+
+  public final CompoundParameter specks =
+    new CompoundParameter("Specks", 0.15, 0, 1)
+    .setDescription("Fraction of figures that are vivid colored specks");
+
+  public final CompoundParameter horizon =
+    new CompoundParameter("Horizon", 0.14, 0.02, 0.45)
+    .setDescription("Where the horizon sits (lower = more landscape, less sky)");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final double facing; // world yaw this panel looks toward
+    Panel(int[][] idx, int w, int h, double facing) {
+      this.idx = idx; this.w = w; this.h = h; this.facing = facing;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  // crowd (built once)
+  private final double[] fx = new double[NUM];
+  private final double[] fz = new double[NUM];
+  private final double[] speckHue = new double[NUM];
+  private final double[] speckRand = new double[NUM];
+  private final double[] wphase = new double[NUM];
+  private final double[] wspeed = new double[NUM];
+  private final double[] fh = new double[NUM]; // terrain height under each figure
+  private boolean crowdBuilt = false;
+
+  private double camX = 0, camZ = 0, timeMs = 0;
+
+  public TheHumanRace(LX lx) {
+    // Base registers color (crowd tint), speed (camera + walk), size (figure size).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("terrain", this.terrain);
+    addParameter("specks", this.specks);
+    addParameter("horizon", this.horizon);
+    addParameter("target", this.target);
+  }
+
+  private void buildCrowd() {
+    double[] cxs = new double[CLUSTERS];
+    double[] czs = new double[CLUSTERS];
+    for (int c = 0; c < CLUSTERS; ++c) {
+      cxs[c] = (Math.random() * 2 - 1) * AREA;
+      czs[c] = (Math.random() * 2 - 1) * AREA;
+    }
+    for (int i = 0; i < NUM; ++i) {
+      if (Math.random() < 0.8) {
+        int c = (int) (Math.random() * CLUSTERS);
+        double sigma = 4 + Math.random() * 8;
+        this.fx[i] = cxs[c] + (Math.random() - Math.random()) * sigma;
+        this.fz[i] = czs[c] + (Math.random() - Math.random()) * sigma;
+      } else {
+        this.fx[i] = (Math.random() * 2 - 1) * AREA;
+        this.fz[i] = (Math.random() * 2 - 1) * AREA;
+      }
+      this.fh[i] = Noise.stb_perlin_fbm_noise3(
+        (float) (this.fx[i] * TERR_FREQ), (float) (this.fz[i] * TERR_FREQ), 0f, 2f, 0.5f, 4);
+      this.speckHue[i] = Math.random();
+      this.speckRand[i] = Math.random();
+      this.wphase[i] = Math.random() * Math.PI * 2;
+      this.wspeed[i] = 0.002 + Math.random() * 0.004;
+    }
+    this.crowdBuilt = true;
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      Apotheneum.Cube.Face[] faces = Apotheneum.cube.exterior.faces;
+      for (int f = 0; f < faces.length; ++f) {
+        int w = faces[f].columns.length;
+        int h = faces[f].columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = faces[f].columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, f * Math.PI / 2));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h, seg * Math.PI / 2));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double wrap(double d) {
+    return d - PERIOD * Math.rint(d / PERIOD);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    if (!this.crowdBuilt) {
+      buildCrowd();
+    }
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    // Wow = festival: the crowd dances harder, more vivid figures light up,
+    // and the camera sweeps faster through them
+    final double wow = getWow();
+    final double dtS = speed * deltaMs * (1 + wow * 0.6);
+    this.timeMs += deltaMs;
+    this.camZ += GLIDE * dtS * (1 + wow);           // glide forward
+    this.camX = 18 * Math.sin(this.timeMs * 0.00005 * (1 + wow)); // side drift
+    final double baseYaw = 0.35 * Math.sin(this.timeMs * 0.00008); // gentle pan
+
+    // advance the walk cycle
+    final int count = this.density.getValuei();
+    for (int i = 0; i < count; ++i) {
+      this.wphase[i] += this.wspeed[i] * dtS;
+    }
+
+    final double baseHue = LXColor.h(getColor());
+    final double specksFrac = Math.min(1, this.specks.getValue() * (1 + wow * 3));
+    final double sizeF = 0.5 + getSize() * 1.5;
+    final double terrScale = this.terrain.getValue() * TERR_MAXH;
+
+    for (Panel p : this.panels) {
+      final double yaw = p.facing + baseYaw;
+      final double cyaw = Math.cos(yaw), syaw = Math.sin(yaw);
+      final double horizon = p.h * this.horizon.getValue();
+      final double focV = p.h * 0.6;
+      // dim cool glow line along the horizon (figures draw over it)
+      int hy = (int) horizon;
+      for (int gy = Math.max(0, hy - 2); gy <= Math.min(p.h - 1, hy + 2); ++gy) {
+        double gg = Math.exp(-((gy - horizon) * (gy - horizon)) / (2 * 1.2 * 1.2));
+        int gc = LXColor.hsb(225, 30, (float) (16 * gg));
+        for (int gx = 0; gx < p.w; ++gx) {
+          this.colors[p.idx[gx][gy]] = LXColor.lightest(this.colors[p.idx[gx][gy]], gc);
+        }
+      }
+      for (int i = 0; i < count; ++i) {
+        double dx = wrap(this.fx[i] - this.camX);
+        double dz = wrap(this.fz[i] - this.camZ);
+        double fwd = dx * syaw + dz * cyaw;
+        if (fwd <= NEAR || fwd > FAR) continue; // fog cull the far crowd
+        double rightRatio = (dx * cyaw - dz * syaw) / fwd;
+        if (rightRatio < -1.05 || rightRatio > 1.05) continue;
+
+        double px = (0.5 + 0.5 * rightRatio) * p.w;
+        // figures stand on terrain: hills lift them toward/over the horizon, valleys drop them
+        double pyBase = horizon + ((H_EYE - this.fh[i] * terrScale) / fwd) * focV;
+        double figH = (1.7 / fwd) * focV * sizeF;
+        if (pyBase - figH > p.h - 1 || pyBase < -figH) continue; // off panel
+        // distance fog: near figures full, fading out toward FAR (no bright horizon bunch)
+        double fogT = LXUtils.clamp((FAR - fwd) / (FAR - NEAR) * 1.3, 0, 1);
+        double bright = Math.pow(fogT, 1.8) * (0.75 + 0.5 * this.speckRand[i]);
+
+        boolean speck = this.speckRand[i] < specksFrac;
+        int color;
+        if (speck) {
+          color = LXColor.hsb((float) (this.speckHue[i] * 360), 85, 100);
+        } else {
+          color = LXColor.hsb((float) baseHue, PALE_SAT, 100);
+          // cool-grade the distant crowd toward a hazy blue
+          double far = 1.0 - fogT;
+          color = LXColor.lerp(color, LXColor.hsb(225, 40, 70), (float) (0.6 * far));
+        }
+
+        drawFigure(p, px, pyBase, figH, bright, color, this.wphase[i]);
+      }
+    }
+
+    copyExterior();
+  }
+
+  private void drawFigure(Panel p, double px, double py, double h,
+      double bright, int color, double wphase) {
+    if (h < 2.5) {
+      splat(p, px, py - 0.4, 0.55 + h * 0.22, bright, color);
+      return;
+    }
+    final double r = Math.max(0.55, h * 0.05);
+    final double headR = h * 0.16;
+    final double headCy = py - h * 0.86;
+    final double hipY = py - h * 0.40;
+    final double shoulderY = headCy + headR + h * 0.06;
+    final double sway = Math.sin(wphase) * h * (0.13 + getWow() * 0.14); // dancing at high Wow
+
+    splat(p, px, headCy, headR, bright, color);                       // head
+    line(p, px, headCy + headR, px, hipY, r, bright, color);          // torso
+    line(p, px, hipY, px - h * 0.14 + sway, py, r, bright, color);    // left leg
+    line(p, px, hipY, px + h * 0.14 - sway, py, r, bright, color);    // right leg
+    line(p, px, shoulderY, px - h * 0.20 - sway, shoulderY + h * 0.16, r, bright, color); // left arm
+    line(p, px, shoulderY, px + h * 0.20 + sway, shoulderY + h * 0.16, r, bright, color); // right arm
+  }
+
+  private void line(Panel p, double x0, double y0, double x1, double y1,
+      double r, double bright, int color) {
+    double dx = x1 - x0, dy = y1 - y0;
+    int steps = (int) Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)));
+    if (steps < 1) steps = 1;
+    for (int k = 0; k <= steps; ++k) {
+      double t = (double) k / steps;
+      splat(p, x0 + dx * t, y0 + dy * t, r, bright, color);
+    }
+  }
+
+  private void splat(Panel p, double x, double y, double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(p.h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.max(0, Math.floor(x - r));
+    int x1 = (int) Math.min(p.w - 1, Math.ceil(x + r));
+    for (int yy = y0; yy <= y1; ++yy) {
+      double ddy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double ddx = xx - x;
+        double dd = Math.sqrt(ddx * ddx + ddy * ddy);
+        if (dd > r) continue;
+        double f = (1.0 - dd / r) * bright;
+        if (f <= 0) continue;
+        int idx = p.idx[xx][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -209,6 +209,9 @@ public class UFOAbduction extends StrandPattern {
         this.collapseT = -1;
         this.cube.reset();
         this.cylinder.reset();
+        // drop queued staggered spawns too, so a wave launched just before
+        // the collapse can't fire into the clean relaunch
+        java.util.Arrays.fill(this.pendAlive, false);
         this.relaunchQueued = true;
       }
     } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
@@ -226,8 +229,15 @@ public class UFOAbduction extends StrandPattern {
       final double strength = this.relaunchQueued ? 1.0
         : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
       final int n = this.lanes.getValuei();
-      launchWave(this.cube, true, n, strength, this.relaunchQueued);
-      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      // only feed the surfaces actually being rendered — a hidden target
+      // would otherwise pile up frozen heads at their spawn points
+      final Target t = getTarget();
+      if (t != Target.CYLINDER) {
+        launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      }
+      if (t != Target.CUBE) {
+        launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      }
       this.relaunchQueued = false;
     }
     this.launchFlash *= Math.exp(-deltaMs / 160.0);

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -1,0 +1,373 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * UFOAbduction — beat-locked counter-propagating waves on strand lanes. On every
+ * beat, green blocks launch upward from the floor at full speed, decelerate
+ * as they pass through the center — slowing to a crawl but never stopping,
+ * fattening into chunky bright slabs — then accelerate back to launch speed
+ * as they exit the top, like waves passing through a dense medium. Red
+ * streaks run the other way, top to floor, threading through the risers.
+ * Tails stretch with speed: long streamers at the edges, short stubs through
+ * the slow center; white-hot cores at speed. Lanes fire in synchronized
+ * clusters, the palette snaps between green-dominant, red-dominant, and
+ * mixed sections, and a big drop collapses the field to black before
+ * slamming a fresh wave up every lane. Modeled on the wave.mov reference.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class UFOAbduction extends StrandPattern {
+
+  private static final int MAX_HEADS = 96;
+  private static final double GREEN_HUE = 120;
+  private static final double RED_HUE = 10;
+  // calibrated from wave.mov: 800ms transit = 165ms entry + 565ms center stall
+  // + 65ms exit burst; stall:exit velocity ratio ~1:36; 900ms launch cadence
+  private static final double V_ENTRY = 0.00135;  // heights/ms, bottom leg
+  private static final double V_STALL = 0.00024;  // crawl through the center
+  private static final double V_EXIT = 0.0075;    // explosive top exit
+  private static final double V_RED = 0.0011;     // ~0.9s full-height descent
+  private static final double STALL_LO = 0.60;    // stall band (y, 0 = top)
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;     // full burst above here
+  private static final double IDLE_WAVE_MS = 900; // measured launch cadence
+  private static final double SECTION_MS = 4500;  // palette section length
+  private static final double COLLAPSE_MS = 450;
+
+  public final DiscreteParameter lanes =
+    new DiscreteParameter("Lanes", 14, 6, 24)
+    .setDescription("Strand lanes around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of launches and drops");
+
+  public final CompoundParameter glow =
+    new CompoundParameter("Glow", 0.6, 0, 1)
+    .setDescription("How far the blocks radiate light");
+
+  public final CompoundParameter trail =
+    new CompoundParameter("Trail", 0.5, 0, 1)
+    .setDescription("How long the gradient tails stream behind");
+
+  private final class Surface {
+    boolean inited;
+    final int[] lane = new int[MAX_HEADS];
+    final double[] y = new double[MAX_HEADS];     // normalized 0..1, 0 = top
+    final double[] v = new double[MAX_HEADS];     // heights/ms, +down -up
+    final boolean[] isRed = new boolean[MAX_HEADS];
+    final boolean[] thin = new boolean[MAX_HEADS]; // single-line red beams
+    final boolean[] waveR = new boolean[MAX_HEADS]; // reds riding the stall profile
+    final boolean[] alive = new boolean[MAX_HEADS];
+    void reset() {
+      for (int i = 0; i < MAX_HEADS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void spawn(int lane, boolean red) {
+      for (int i = 0; i < MAX_HEADS; ++i) {
+        if (this.alive[i]) continue;
+        this.lane[i] = lane;
+        this.isRed[i] = red;
+        this.thin[i] = red && Math.random() < 0.5;
+        // half the single lines mirror the risers' stall trajectory downward;
+        // the rest plummet straight to the floor
+        this.waveR[i] = red && this.thin[i] && Math.random() < 0.5;
+        if (red) {
+          this.y[i] = -0.02 - Math.random() * 0.08;
+          this.v[i] = this.waveR[i]
+            ? (0.9 + Math.random() * 0.2) // variance factor for the profile
+            : V_RED * (0.9 + Math.random() * 0.25) * (this.thin[i] ? 1.25 : 1.0);
+        } else {
+          this.y[i] = 1.02 + Math.random() * 0.10;
+          this.v[i] = -(0.75 + Math.random() * 0.5); // wide variance staggers the field
+        }
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double waveTimer = 0;
+  private double launchFlash = 0;
+  private double collapseT = -1;
+  private boolean relaunchQueued = false;
+  private int section = 0;
+
+  public UFOAbduction(LX lx) {
+    // Base registers color (hue shift), speed (cadence + velocity), size (block thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("lanes", this.lanes);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("glow", this.glow);
+    addParameter("trail", this.trail);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  /** Measured rise profile: brisk entry, long center stall, explosive exit. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Section palette mode: 0 = green-dominant, 1 = red-dominant, 2 = mixed. */
+  private int sectionMode() {
+    final double r = hashd(this.section * 613 + 29);
+    return (r < 0.42) ? 0 : (r < 0.68 ? 1 : 2);
+  }
+
+  // pending staggered spawns for launch wipes (lane, color, delay)
+  private final int[] pendLane = new int[MAX_HEADS];
+  private final boolean[] pendRed = new boolean[MAX_HEADS];
+  private final double[] pendMs = new double[MAX_HEADS];
+  private final boolean[] pendCube = new boolean[MAX_HEADS];
+  private final boolean[] pendAlive = new boolean[MAX_HEADS];
+
+  private void launchWave(Surface s, boolean isCube, int nLanes, double strength, boolean forceAll) {
+    final int mode = sectionMode();
+    final double redFrac = (mode == 0) ? 0.20 : (mode == 1 ? 0.75 : 0.5);
+    // per-event wipe: 0 = global, 1 = left->right, 2 = right->left, 3 = edges->center
+    final int wipe = (int) (hashd((int) (this.timeMs * 7) + 31) * 4);
+    for (int l = 0; l < nLanes; ++l) {
+      final int cluster = l / 3;
+      final double on = hashd(this.section * 977 + cluster * 131 + (int) (this.timeMs / 400));
+      if (!forceAll && on > 0.40 + strength * 0.55) continue;
+      final boolean red = hashd(this.section * 313 + cluster * 53) < redFrac;
+      double delay = 0;
+      final double u = (double) l / Math.max(1, nLanes - 1);
+      if (wipe == 1) delay = u * 370;
+      else if (wipe == 2) delay = (1 - u) * 370;
+      else if (wipe == 3) delay = (1.0 - Math.abs(u - 0.5) * 2) * 200; // edges first
+      // per-lane scatter on every wave so blocks never march in one big group
+      delay += hashd(l * 641 + (int) (this.timeMs * 3)) * 280;
+      queueSpawn(s, isCube, l, red, delay);
+      if (mode == 2 && hashd(l * 97 + (int) this.timeMs) < 0.3) {
+        queueSpawn(s, isCube, l, !red, delay + 60);
+      }
+    }
+  }
+
+  private void queueSpawn(Surface s, boolean isCube, int lane, boolean red, double delay) {
+    if (delay <= 0) {
+      s.spawn(lane, red);
+      return;
+    }
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) {
+        this.pendLane[i] = lane;
+        this.pendRed[i] = red;
+        this.pendMs[i] = delay;
+        this.pendCube[i] = isCube;
+        this.pendAlive[i] = true;
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    this.section = (int) (this.timeMs / SECTION_MS);
+
+    // collapse-to-black then hard re-drop on big hits
+    if (this.collapseT >= 0) {
+      this.collapseT += deltaMs;
+      if (this.collapseT >= COLLAPSE_MS) {
+        this.collapseT = -1;
+        this.cube.reset();
+        this.cylinder.reset();
+        this.relaunchQueued = true;
+      }
+    } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
+      this.collapseT = 0;
+    }
+
+    // beat-locked launches, with an idle subdivision cadence as fallback
+    this.waveTimer += deltaMs * speed * 2;
+    final boolean waveDue = this.waveTimer >= IDLE_WAVE_MS;
+    final boolean launch = this.relaunchQueued
+      || (this.collapseT < 0 && ((this.beat && this.beatLevel > 0.15) || waveDue));
+    if (launch) {
+      this.waveTimer = 0;
+      this.launchFlash = 1;
+      final double strength = this.relaunchQueued ? 1.0
+        : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
+      final int n = this.lanes.getValuei();
+      launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      this.relaunchQueued = false;
+    }
+    this.launchFlash *= Math.exp(-deltaMs / 160.0);
+
+    // fire staggered wipe spawns as their delays elapse
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) continue;
+      this.pendMs[i] -= deltaMs;
+      if (this.pendMs[i] <= 0) {
+        (this.pendCube[i] ? this.cube : this.cylinder).spawn(this.pendLane[i], this.pendRed[i]);
+        this.pendAlive[i] = false;
+      }
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((GREEN_HUE + hueShift) % 360)), 96, 100);
+    final int red = LXColor.hsb((float) (((RED_HUE + hueShift) % 360)), 98, 100);
+    final int nLanes = this.lanes.getValuei();
+    final double laneW = (double) w / nLanes;
+    // collapse envelope dims everything toward black before the re-drop
+    final double collapse = (this.collapseT >= 0)
+      ? 1.0 - this.collapseT / COLLAPSE_MS : 1.0;
+
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!s.alive[i]) continue;
+
+      // --- velocity field: green decelerates through the center and accelerates
+      // back out — waves passing through a dense medium, never stopping ---
+      final double vScale = speed * 2; // default Speed 0.5 == measured reference speed
+      if (s.isRed[i]) {
+        if (s.waveR[i]) {
+          // mirrored riser trajectory: zoom in from the top, slow-motion crawl
+          // through the center, burst out the floor
+          s.y[i] += s.v[i] * riseProfile(1.0 - s.y[i]) * vScale * deltaMs;
+        } else {
+          s.y[i] += s.v[i] * vScale * deltaMs; // straight plummet
+        }
+        if (s.y[i] >= 1.05) { s.alive[i] = false; continue; }
+      } else {
+        s.y[i] += s.v[i] * riseProfile(s.y[i]) * vScale * deltaMs;
+        if (s.y[i] <= -0.08) { s.alive[i] = false; continue; } // bursts out the top
+      }
+
+      // --- geometry: thick through the slow center, thin at speed; tail follows ---
+      double vNorm;
+      if (s.isRed[i] && !s.waveR[i]) {
+        vNorm = LXUtils.clamp(Math.abs(s.v[i]) / V_ENTRY, 0, 1.2);
+      } else {
+        final double yp = s.isRed[i] ? 1.0 - s.y[i] : s.y[i];
+        vNorm = LXUtils.clamp(riseProfile(yp) / V_ENTRY, 0, 1.2);
+      }
+      final double thickN = LXUtils.lerp(0.11 * (0.6 + getSize() * 0.9), 0.045, Math.min(1, vNorm));
+      final int thick = Math.max(2, (int) Math.round(thickN * h));
+      // Trail dial: 0.5 == 2x the original length; up to ~4x at full
+      final double trailK = 0.7 + this.trail.getValue() * 2.6;
+      final double tailN = LXUtils.clamp(vNorm * 0.85 * trailK, 0.16 * trailK, 1.9);
+      final int tail = (int) Math.round(tailN * h);
+      double bright = collapse;
+      if (bright <= 0.01) continue;
+
+      final int base = s.isRed[i] ? red : green;
+      // white-hot core at launch speed and on the beat flash
+      final double hot = LXUtils.clamp(vNorm * 0.7 + this.launchFlash * 0.4, 0, 0.85);
+      final int headC = LXColor.lerp(base, LXColor.WHITE, (float) hot);
+
+      int x0 = (int) (s.lane[i] * laneW);
+      int x1 = Math.min(w - 1, (int) ((s.lane[i] + 1) * laneW) - 2); // 1-col dark seam
+      if (s.isRed[i]) {
+        // red runs thin down the lane: some 2-wide strands, some single lines
+        final int cxr = (x0 + x1) / 2;
+        x0 = cxr;
+        x1 = s.thin[i] ? cxr : Math.min(w - 1, cxr + 1);
+      }
+      // strictly monotonic travel: the slow-motion crawl through the center is
+      // pure velocity — no positional oscillation (it read as shaking at LED scale)
+      final double ycF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final int yc = (int) Math.round(ycF);
+      final int dir = s.isRed[i] ? 1 : -1; // travel direction (+down)
+      // red pulses as it descends: a throb riding the moving packet
+      final double throb = s.isRed[i]
+        ? 0.55 + 0.45 * Math.sin(2 * Math.PI * this.timeMs / 1000.0 + i * 0.4) : 1.0;
+
+      final int headThick = s.isRed[i] ? Math.max(2, thick / 2) : thick; // compact red pulse
+
+      // radiant aura: soft gradient bloom bleeding off the block (ComeUp-style),
+      // strongest around the slow heavy slabs; the Glow dial sets reach + intensity
+      final double glowV = this.glow.getValue();
+      final int auraR = (s.isRed[i] ? 1 : 2) + (int) Math.round(glowV * 4);
+      final double auraB = bright * throb * (s.isRed[i] ? 0.5 : 1.0)
+        * (0.08 + glowV * 0.50) * (1.0 - 0.4 * Math.min(1, vNorm));
+      if (auraB > 0.02) {
+        final int byTop = Math.min(yc, yc - dir * (headThick - 1));
+        final int byBot = Math.max(yc, yc - dir * (headThick - 1));
+        for (int x = x0 - auraR; x <= x1 + auraR; ++x) {
+          final int dxo = (x < x0) ? (x0 - x) : ((x > x1) ? (x - x1) : 0);
+          for (int yy = byTop - auraR; yy <= byBot + auraR; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final int dyo = (yy < byTop) ? (byTop - yy) : ((yy > byBot) ? (yy - byBot) : 0);
+            final int dout = dxo + dyo;
+            if (dout == 0) continue; // inside the block
+            addPix(o, x, yy, base, auraB * Math.exp(-dout * (1.4 - glowV * 0.7)));
+          }
+        }
+      }
+
+      // continuous block span with sub-pixel feathered edges — glides, no snapping
+      final double leadF = ycF;
+      final double trailF = ycF - dir * (headThick - 1);
+      final double topF = Math.min(leadF, trailF);
+      final double botF = Math.max(leadF, trailF);
+      for (int x = x0; x <= x1; ++x) {
+        for (int yy = (int) Math.floor(topF) - 1; yy <= (int) Math.ceil(botF) + 1; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = (yy < topF) ? (topF - yy) : ((yy > botF) ? (yy - botF) : 0);
+          final double cov = LXUtils.clamp(1.0 - dOut, 0, 1); // edge feather
+          if (cov <= 0.02) continue;
+          final double u = LXUtils.clamp(1.0 - Math.abs(leadF - yy) / headThick, 0, 1);
+          addPix(o, x, yy, (u > 0.5) ? headC : base, bright * throb * (0.55 + 0.45 * u) * cov);
+        }
+        // tail streams behind, sub-pixel anchored to the trailing edge
+        for (int k = 1; k <= tail; ++k) {
+          final double yyF = trailF - dir * k;
+          final double fFall = Math.exp(-1.8 * k / tail);
+          if (fFall < 0.02) break;
+          final int yy0 = (int) Math.floor(yyF);
+          final double frac = yyF - yy0;
+          final double tb = bright * throb * fFall * 0.8;
+          if (yy0 >= 0 && yy0 < h) addPix(o, x, yy0, base, tb * (1 - frac));
+          if (yy0 + 1 >= 0 && yy0 + 1 < h) addPix(o, x, yy0 + 1, base, tb * frac);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
adds the next batch of piemonte patterns. all files live flat in apotheneum/piemonte/.

patterns:
- origami: the surface is a sheet of paper ruled with drifting diagonal lines in one color. hit the fold button (or let a dramatic swell in the music do it) and the sheet creases: the remaining area folds in half upon itself, the flap sweeping over and dissolving to...
- digits: a giant terminal readout: a handful of huge white-hot characters fill the wall nearly top to bottom, swapping as a group on the beat, over a dim churning field of small blue log-glyphs. on every swap, full-height red and blue strand flares ignite through...
- safteythird: a bold dead smiley across the whole piece, in the full-facade spirit of ex machina. one huge grinning face per cube facade (two around the cylinder): a bright disc textured with slow ex machina-style radial shimmer bands, x x eyes cut dark into the glow,...
- sunrise: a sun literally rises from the bottom of each facade. the disc climbs from below the horizon — huge, molten, all orange and yellow — radiating thick yellow and orange beams outward at angled directions.
- superbloom: rare rains hit the desert and the whole canvas erupts. giant green pixel-chunk buds appear scattered across the surface, swell, then blossom open into top-down flowers in wild multi-colors all their own: six species, each with two or three petal colors...
- candyflip: rainbow comets roam the surface; each lives briefly then bursts into a fresh generation of comets flying outward, cascading until the energy runs out. white-hot heads trail fading rainbow gradients that shift hue with each generation.

depends on #46

will attach video