### PR TITLE
add piemonte patterns: final set and project file

### DIFF
--- a/src/main/java/apotheneum/piemonte/Afterglow.java
+++ b/src/main/java/apotheneum/piemonte/Afterglow.java
@@ -22,17 +22,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Afterglow extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_STARS = 48;
   private static final double CYCLE_MS = 3000; // one pulse cycle at speed 1
@@ -52,10 +45,6 @@ public class Afterglow extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How strongly the stars follow the music");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private double phase = 0;
 
@@ -95,19 +84,17 @@ public class Afterglow extends ParameterPattern {
     addParameter("reach", this.reach);
     addParameter("pulses", this.pulses);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   /** Returns 0 = nothing, 1 = beat, 2 = drop. */
   private int detect(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= 140)
       && (bass > 0.01);
@@ -116,7 +103,7 @@ public class Afterglow extends ParameterPattern {
     if (beat) {
       this.sinceBeatMs = 0;
     }
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0)
       : 1 - Math.exp(-deltaMs / 220.0);
@@ -155,7 +142,7 @@ public class Afterglow extends ParameterPattern {
       : 0.5 + (speed - 0.5) * 5.0;
     this.phase += deltaMs * rate * (1.0 + this.levelEnv * 0.4) / CYCLE_MS;
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(Apotheneum.cube.exterior, 0);
     }

--- a/src/main/java/apotheneum/piemonte/Afterglow.java
+++ b/src/main/java/apotheneum/piemonte/Afterglow.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Afterglow — joints of light scattered across the surfaces, each constantly
+ * pulsing white dots outward along its own rays — a handful of directions at
+ * arbitrary angles, like edges meeting at a vertex. The joints themselves stay
+ * dark; all you see is the endless soft exhale of dots leaving them and dying
+ * away, every ray on its own phase. Kicks flare the field, drops send one
+ * synchronized wave down every ray at once, and Wow grows extra rays.
+ * After the LXStudio-TE Afterglow.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Afterglow extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_STARS = 48;
+  private static final double CYCLE_MS = 3000; // one pulse cycle at speed 1
+
+  public final DiscreteParameter stars =
+    new DiscreteParameter("Stars", 28, 6, MAX_STARS)
+    .setDescription("How many stars pulse on each surface");
+
+  public final CompoundParameter reach =
+    new CompoundParameter("Reach", 0.55, 0.2, 1)
+    .setDescription("How far the pulses travel before dying");
+
+  public final DiscreteParameter pulses =
+    new DiscreteParameter("Pulses", 4, 1, 8)
+    .setDescription("Concurrent pulses per ray");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How strongly the stars follow the music");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private double phase = 0;
+
+  // stratified star placement per surface: even spread with jitter, stable
+  // across frames (the old per-frame hash clustered mid-surface)
+  private final double[][] starX = new double[2][MAX_STARS];
+  private final double[][] starY = new double[2][MAX_STARS];
+  private final boolean[] placed = new boolean[2];
+
+  private void place(int surf, int w, int h) {
+    // shuffle column strata so neighbors aren't sequential
+    final int[] slot = new int[MAX_STARS];
+    for (int i = 0; i < MAX_STARS; ++i) slot[i] = i;
+    for (int i = MAX_STARS - 1; i > 0; --i) {
+      int j = (int) (Math.random() * (i + 1));
+      int tmp = slot[i]; slot[i] = slot[j]; slot[j] = tmp;
+    }
+    for (int i = 0; i < MAX_STARS; ++i) {
+      this.starX[surf][i] = (slot[i] + 0.15 + Math.random() * 0.7) / MAX_STARS * w;
+      // stratify vertically in interleaved bands for full top-to-bottom coverage
+      final double band = (i % 6 + Math.random()) / 6.0;
+      this.starY[surf][i] = 2 + band * (h - 4);
+    }
+    this.placed[surf] = true;
+  }
+
+  // audio: kicks flare the cores, drops send one wave from every star at once
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+  private double beatPulse = 0;
+  private double unison = -1; // 0..1 while a unison wave is traveling; <0 idle
+
+  public Afterglow(LX lx) {
+    // Base registers color (star tint), speed (pulse rate), size (dot size).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("stars", this.stars);
+    addParameter("reach", this.reach);
+    addParameter("pulses", this.pulses);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  /** Returns 0 = nothing, 1 = beat, 2 = drop. */
+  private int detect(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 140)
+      && (bass > 0.01);
+    double ratio = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+    if (!beat) return 0;
+    return (ratio > 0.60 - sens * 0.15) ? 2 : 1;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final double speed = Math.max(0.02, getSpeed());
+    final int hit = detect(deltaMs);
+    if (hit == 1) {
+      this.beatPulse = 1; // cores flare on the kick
+    } else if (hit == 2 && this.unison < 0) {
+      this.unison = 0; // the drop: every star fires one wave together
+      this.beatPulse = 1;
+    }
+    this.beatPulse *= Math.exp(-deltaMs / 240.0);
+    if (this.unison >= 0) {
+      this.unison += deltaMs / 700.0;
+      if (this.unison >= 1) this.unison = -1;
+    }
+    // louder music quickens the breathing slightly; the knob maps to a wide
+    // rate range (crawl at 0 -> ~6x at full) so Speed has real impact
+    final double rate = (speed <= 0.5)
+      ? 0.05 + 0.9 * speed
+      : 0.5 + (speed - 0.5) * 5.0;
+    this.phase += deltaMs * rate * (1.0 + this.levelEnv * 0.4) / CYCLE_MS;
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(Apotheneum.cube.exterior, 0);
+    }
+    if (t != Target.CUBE) {
+      step(Apotheneum.cylinder.exterior, 1);
+    }
+    copyExterior();
+  }
+
+  private void step(Apotheneum.Orientation o, int seed) {
+    final int w = o.width();
+    final int h = o.height();
+    if (!this.placed[seed]) {
+      place(seed, w, h);
+    }
+    final int base = getColor();
+    final int dot = LXColor.lerp(base, LXColor.WHITE, 0.75f); // near-white pulses
+    final double wow = getWow();
+    final int nStars = this.stars.getValuei();
+    final int nPulses = this.pulses.getValuei();
+    // full-canvas reach: default sends pulses ~0.85x the surface height, max well past it
+    final double maxTravel = h * (0.25 + 1.05 * this.reach.getValue());
+    final double dotR = 1.0 + getSize() * 1.6; // >=1 so sub-pixel motion stays smooth
+    final boolean diagonals = wow > 0.15;
+    final double gain = (1.0 + wow * 0.5) * (1.0 + this.levelEnv * 0.5 + this.beatPulse * 0.35);
+
+    for (int i = 0; i < nStars; ++i) {
+      final double sx = this.starX[seed][i];
+      final double sy = this.starY[seed][i];
+      final double offset = hashd(i * 97 + (seed + 1) * 1299709);
+
+      // each joint has its own set of rays at arbitrary angles, like edges
+      // meeting at a vertex — no lit core, just dots constantly leaving it
+      final int nRays = 3 + (int) (hashd(i * 131 + seed * 15485863) * 3) + (diagonals ? 2 : 0);
+      for (int r = 0; r < nRays; ++r) {
+        final double ang = hashd(i * 197 + r * 613 + seed * 27644437) * 2 * Math.PI;
+        final double ux = Math.cos(ang), uy = Math.sin(ang);
+        final double rayLen = maxTravel * (0.6 + 0.4 * hashd(i * 331 + r * 89 + seed));
+        final double rayOff = hashd(i * 419 + r * 157 + seed * 3) * 0.5; // desync directions
+
+        // dots constantly streaming out along this ray
+        for (int p = 0; p < nPulses; ++p) {
+          final double adj = (this.phase + offset + rayOff + (double) p / nPulses) % 1.0;
+          final double travel = adj * rayLen;
+          final double in = LXUtils.clamp(adj / 0.08, 0, 1);
+          final double fade = Math.pow(1.0 - adj, 1.4) * gain * (in * in * (3 - 2 * in));
+          if (fade <= 0.01) continue;
+          splat(o, w, h, sx + ux * travel, sy + uy * travel, dotR, fade, dot);
+        }
+
+        // the drop: one synchronized white wave down every ray of every joint
+        if (this.unison >= 0) {
+          final double uTravel = this.unison * rayLen;
+          final double uFade = Math.pow(1.0 - this.unison, 1.2) * (1.2 + wow * 0.5);
+          if (uFade > 0.01 && uTravel >= 0.5) {
+            splat(o, w, h, sx + ux * uTravel, sy + uy * uTravel, dotR, uFade, LXColor.WHITE);
+          }
+        }
+      }
+    }
+
+    // Wow: glowy glitch — random pixels flare softly across the whole canvas
+    if (wow > 0.05) {
+      final int glints = (int) (w * h * 0.012 * wow);
+      for (int g = 0; g < glints; ++g) {
+        final double gx = Math.random() * w;
+        final double gy = Math.random() * h;
+        final double gb = (0.25 + Math.random() * 0.75) * wow;
+        final int gc = LXColor.lerp(base, LXColor.WHITE, (float) (0.5 + Math.random() * 0.5));
+        splat(o, w, h, gx, gy, 1.2, gb, gc);
+      }
+    }
+  }
+
+  /** Soft round dab; x wraps, y clips. */
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    if (bright <= 0.004) return;
+    final int y0 = (int) Math.max(0, Math.floor(y - r));
+    final int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    final int x0 = (int) Math.floor(x - r);
+    final int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      final double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        final double dx = xx - x;
+        final double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        final double u = 1.0 - dd / r;
+        final double f = u * u * bright;
+        if (f <= 0.004) continue;
+        final int xi = ((xx % w) + w) % w;
+        final int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(color, (float) LXUtils.clamp(f, 0, 1)));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Bruh.java
+++ b/src/main/java/apotheneum/piemonte/Bruh.java
@@ -18,17 +18,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Bruh extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_DROPS = 160;
   private static final int MAX_SPLASH = 600;
@@ -46,10 +39,6 @@ public class Bruh extends ParameterPattern {
   public final CompoundParameter trail =
     new CompoundParameter("Trail", 0.5, 0, 1)
     .setDescription("How long the rain streaks trail behind each drop");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     int w, h;
@@ -117,14 +106,14 @@ public class Bruh extends ParameterPattern {
     addParameter("drops", this.drops);
     addParameter("splash", this.splash);
     addParameter("trail", this.trail);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
     final int base = getColor();
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, deltaMs, base);
     }

--- a/src/main/java/apotheneum/piemonte/Bruh.java
+++ b/src/main/java/apotheneum/piemonte/Bruh.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Bruh — a heavy downpour of vertical streaks falling through the piece like rain
+ * in a bamboo forest. Where each drop strikes the floor, water splashes upward in
+ * a small arc and falls back. Dense, continuous, elemental.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Bruh extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_DROPS = 160;
+  private static final int MAX_SPLASH = 600;
+  private static final double FALL = 0.045;      // cells / ms at speed 1
+  private static final double GRAVITY = 0.00018; // splash gravity, cells / ms^2
+
+  public final DiscreteParameter drops =
+    new DiscreteParameter("Drops", 60, 10, MAX_DROPS)
+    .setDescription("How many raindrops are falling at once");
+
+  public final CompoundParameter splash =
+    new CompoundParameter("Splash", 0.5, 0, 1)
+    .setDescription("How much water splashes up on impact");
+
+  public final CompoundParameter trail =
+    new CompoundParameter("Trail", 0.5, 0, 1)
+    .setDescription("How long the rain streaks trail behind each drop");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    // drops
+    final double[] dx = new double[MAX_DROPS];
+    final double[] dy = new double[MAX_DROPS];
+    final double[] dvy = new double[MAX_DROPS]; // per-drop speed factor
+    final double[] dlen = new double[MAX_DROPS];
+    // splash particles
+    final double[] sx = new double[MAX_SPLASH];
+    final double[] sy = new double[MAX_SPLASH];
+    final double[] svx = new double[MAX_SPLASH];
+    final double[] svy = new double[MAX_SPLASH];
+    final double[] slife = new double[MAX_SPLASH];
+    final double[] smax = new double[MAX_SPLASH];
+    final boolean[] salive = new boolean[MAX_SPLASH];
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      for (int i = 0; i < MAX_DROPS; ++i) {
+        respawnDrop(i, true);
+      }
+      for (int i = 0; i < MAX_SPLASH; ++i) {
+        this.salive[i] = false;
+      }
+    }
+
+    void respawnDrop(int i, boolean scatter) {
+      this.dx[i] = Math.random() * this.w;
+      this.dy[i] = scatter ? Math.random() * this.h : -(Math.random() * 12);
+      this.dvy[i] = 0.7 + Math.random() * 0.6;
+      this.dlen[i] = 1; // set at render from Size
+    }
+
+    void spawnSplash(double x, int count, double energy) {
+      for (int c = 0; c < count; ++c) {
+        int idx = -1;
+        for (int k = 0; k < MAX_SPLASH; ++k) {
+          if (!this.salive[k]) { idx = k; break; }
+        }
+        if (idx < 0) return;
+        this.sx[idx] = x;
+        this.sy[idx] = this.h - 1;
+        this.svx[idx] = (Math.random() - 0.5) * 0.03;
+        this.svy[idx] = -(0.015 + Math.random() * 0.03) * (0.5 + energy); // upward
+        this.smax[idx] = 350 + Math.random() * 450;
+        this.slife[idx] = this.smax[idx];
+        this.salive[idx] = true;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public Bruh(LX lx) {
+    // Base registers color, speed, size; speed = fall speed, size = streak/splash size.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("drops", this.drops);
+    addParameter("splash", this.splash);
+    addParameter("trail", this.trail);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final int base = getColor();
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, base);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, base);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs, int base) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double size = getSize();
+    final double wow = getWow();
+    // Wow = downpour surge: more drops falling faster, eruptive splashes
+    final int count = Math.min(MAX_DROPS, (int) (this.drops.getValuei() * (1 + wow * 1.5)));
+    final double fall = FALL * speed * deltaMs * (1 + wow * 0.8);
+    // Trail dial: 0.5 == the original streak length, up to ~3.3x at full
+    final double streak = (2 + size * 9) * (0.7 + this.trail.getValue() * 2.6);
+    // Wow makes impacts erupt: many more droplets, more upward energy, whiter foam.
+    final double splashAmt = this.splash.getValue();
+    final double splashEnergy = splashAmt + wow;
+    final int splashCount = (int) (1 + splashAmt * 14 + wow * 14);
+    final int splashColor = LXColor.lerp(base, LXColor.WHITE, (float) LXUtils.clamp(0.6 + wow * 0.4, 0, 1));
+    final int headColor = LXColor.lerp(base, LXColor.WHITE, 0.5f); // hot bead at the drop head
+
+    // --- drops ---
+    for (int i = 0; i < count; ++i) {
+      s.dy[i] += fall * s.dvy[i];
+      if (s.dy[i] >= h - 1) {
+        if (splashEnergy > 0) {
+          s.spawnSplash(s.dx[i], splashCount, splashEnergy);
+        }
+        s.respawnDrop(i, false);
+      }
+      // render vertical streak: head at dy, trail above, fading up
+      int xi = (((int) Math.round(s.dx[i])) % w + w) % w;
+      int head = (int) s.dy[i];
+      double hf = s.dy[i] - Math.floor(s.dy[i]); // sub-pixel head fraction
+      for (int k = 0; k <= (int) streak; ++k) {
+        int row = head - k;
+        if (row < 0 || row >= h) continue;
+        double b = Math.exp(-2.2 * k / (streak + 1)); // reads along the full trail
+        int c = base;
+        if (k == 0) {
+          b *= (0.4 + 0.6 * hf);
+          c = headColor;
+        }
+        int idx = o.point(xi, row).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(c, (float) b));
+      }
+      // smooth falling bead: light the row below the head at the leftover fraction
+      int below = head + 1;
+      if (below >= 0 && below < h) {
+        int idx = o.point(xi, below).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(base, (float) (hf * 0.5)));
+      }
+    }
+
+    // --- splashes ---
+    final double r = 0.9 + size * 0.9 + splashAmt * 1.3 + wow * 1.5;
+    for (int i = 0; i < MAX_SPLASH; ++i) {
+      if (!s.salive[i]) continue;
+      s.slife[i] -= deltaMs;
+      if (s.slife[i] <= 0) { s.salive[i] = false; continue; }
+      s.svy[i] += GRAVITY * deltaMs;          // gravity pulls back down
+      s.sy[i] += s.svy[i] * speed * deltaMs;
+      s.sx[i] += s.svx[i] * speed * deltaMs;
+      if (s.sy[i] >= h - 1 && s.svy[i] > 0) { s.salive[i] = false; continue; } // fell back
+      double fade = s.slife[i] / s.smax[i];
+      splat(o, w, h, s.sx[i], s.sy[i], r, Math.pow(fade, 1.5) * (0.55 + 0.65 * splashAmt + wow * 0.4), splashColor);
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/CandyFlip.java
+++ b/src/main/java/apotheneum/piemonte/CandyFlip.java
@@ -18,17 +18,10 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class CandyFlip extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_P = 256;
   private static final double BASE_VEL = 0.03;   // grid cells / ms at speed 1
@@ -46,10 +39,6 @@ public class CandyFlip extends ParameterPattern {
   public final DiscreteParameter generations =
     new DiscreteParameter("Gens", 4, 1, 6)
     .setDescription("How many generations the cascade goes");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** A 2D cascade field on one orientation (wraps in X, bounces in Y). */
   private final class Surface {
@@ -115,7 +104,7 @@ public class CandyFlip extends ParameterPattern {
     super(lx, 0.4, 0, 1, 0.5, 0, 1);
     addParameter("density", this.density);
     addParameter("generations", this.generations);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -123,7 +112,7 @@ public class CandyFlip extends ParameterPattern {
     setColors(LXColor.BLACK);
     this.timeMs += deltaMs;
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     final double baseHue = LXColor.h(getColor());
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, deltaMs, baseHue);

--- a/src/main/java/apotheneum/piemonte/CandyFlip.java
+++ b/src/main/java/apotheneum/piemonte/CandyFlip.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * CandyFlip — rainbow comets roam the surface; each lives briefly then bursts
+ * into a fresh generation of comets flying outward, cascading until the energy
+ * runs out. White-hot heads trail fading rainbow gradients that shift hue with
+ * each generation. An Apotheneum take on a vertex-to-vertex cascade.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class CandyFlip extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_P = 256;
+  private static final double BASE_VEL = 0.03;   // grid cells / ms at speed 1
+  private static final double BURST_CYCLE = 2400; // ms (speed-scaled) between gen-0 bursts
+  private static final double BASE_AGE = 1100;    // ms (speed-scaled) particle life
+  private static final int FAN = 3;               // children per burst
+  private static final double GEN_HUE = 95;       // hue shift per generation
+  private static final double TRAIL_HUE = 26;     // hue shift along the trail (rainbow streak)
+  private static final double HUE_DRIFT = 0.03;   // hue drift per ms
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 5, 1, 16)
+    .setDescription("Gen-0 comets spawned per burst");
+
+  public final DiscreteParameter generations =
+    new DiscreteParameter("Gens", 4, 1, 6)
+    .setDescription("How many generations the cascade goes");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** A 2D cascade field on one orientation (wraps in X, bounces in Y). */
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    final double[] px = new double[MAX_P];
+    final double[] py = new double[MAX_P];
+    final double[] vx = new double[MAX_P];
+    final double[] vy = new double[MAX_P];
+    final int[] gen = new int[MAX_P];
+    final double[] age = new double[MAX_P];
+    final double[] maxAge = new double[MAX_P];
+    final boolean[] alive = new boolean[MAX_P];
+    double spawnAcc;
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      this.spawnAcc = 0;
+      for (int i = 0; i < MAX_P; ++i) {
+        this.alive[i] = false;
+      }
+    }
+
+    int freeSlot() {
+      for (int i = 0; i < MAX_P; ++i) {
+        if (!this.alive[i]) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    void spawn(double x, double y, int generation) {
+      int i = freeSlot();
+      if (i < 0) {
+        return;
+      }
+      this.px[i] = x;
+      this.py[i] = y;
+      double theta = Math.random() * Math.PI * 2;
+      double mag = 0.6 + 0.7 * Math.random();
+      this.vx[i] = Math.cos(theta) * mag;
+      this.vy[i] = Math.sin(theta) * mag;
+      this.gen[i] = generation;
+      // negative age staggers each particle's start so bursts don't pop in lockstep
+      this.age[i] = -Math.random() * 200;
+      this.maxAge[i] = BASE_AGE * (0.7 + 0.6 * Math.random());
+      this.alive[i] = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double timeMs = 0;
+
+  public CandyFlip(LX lx) {
+    // Base registers color (base hue), speed, size; speed is a magnitude here.
+    super(lx, 0.4, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("generations", this.generations);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    final Target t = this.target.getEnum();
+    final double baseHue = LXColor.h(getColor());
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, baseHue);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, baseHue);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs, double baseHue) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double size = getSize();
+    final double wow = getWow();
+    final double move = speed * BASE_VEL * deltaMs;
+    final int maxGen = this.generations.getValuei();
+    // Wow makes the cascade explosive: more children per burst, hotter heads.
+    final int fan = FAN + (int) Math.round(wow * 5);
+
+    // --- seed gen-0 bursts on a timer ---
+    s.spawnAcc += deltaMs * speed;
+    if (s.spawnAcc >= BURST_CYCLE) {
+      s.spawnAcc -= BURST_CYCLE;
+      int n = this.density.getValuei();
+      for (int k = 0; k < n; ++k) {
+        s.spawn(Math.random() * w, Math.random() * h, 0);
+      }
+    }
+
+    // --- update: move, age, burst into next generation ---
+    for (int i = 0; i < MAX_P; ++i) {
+      if (!s.alive[i]) continue;
+      double x = s.px[i] + s.vx[i] * move;
+      double y = s.py[i] + s.vy[i] * move;
+      x = ((x % w) + w) % w;
+      if (y < 0) { y = -y; s.vy[i] = -s.vy[i]; }
+      else if (y > h - 1) { y = 2 * (h - 1) - y; s.vy[i] = -s.vy[i]; }
+      s.px[i] = x;
+      s.py[i] = LXUtils.clamp(y, 0, h - 1);
+
+      s.age[i] += deltaMs * speed;
+      if (s.age[i] >= s.maxAge[i]) {
+        if (s.gen[i] + 1 < maxGen) {
+          for (int c = 0; c < fan; ++c) {
+            s.spawn(s.px[i], s.py[i], s.gen[i] + 1);
+          }
+        }
+        s.alive[i] = false;
+      }
+    }
+
+    // --- render: white-hot heads + fading rainbow trails ---
+    final double headR = (0.8 + size * 1.5) * (1.0 + wow * 1.2); // wow -> bigger, hotter heads
+    final int tailCells = (int) (16 + size * 90);
+    for (int i = 0; i < MAX_P; ++i) {
+      if (!s.alive[i]) continue;
+      // fade out over the particle's life so bursts feel like they spend energy,
+      // with a brief birth pop that flares then settles
+      double lifeFade = Math.min(1.6,
+        (1.0 - 0.6 * (s.age[i] / s.maxAge[i])) * (1.0 + 0.8 * Math.exp(-s.age[i] / 120.0)));
+      splat(s, o, s.px[i], s.py[i], headR, LXUtils.clamp(lifeFade, 0, 1), LXColor.WHITE);
+
+      double vlen = Math.sqrt(s.vx[i] * s.vx[i] + s.vy[i] * s.vy[i]);
+      if (vlen < 1e-4) continue;
+      double ux = s.vx[i] / vlen, uy = s.vy[i] / vlen;
+      for (int k = 1; k <= tailCells; ++k) {
+        double f = Math.exp(-2.5 * k / tailCells) * lifeFade;
+        if (f <= 0) break;
+        double hue = baseHue + s.gen[i] * GEN_HUE + k * TRAIL_HUE + this.timeMs * HUE_DRIFT;
+        hue = ((hue % 360) + 360) % 360;
+        // trail emerges white from the head and blooms into color
+        float sat = (float) (100.0 * Math.min(1.0, k / (0.25 * tailCells)));
+        int col = LXColor.hsb((float) hue, sat, 100);
+        splat(s, o, s.px[i] - ux * k * 0.9, s.py[i] - uy * k * 0.9, 0.9, LXUtils.clamp(f, 0, 1), col);
+      }
+    }
+  }
+
+  /** Draw a soft round dab at (x,y); x wraps, y is clamped to the surface. */
+  private void splat(Surface s, Apotheneum.Orientation o, double x, double y,
+      double r, double bright, int color) {
+    final int w = s.w, h = s.h;
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double f = (1.0 - dd / r) * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ComeUp.java
+++ b/src/main/java/apotheneum/piemonte/ComeUp.java
@@ -22,18 +22,11 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class ComeUp extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double RISE_RATE_PER_MS = 1.0 / 6000.0; // full rise in ~6s at speed 1
   private static final double MAX_HOLD_MS = 2500.0;
@@ -142,10 +135,6 @@ public class ComeUp extends ParameterPattern {
     }
   }
 
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures the glass fills");
-
   private final Tide exterior = new Tide(0.0, 0.0, 0.0);
   // Interior seeded out of lockstep (height + time) and in a different hue.
   private final Tide interior = new Tide(0.4, 4000.0, INTERIOR_HUE_OFFSET);
@@ -158,7 +147,7 @@ public class ComeUp extends ParameterPattern {
     addParameter("hold", this.hold);
     addParameter("bubbles", this.bubbles);
     addParameter("sparkle", this.sparkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -174,7 +163,7 @@ public class ComeUp extends ParameterPattern {
     final double wow = getWow();
     final int base = getColor();
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     this.exterior.advance(deltaMs, speed, holdAmt);
     this.exterior.updateBubbles(deltaMs, speed, bubbleCount);
     if (Apotheneum.hasInterior) {

--- a/src/main/java/apotheneum/piemonte/ComeUp.java
+++ b/src/main/java/apotheneum/piemonte/ComeUp.java
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * ComeUp — a glass of water filling up. On the cylinder and/or cube (Target;
+ * interior and exterior,
+ * two independent glasses out of lockstep) a liquid tide rises bottom-to-top with
+ * a crisp, turbulent, foamy waterline. The body below the surface teems with
+ * rising bubbles and scintillating sparkles. Each time the glass fills, the flood
+ * color rotates to a new hue, so the piece cycles color with every fill.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class ComeUp extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double RISE_RATE_PER_MS = 1.0 / 6000.0; // full rise in ~6s at speed 1
+  private static final double MAX_HOLD_MS = 2500.0;
+  private static final double TEMPORAL_HZ = 0.5;
+  private static final double EDGE_BAND = 0.02;                // crisp waterline
+  private static final double INV_BAND = 1.0 / EDGE_BAND;
+  private static final int MAX_BUBBLES = 96;
+  private static final double BUBBLE_RISE = 0.00010;           // normalized rise / ms at speed 1
+  private static final double HUE_STEP = 43.0;                 // hue advance per fill (deg)
+  private static final double INTERIOR_HUE_OFFSET = 137.0;     // interior glass differs
+
+  public final DiscreteParameter detail =
+    new DiscreteParameter("Detail", 3, 1, 11)
+    .setDescription("Spatial frequency of the surface noise");
+
+  public final CompoundParameter chop =
+    new CompoundParameter("Chop", 0.35, 0, 1)
+    .setDescription("Turbulent whitewater chop (dreamy roll to full storm)");
+
+  public final CompoundParameter hold =
+    new CompoundParameter("Hold", 0.30, 0, 1)
+    .setDescription("How long the tide rests at the crest before the next surge");
+
+  public final DiscreteParameter bubbles =
+    new DiscreteParameter("Bubbles", 40, 0, MAX_BUBBLES)
+    .setDescription("Bubbles rising through each tide");
+
+  public final CompoundParameter sparkle =
+    new CompoundParameter("Sparkle", 0.4, 0, 1)
+    .setDescription("Sparse scintillating glints suspended in the liquid");
+
+  private enum Phase {
+    RISING,
+    HOLD
+  }
+
+  /** Per-surface animation state, so interior/exterior are fully independent. */
+  private static final class Tide {
+    double fillLevel;
+    double holdElapsedMs;
+    double timeMs;
+    double currOffsetDeg;   // hue offset of the flood currently rising
+    double prevOffsetDeg;   // hue offset of the receding flood above it
+    Phase phase = Phase.RISING;
+
+    // bubbles (normalized: bx 0..1 wraps, by 0=bottom..1=top)
+    final double[] bx = new double[MAX_BUBBLES];
+    final double[] by = new double[MAX_BUBBLES];
+    final double[] bsize = new double[MAX_BUBBLES];
+    final double[] bspeed = new double[MAX_BUBBLES];
+    final double[] bphase = new double[MAX_BUBBLES];
+    final boolean[] binit = new boolean[MAX_BUBBLES];
+
+    Tide(double fillLevel, double timeMs, double hueSeedDeg) {
+      this.fillLevel = fillLevel;
+      this.timeMs = timeMs;
+      this.currOffsetDeg = hueSeedDeg;
+      this.prevOffsetDeg = hueSeedDeg;
+    }
+
+    void advance(double deltaMs, double speed, double holdAmt) {
+      this.timeMs += deltaMs;
+      if (this.phase == Phase.RISING) {
+        this.fillLevel += deltaMs * speed * RISE_RATE_PER_MS;
+        if (this.fillLevel >= 1.0) {
+          this.fillLevel = 1.0;
+          this.holdElapsedMs = 0.0;
+          this.phase = Phase.HOLD;
+        }
+      } else {
+        this.holdElapsedMs += deltaMs;
+        if (this.holdElapsedMs >= holdAmt * MAX_HOLD_MS) {
+          // next glass fills with a fresh hue rising over the previous color
+          this.prevOffsetDeg = this.currOffsetDeg;
+          this.currOffsetDeg = (this.currOffsetDeg + HUE_STEP) % 360.0;
+          this.fillLevel = 0.0;
+          this.phase = Phase.RISING;
+        }
+      }
+    }
+
+    private void spawnBubble(int i) {
+      this.bx[i] = Math.random();
+      this.by[i] = 0;
+      this.bsize[i] = 0.6 + Math.random() * 1.2;
+      this.bspeed[i] = 0.6 + Math.random() * 0.9;
+      this.bphase[i] = Math.random() * Math.PI * 2;
+      this.binit[i] = true;
+    }
+
+    void updateBubbles(double deltaMs, double speed, int count) {
+      for (int i = 0; i < count; ++i) {
+        if (!this.binit[i]) {
+          spawnBubble(i);
+          // stagger initial heights so they don't all start at the floor
+          this.by[i] = Math.random() * Math.max(0.01, this.fillLevel);
+        }
+        this.by[i] += BUBBLE_RISE * speed * this.bspeed[i] * deltaMs;
+        this.bx[i] += Math.sin(this.timeMs * 0.002 + this.bphase[i]) * 0.00003 * deltaMs;
+        this.bx[i] -= Math.floor(this.bx[i]);
+        // pop at the surface, respawn at the floor
+        if (this.by[i] >= this.fillLevel || this.by[i] > 1.0) {
+          spawnBubble(i);
+        }
+      }
+    }
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures the glass fills");
+
+  private final Tide exterior = new Tide(0.0, 0.0, 0.0);
+  // Interior seeded out of lockstep (height + time) and in a different hue.
+  private final Tide interior = new Tide(0.4, 4000.0, INTERIOR_HUE_OFFSET);
+
+  public ComeUp(LX lx) {
+    // Base registers color (starting hue), speed (rise rate), size (surface amplitude), wow.
+    super(lx, 1, 0.1, 4, 0.1, 0, 0.3);
+    addParameter("detail", this.detail);
+    addParameter("chop", this.chop);
+    addParameter("hold", this.hold);
+    addParameter("bubbles", this.bubbles);
+    addParameter("sparkle", this.sparkle);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    // power curve: default (1.0) unchanged, but the ends bite — crawl at the
+    // bottom of the knob, ~9x fill rate at the top
+    final double speed = Math.pow(getSpeed(), 1.6);
+    final double holdAmt = this.hold.getValue();
+    final int bubbleCount = this.bubbles.getValuei();
+    final double sparkleAmt = this.sparkle.getValue();
+    final double wow = getWow();
+    final int base = getColor();
+
+    final Target t = this.target.getEnum();
+    this.exterior.advance(deltaMs, speed, holdAmt);
+    this.exterior.updateBubbles(deltaMs, speed, bubbleCount);
+    if (Apotheneum.hasInterior) {
+      this.interior.advance(deltaMs, speed, holdAmt);
+      this.interior.updateBubbles(deltaMs, speed, bubbleCount);
+    }
+
+    // one shared fluid state per surface pair: cube and cylinder fill in step
+    if (t != Target.CUBE) {
+      renderTide(this.exterior, Apotheneum.cylinder.exterior, base, bubbleCount, sparkleAmt, wow);
+      if (Apotheneum.hasInterior) {
+        renderTide(this.interior, Apotheneum.cylinder.interior, base, bubbleCount, sparkleAmt, wow);
+      }
+    }
+    if (t != Target.CYLINDER) {
+      renderTide(this.exterior, Apotheneum.cube.exterior, base, bubbleCount, sparkleAmt, wow);
+      if (Apotheneum.hasInterior) {
+        renderTide(this.interior, Apotheneum.cube.interior, base, bubbleCount, sparkleAmt, wow);
+      }
+    }
+
+    // Intentionally no copyExterior(): the two surfaces render independently.
+  }
+
+  private void renderTide(Tide tide, Apotheneum.Orientation o, int baseColor,
+      int bubbleCount, double sparkleAmt, double wow) {
+    // Rotate hue only; keep the palette color's saturation/brightness.
+    final float baseHue = LXColor.h(baseColor);
+    final float baseSat = LXColor.s(baseColor);
+    final float baseBri = LXColor.b(baseColor);
+    final int curr = LXColor.hsb((float) ((baseHue + tide.currOffsetDeg) % 360.0), baseSat, baseBri);
+    final int prev = LXColor.hsb((float) ((baseHue + tide.prevOffsetDeg) % 360.0), baseSat, baseBri);
+
+    final double amp = getSize();
+    final double chopAmt = this.chop.getValue();
+    final float freq = Math.max(1, this.detail.getValuei());
+    final float t = (float) (tide.timeMs * 0.001 * TEMPORAL_HZ);
+    final float driftX = t * 0.3f;
+    final float driftZ = t * 0.17f;
+    final double level = tide.fillLevel;
+
+    final double foamW = 0.012 + 0.020 * chopAmt;
+    final double foamGain = (0.55 + 0.45 * chopAmt) * (1.0 + wow * 0.8);
+    final double sTime = tide.timeMs * 0.004;
+    final int tq = (int) sTime;
+    final double tf = sTime - tq;
+    final double twEnv = Math.sin(tf * Math.PI);
+    final float glint = (float) (twEnv * twEnv);
+    final double sparkThresh = 1.0 - sparkleAmt * (0.05 + wow * 0.08);
+
+    // --- liquid body + churning surface + foam + sparkles ---
+    for (Apotheneum.Column column : o.columns()) {
+      final LXPoint[] points = column.points;
+      final int len = points.length;
+      final int last = len - 1;
+      for (int j = 0; j < len; ++j) {
+        final LXPoint p = points[j];
+        final float nx = (p.xn + driftX) * freq;
+        final float nz = (p.zn + driftZ) * freq;
+        final float base = Noise.stb_perlin_fbm_noise3(nx, nz, t, 2.0f, 0.5f, 3);
+        final float chopRaw =
+          Noise.stb_perlin_turbulence_noise3(nx * 2.3f, nz * 2.3f, t * 1.7f, 2.2f, 0.5f, 4);
+        final float chopN = (chopRaw - 0.5f) * 2.0f;
+        final double n = base + chopN * chopAmt * 1.2;
+
+        // Y=0 is the top of the column, so invert the index for a bottom-up fill.
+        final double vBottom = (last == 0) ? 0.0 : (double) (last - j) / last;
+        final double localLevel = level + n * amp;
+        final double d = localLevel - vBottom; // >0 below the surface (in the liquid)
+        final double mix = LXUtils.clamp(0.5 + 0.5 * d * INV_BAND, 0, 1);
+
+        int c;
+        if (mix <= 0.0) {
+          c = prev;
+        } else if (mix >= 1.0) {
+          c = curr;
+        } else {
+          c = LXColor.lerp(prev, curr, (float) mix);
+        }
+
+        // depth-shade the liquid body: brightest at the waterline, noise-modulated below
+        if (d > 0) {
+          double glow = 0.62 + 0.23 * LXUtils.clamp(1.0 - d * 2.0, 0, 1) + 0.15 * (base * 0.5 + 0.5);
+          c = LXColor.scaleBrightness(c, (float) Math.min(1.0, glow));
+        }
+
+        // whitewater foam riding the turbulent surface
+        final double fd = Math.abs(d) / foamW;
+        if (fd < 1.0) {
+          double foam = (1.0 - fd) * LXUtils.clamp((chopRaw - 0.35) * 3.0, 0, 1) * foamGain;
+          if (foam > 0) {
+            foam = LXUtils.clamp(foam, 0, 1);
+            foam = foam * foam * (3 - 2 * foam);
+            c = LXColor.lerp(c, LXColor.WHITE, (float) foam);
+          }
+        }
+
+        // sparse scintillating glints suspended below the surface
+        if (sparkleAmt > 0 && d > 0) {
+          int hs = p.index * 374761393 + tq * 668265263;
+          hs = (hs ^ (hs >>> 13)) * 1274126177;
+          double r = ((hs >>> 8) & 0xFFFF) / 65535.0;
+          if (r > sparkThresh) {
+            c = LXColor.lightest(c, LXColor.scaleBrightness(LXColor.WHITE, glint));
+          }
+        }
+
+        this.colors[p.index] = c;
+      }
+    }
+
+    // --- bubbles rising through the liquid ---
+    if (bubbleCount > 0 && level > 0.02) {
+      final int w = o.width();
+      final int h = o.height();
+      final int bubbleColor = LXColor.lerp(curr, LXColor.WHITE, 0.7f);
+      for (int i = 0; i < bubbleCount; ++i) {
+        if (!tide.binit[i] || tide.by[i] >= level) {
+          continue; // only visible within the liquid body
+        }
+        double gx = tide.bx[i] * w;
+        double gy = (h - 1) * (1.0 - tide.by[i]); // by=0 bottom -> y=h-1
+        // brighter deep down, fading as it nears the surface
+        double depth = (level - tide.by[i]) / level;
+        double b = 0.35 + 0.65 * LXUtils.clamp(depth * 1.8, 0, 1);
+        splat(o, w, h, gx, gy, 1.0 + tide.bsize[i], b, bubbleColor);
+      }
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Cooked.java
+++ b/src/main/java/apotheneum/piemonte/Cooked.java
@@ -23,17 +23,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Cooked extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_SNAKES = 96;
   private static final int MAX_LEN = 64;
@@ -55,10 +48,6 @@ public class Cooked extends ParameterPattern {
   public final DiscreteParameter length =
     new DiscreteParameter("Length", 26, 5, MAX_LEN)
     .setDescription("Snake body length");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     int w, h;
@@ -125,14 +114,14 @@ public class Cooked extends ParameterPattern {
     addParameter("snakes", this.snakes);
     addParameter("rate", this.rate);
     addParameter("length", this.length);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
     this.timeMs += deltaMs;
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, deltaMs);
     }
@@ -232,26 +221,28 @@ public class Cooked extends ParameterPattern {
           break;
         }
 
-        // slither forward
+        // slither forward; note the cell the tail vacates BEFORE the head
+        // moves — computing it after resolves to the still-occupied tail and
+        // leaves a stale owner entry (false collisions on multi-step frames)
+        final boolean willGrow = s.curLen[i] < Math.min(maxLen, MAX_LEN);
+        final int vacated = willGrow ? -1
+          : s.body[i][(s.headIdx[i] - s.curLen[i] + 1 + MAX_LEN * 2) % MAX_LEN];
         s.headIdx[i] = (s.headIdx[i] + 1) % MAX_LEN;
         s.body[i][s.headIdx[i]] = cell;
-        if (s.curLen[i] < Math.min(maxLen, MAX_LEN)) {
+        if (willGrow) {
           s.curLen[i]++;
         }
         s.owner[cell] = i;
-        // release the vacated tail cell
-        final int tailCell = s.body[i][(s.headIdx[i] - s.curLen[i] + 1 + MAX_LEN * 2) % MAX_LEN];
-        if (s.owner[tailCell] == i && tailCell != cell) {
-          // only clear if the tail actually moved off it this step
+        if (vacated >= 0 && vacated != cell && s.owner[vacated] == i) {
           boolean stillBody = false;
           for (int k = 0; k < s.curLen[i]; ++k) {
-            if (s.body[i][(s.headIdx[i] - k + MAX_LEN * 2) % MAX_LEN] == tailCell) {
+            if (s.body[i][(s.headIdx[i] - k + MAX_LEN * 2) % MAX_LEN] == vacated) {
               stillBody = true;
               break;
             }
           }
           if (!stillBody) {
-            s.owner[tailCell] = -1;
+            s.owner[vacated] = -1;
           }
         }
       }

--- a/src/main/java/apotheneum/piemonte/Cooked.java
+++ b/src/main/java/apotheneum/piemonte/Cooked.java
@@ -1,0 +1,297 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Cooked — Snake, but the whole arcade at once. A massive population of
+ * glowing snakes carves right-angle paths across the surfaces, each dragging
+ * a fading tail. When a snake's head runs into another snake's tail it's
+ * over: the loser glitches — strobing cyan-white, jittering like SpecialKube —
+ * and fades away, while a fresh snake hatches somewhere else. The Rate knob
+ * sets how fast they run; Wow makes them twitchier and the deaths more
+ * spectacular. Inspired by the racing right-angle strand runs of the
+ * holotrigger reference.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Cooked extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_SNAKES = 96;
+  private static final int MAX_LEN = 64;
+  private static final int CYAN = LXColor.rgb(0, 255, 255);
+  private static final int STROBE_COLOR = LXColor.lerp(LXColor.WHITE, CYAN, 0.30f);
+  private static final double DIE_MS = 500;      // glitch-out duration
+  private static final double RESPAWN_MS = 400;
+  private static final double BASE_STEPS_S = 26; // cells/sec at Rate 0.5
+  private static final double HUE_SPREAD = 70;   // per-snake hue variety
+
+  public final DiscreteParameter snakes =
+    new DiscreteParameter("Snakes", 48, 8, MAX_SNAKES)
+    .setDescription("How many snakes run at once per surface");
+
+  public final CompoundParameter rate =
+    new CompoundParameter("Rate", 0.5, 0.05, 1)
+    .setDescription("How fast the snakes run");
+
+  public final DiscreteParameter length =
+    new DiscreteParameter("Length", 26, 5, MAX_LEN)
+    .setDescription("Snake body length");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    // ring-buffer bodies: packed cells (y * w + x), newest at headIdx
+    final int[][] body = new int[MAX_SNAKES][MAX_LEN];
+    final int[] headIdx = new int[MAX_SNAKES];
+    final int[] curLen = new int[MAX_SNAKES];
+    final int[] dx = new int[MAX_SNAKES];
+    final int[] dy = new int[MAX_SNAKES];
+    final double[] stepAcc = new double[MAX_SNAKES];
+    final double[] speedVar = new double[MAX_SNAKES];
+    final double[] raceMs = new double[MAX_SNAKES]; // racer phase time remaining
+    final double[] hue = new double[MAX_SNAKES];
+    final double[] dieMs = new double[MAX_SNAKES];  // >0 while glitching out
+    final double[] waitMs = new double[MAX_SNAKES]; // respawn delay
+    final boolean[] alive = new boolean[MAX_SNAKES];
+    int[] owner; // occupancy grid, -1 = empty
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) return;
+      this.w = w;
+      this.h = h;
+      this.owner = new int[w * h];
+      for (int i = 0; i < MAX_SNAKES; ++i) {
+        this.alive[i] = false;
+        this.dieMs[i] = 0;
+        this.waitMs[i] = Math.random() * 600;
+      }
+      this.inited = true;
+    }
+
+    void hatch(int i) {
+      final int x = (int) (Math.random() * this.w);
+      final int y = 1 + (int) (Math.random() * (this.h - 2));
+      // start moving in a random cardinal direction
+      if (Math.random() < 0.6) { // mostly horizontal, like the reference runs
+        this.dx[i] = Math.random() < 0.5 ? 1 : -1;
+        this.dy[i] = 0;
+      } else {
+        this.dx[i] = 0;
+        this.dy[i] = Math.random() < 0.5 ? 1 : -1;
+      }
+      this.headIdx[i] = 0;
+      this.curLen[i] = 1;
+      this.body[i][0] = y * this.w + x;
+      this.stepAcc[i] = 0;
+      this.speedVar[i] = 0.7 + Math.random() * 0.6;
+      // most snakes hatch as fast racers, then settle into crawlers
+      this.raceMs[i] = (Math.random() < 0.7) ? 900 + Math.random() * 900 : 0;
+      this.hue[i] = Math.random();
+      this.dieMs[i] = 0;
+      this.alive[i] = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double timeMs = 0;
+
+  public Cooked(LX lx) {
+    // Base registers color (base hue), speed (unused: Rate governs), size (glow width).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("snakes", this.snakes);
+    addParameter("rate", this.rate);
+    addParameter("length", this.length);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final double wow = getWow();
+    final int want = Math.min(MAX_SNAKES, this.snakes.getValuei());
+    final int maxLen = this.length.getValuei();
+    // parameterized speed: Rate knob, quadratic for reach at the top end
+    final double r = this.rate.getValue();
+    final double stepsPerMs = BASE_STEPS_S * (0.15 + 1.85 * r * r) * 2 / 1000.0;
+    final double turnCrawl = 0.12 + wow * 0.18; // crawlers meander
+    final double turnRace = 0.025 + wow * 0.06;  // racers run straight, rare jogs
+
+    // rebuild occupancy from living bodies
+    java.util.Arrays.fill(s.owner, -1);
+    for (int i = 0; i < MAX_SNAKES; ++i) {
+      if (!s.alive[i] || s.dieMs[i] > 0) continue;
+      for (int k = 0; k < s.curLen[i]; ++k) {
+        final int cell = s.body[i][(s.headIdx[i] - k + MAX_LEN * 2) % MAX_LEN];
+        s.owner[cell] = i;
+      }
+    }
+
+    int alive = 0;
+    for (int i = 0; i < MAX_SNAKES; ++i) {
+      if (s.alive[i]) ++alive;
+    }
+
+    for (int i = 0; i < MAX_SNAKES; ++i) {
+      if (!s.alive[i]) {
+        if (alive < want) {
+          s.waitMs[i] -= deltaMs;
+          if (s.waitMs[i] <= 0) {
+            s.hatch(i);
+            ++alive;
+          }
+        }
+        continue;
+      }
+
+      // dying: glitch out, then free the slot
+      if (s.dieMs[i] > 0) {
+        s.dieMs[i] -= deltaMs;
+        if (s.dieMs[i] <= 0) {
+          s.alive[i] = false;
+          s.waitMs[i] = RESPAWN_MS + Math.random() * 600;
+          --alive;
+        }
+        continue;
+      }
+
+      // advance in grid steps; racers run ~3.5x until they settle
+      final boolean racing = s.raceMs[i] > 0;
+      if (racing) {
+        s.raceMs[i] -= deltaMs;
+      }
+      s.stepAcc[i] += deltaMs * stepsPerMs * s.speedVar[i] * (racing ? 3.5 : 1.0);
+      int guard = 0;
+      while (s.stepAcc[i] >= 1 && guard++ < 6) {
+        s.stepAcc[i] -= 1;
+
+        // occasional right-angle turn; forced at the top/bottom walls
+        final int hx = s.body[i][s.headIdx[i]] % w;
+        final int hy = s.body[i][s.headIdx[i]] / w;
+        if (Math.random() < (racing ? turnRace : turnCrawl)) {
+          if (s.dx[i] != 0) {
+            s.dx[i] = 0;
+            s.dy[i] = Math.random() < 0.5 ? 1 : -1;
+          } else {
+            s.dy[i] = 0;
+            s.dx[i] = Math.random() < 0.5 ? 1 : -1;
+          }
+        }
+        int ny = hy + s.dy[i];
+        if (ny < 0 || ny >= h) { // bounce off floor/ceiling into a horizontal run
+          s.dy[i] = 0;
+          s.dx[i] = Math.random() < 0.5 ? 1 : -1;
+          ny = hy;
+        }
+        final int nx = ((hx + s.dx[i]) % w + w) % w;
+        final int cell = ny * w + nx;
+
+        // the kill rule: another snake's body ends this one
+        final int hit = s.owner[cell];
+        if (hit >= 0 && hit != i) {
+          s.dieMs[i] = DIE_MS * (1 + wow * 0.6);
+          break;
+        }
+
+        // slither forward
+        s.headIdx[i] = (s.headIdx[i] + 1) % MAX_LEN;
+        s.body[i][s.headIdx[i]] = cell;
+        if (s.curLen[i] < Math.min(maxLen, MAX_LEN)) {
+          s.curLen[i]++;
+        }
+        s.owner[cell] = i;
+        // release the vacated tail cell
+        final int tailCell = s.body[i][(s.headIdx[i] - s.curLen[i] + 1 + MAX_LEN * 2) % MAX_LEN];
+        if (s.owner[tailCell] == i && tailCell != cell) {
+          // only clear if the tail actually moved off it this step
+          boolean stillBody = false;
+          for (int k = 0; k < s.curLen[i]; ++k) {
+            if (s.body[i][(s.headIdx[i] - k + MAX_LEN * 2) % MAX_LEN] == tailCell) {
+              stillBody = true;
+              break;
+            }
+          }
+          if (!stillBody) {
+            s.owner[tailCell] = -1;
+          }
+        }
+      }
+    }
+
+    // --- draw ---
+    final double baseHue = LXColor.h(getColor());
+    final int tq = (int) (this.timeMs / 60);
+    for (int i = 0; i < MAX_SNAKES; ++i) {
+      if (!s.alive[i]) continue;
+      final boolean dying = s.dieMs[i] > 0;
+      final double dieF = dying ? LXUtils.clamp(s.dieMs[i] / DIE_MS, 0, 1) : 1;
+      final double grpHue = (s.hue[i] < 0.7)
+        ? 120 + (s.hue[i] / 0.7 - 0.5) * 22   // green family (~70%)
+        : 10 + ((s.hue[i] - 0.7) / 0.3 - 0.5) * 20; // red-orange family (~30%)
+      final float hue = (float) (((baseHue - 120 + grpHue) % 360 + 360) % 360);
+      final int col = LXColor.hsb(hue, 92, 100);
+      final int head = LXColor.lerp(col, LXColor.WHITE, 0.6f);
+      // dying snakes strobe cyan-white in sync, SpecialKube-style
+      final boolean strobeOn = dying && ((tq + i) & 1) == 0;
+
+      for (int k = 0; k < s.curLen[i]; ++k) {
+        final int cell = s.body[i][(s.headIdx[i] - k + MAX_LEN * 2) % MAX_LEN];
+        int x = cell % w;
+        final int y = cell / w;
+        double b = (k == 0 ? 1.0 : Math.exp(-2.0 * k / s.curLen[i])) * dieF;
+        int c = (k == 0) ? head : col;
+        if (dying) {
+          if (strobeOn) {
+            c = STROBE_COLOR;
+            b = Math.min(1, b * 2.2);
+            x = ((x + (int) ((Math.random() - 0.5) * (2 + getWow() * 4))) % w + w) % w; // jitter
+          } else {
+            b *= 0.4;
+          }
+        }
+        final int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Cope.java
+++ b/src/main/java/apotheneum/piemonte/Cope.java
@@ -20,17 +20,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Cope extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_PULSE = 8;
   private static final double MIN_BEAT_MS = 110;
@@ -48,10 +41,6 @@ public class Cope extends ParameterPattern {
   public final DiscreteParameter lines =
     new DiscreteParameter("Lines", 6, 1, 24)
     .setDescription("Number of vertical lines around the cylinder");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** A surface's edge columns + a pool of expanding glow pulses. */
   private final class Surface {
@@ -119,19 +108,17 @@ public class Cope extends ParameterPattern {
     addParameter("reactivity", this.reactivity);
     addParameter("sensitivity", this.sensitivity);
     addParameter("lines", this.lines);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private boolean detectBeat(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
     this.sinceBeatMs += deltaMs;
 
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= MIN_BEAT_MS)
       && (bass > 0.01);
@@ -144,8 +131,7 @@ public class Cope extends ParameterPattern {
   }
 
   private double broadband() {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    return m.getAveragef(0, Math.max(1, m.numBands));
+    return this.level.getValue();
   }
 
   @Override
@@ -169,7 +155,7 @@ public class Cope extends ParameterPattern {
     this.beatKick *= Math.exp(-deltaMs / 250.0);
     final double norm = LXUtils.clamp((ratio - 0.55) * 1.6, 0, 1.2)
       + this.beatKick * 0.6;
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     final int nLines = this.lines.getValuei();
 
     if (t != Target.CYLINDER) {

--- a/src/main/java/apotheneum/piemonte/Cope.java
+++ b/src/main/java/apotheneum/piemonte/Cope.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Cope — the structure's vertical edges lit as thick glowing bars: the four
+ * corners of the cube and a set of evenly spaced lines around the cylinder. The
+ * bars breathe with the music, swelling thicker as the sound gets louder, and on
+ * a bass drop a bright radial glow erupts from an edge and blooms outward across
+ * the surface. Audio-reactive architecture.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Cope extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_PULSE = 8;
+  private static final double MIN_BEAT_MS = 110;
+  private static final double GLOW_BASE = 0.055;   // bloom growth, cells / ms at speed 1
+  private static final double MAXAGE_BASE = 1400;  // pulse lifetime (ms) at speed 1
+
+  public final CompoundParameter reactivity =
+    new CompoundParameter("Reactivity", 0.6, 0, 1)
+    .setDescription("How strongly audio thickens the edge bars");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Bass-drop trigger sensitivity for the radial glow");
+
+  public final DiscreteParameter lines =
+    new DiscreteParameter("Lines", 6, 1, 24)
+    .setDescription("Number of vertical lines around the cylinder");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** A surface's edge columns + a pool of expanding glow pulses. */
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    boolean isCube;
+    int builtLines = -1;
+    int[] edgeX = new int[0];
+    final double[] ox = new double[MAX_PULSE];
+    final double[] oy = new double[MAX_PULSE];
+    final double[] age = new double[MAX_PULSE];
+    final boolean[] alive = new boolean[MAX_PULSE];
+
+    void ensure(int w, int h, boolean isCube, int nLines) {
+      if (this.inited && this.w == w && this.h == h
+          && (isCube || this.builtLines == nLines)) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.isCube = isCube;
+      this.inited = true;
+      if (isCube) {
+        this.edgeX = new int[] { 0, 50, 100, 150 }; // the four vertical corners
+        this.builtLines = -1;
+      } else {
+        this.edgeX = new int[nLines];
+        for (int k = 0; k < nLines; ++k) {
+          this.edgeX[k] = (int) Math.round((double) k * w / nLines);
+        }
+        this.builtLines = nLines;
+      }
+      for (int i = 0; i < MAX_PULSE; ++i) {
+        this.alive[i] = false;
+      }
+    }
+
+    void spawnPulse(double x, double y) {
+      for (int i = 0; i < MAX_PULSE; ++i) {
+        if (!this.alive[i]) {
+          this.ox[i] = x;
+          this.oy[i] = y;
+          this.age[i] = 0;
+          this.alive[i] = true;
+          return;
+        }
+      }
+      // pool full -> drop the request (oldest keeps blooming)
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  // shared bass-onset state (computed once per frame)
+  private double bassAvg, prevBass, sinceBeatMs, beatLevel;
+  private double levelEnv = 0;
+  private double levelAvg = 0; // slow auto-gain reference
+  private double beatKick = 0; // bars snap wide on each hit
+
+  public Cope(LX lx) {
+    // Base registers color (edge/glow tint), speed (glow expand/decay), size (base
+    // thickness), wow (glow intensity). We add audio + geometry controls.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("reactivity", this.reactivity);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("lines", this.lines);
+    addParameter("target", this.target);
+  }
+
+  private boolean detectBeat(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
+    this.sinceBeatMs += deltaMs;
+
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= MIN_BEAT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    return beat;
+  }
+
+  private double broadband() {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    return m.getAveragef(0, Math.max(1, m.numBands));
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final boolean beat = detectBeat(deltaMs);
+    final double level = broadband();
+    // attack/release envelope so the bars snap up quickly and relax smoothly
+    double aAtk = 1 - Math.exp(-deltaMs / 25.0);
+    double aRel = 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * (level > this.levelEnv ? aAtk : aRel);
+    // auto-gain drive: the envelope/average RATIO carries the dynamics (steady
+    // music sits ~0.9-1.0; hits spike it, gaps drop it). Expand the contrast
+    // around that resting point and snap on beats so the bars actually pump.
+    this.levelAvg += (level - this.levelAvg) * (1 - Math.exp(-deltaMs / 2500.0));
+    final double ratio = this.levelEnv / Math.max(1e-4, this.levelAvg);
+    if (beat) {
+      this.beatKick = 1;
+    }
+    this.beatKick *= Math.exp(-deltaMs / 250.0);
+    final double norm = LXUtils.clamp((ratio - 0.55) * 1.6, 0, 1.2)
+      + this.beatKick * 0.6;
+    final Target t = this.target.getEnum();
+    final int nLines = this.lines.getValuei();
+
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, beat, norm, true, 0);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, beat, norm, false, nLines);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs,
+      boolean beat, double level, boolean isCube, int nLines) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h, isCube, nLines);
+
+    final double wow = getWow();
+    final int base = getColor();
+
+    // --- thick vertical edge bars, thickness breathes with audio ---
+    final double baseR = 0.5 + getSize() * 4.0 + wow * 2.0;
+    final double thickMax = isCube ? w * 0.25 : 0.45 * (double) w / Math.max(1, nLines);
+    final double thick = LXUtils.clamp(
+      baseR + this.reactivity.getValue() * level * (thickMax - baseR) * 0.85, 0.5, thickMax);
+    final double barBright = 0.50 + 0.50 * LXUtils.clamp(level * 0.8, 0, 1);
+    for (int ex : s.edgeX) {
+      for (int y = 0; y < h; ++y) {
+        vbar(o, w, h, ex, y, thick, barBright, base);
+      }
+    }
+
+    // --- bass drop spawns a radial glow from a random edge ---
+    if (beat && s.edgeX.length > 0) {
+      double x0 = s.edgeX[(int) (Math.random() * s.edgeX.length)];
+      double y0 = (0.2 + 0.6 * Math.random()) * h;
+      s.spawnPulse(x0, y0);
+    }
+
+    // --- advance + draw glow pulses (bounded bbox, X-wrapped) ---
+    final double speed = getSpeed();
+    final double glowSpeed = GLOW_BASE * (0.5 + speed);
+    final double maxAge = MAXAGE_BASE / (0.5 + speed);
+    for (int i = 0; i < MAX_PULSE; ++i) {
+      if (!s.alive[i]) continue;
+      s.age[i] += deltaMs;
+      if (s.age[i] >= maxAge) {
+        s.alive[i] = false;
+        continue;
+      }
+      double R = glowSpeed * s.age[i] * (1.0 + wow * 0.5);
+      if (R < 0.5) continue;
+      double fade = LXUtils.clamp((1.0 - s.age[i] / maxAge) * (1.0 + wow), 0, 1.5);
+      double cx = s.ox[i], cy = s.oy[i];
+      int y0 = (int) Math.max(0, Math.floor(cy - R));
+      int y1 = (int) Math.min(h - 1, Math.ceil(cy + R));
+      int x0 = (int) Math.floor(cx - R);
+      int x1 = (int) Math.ceil(cx + R);
+      for (int yy = y0; yy <= y1; ++yy) {
+        double dy = yy - cy;
+        for (int xx = x0; xx <= x1; ++xx) {
+          double dx = xx - cx;
+          dx = dx - w * Math.rint(dx / w); // X-wrap distance
+          double d = Math.sqrt(dx * dx + dy * dy);
+          if (d > R) continue;
+          // traveling shock ring: Gaussian shell near the wavefront
+          double sigma = Math.max(1.0, 0.18 * R);
+          double rd = d - 0.85 * R;
+          double ring = Math.exp(-(rd * rd) / (2 * sigma * sigma));
+          double b = LXUtils.clamp(ring * fade * fade, 0, 1);
+          if (b <= 0) continue;
+          // white flash core, only during the pulse's early life
+          double core = (s.age[i] < 150) ? LXUtils.clamp(1.0 - d / (R * 0.4), 0, 1) : 0;
+          int c = LXColor.lerp(base, LXColor.WHITE, (float) core);
+          int xi = ((xx % w) + w) % w;
+          int idx = o.point(xi, yy).index;
+          this.colors[idx] = LXColor.lightest(this.colors[idx],
+            LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+        }
+      }
+    }
+  }
+
+  /** A thick vertical bar segment: 1-D horizontal falloff, X-wrapped (corner spill). */
+  private void vbar(Apotheneum.Orientation o, int w, int h, double cx, int y,
+      double r, double bright, int color) {
+    int x0 = (int) Math.floor(cx - r);
+    int x1 = (int) Math.ceil(cx + r);
+    for (int xx = x0; xx <= x1; ++xx) {
+      double u = 1.0 - Math.abs(xx - cx) / r;
+      if (u <= 0) continue;
+      double f = u * u * bright; // gamma falloff for a tighter profile
+      int cc = color;
+      if (u > 0.8) {
+        cc = LXColor.lerp(color, LXColor.WHITE, (float) ((u - 0.8) / 0.2 * 0.6)); // hot core
+      }
+      int xi = ((xx % w) + w) % w;
+      int idx = o.point(xi, y).index;
+      this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(cc, (float) f));
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/CrashingOut.java
+++ b/src/main/java/apotheneum/piemonte/CrashingOut.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * CrashingOut — LockedIn's restless sibling. A set of thick bars beams in
+ * from an edge as solid columns, each on its own clock — fast travel,
+ * decelerating approach, bounces on the entry velocity model — and locks
+ * into the center. But nothing stays locked: the bars keep bouncing, restless,
+ * until the whole set crashes back out — each bar retreating mid-bounce in
+ * reverse off its entry edge, slow to break loose and accelerating away. Then the next set enters from
+ * the opposite edge at a new horizontal offset and the next of five colors.
+ * Beats punch the bounces; Wow adds bounce reach and speeds the crash.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class CrashingOut extends StrandPattern {
+
+  private static final int N_COLORS = 5;
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_MS = 1800;    // sustained bounce before the crash
+  private static final double GONE = 1.25;         // off-canvas travel distance
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // one set at a time (normalized; shared across surfaces)
+  private final double[] barX = new double[MAX_BARS];
+  private final double[] barLen = new double[MAX_BARS];
+  private final double[] barYc = new double[MAX_BARS];
+  private final int[] barPhase = new int[MAX_BARS]; // 0 enter, 1 bounce, 3 crash
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barRnd = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];
+  private final int[] barBounce = new int[MAX_BARS];
+
+  private int gen = 0;          // total sets launched (drives color + edge)
+  private boolean fromTop = false;
+  private int mode = 0;         // 0 = animating in, 1 = bouncing, 2 = crashing out
+  private double holdT = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  public CrashingOut(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(this.gen * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void launchSet() {
+    this.fromTop = (this.gen & 1) == 1; // alternate bottom / top entries
+    this.mode = 0;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.barX[b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.barLen[b] = (0.14 + Math.random() * 0.30) * (0.8 + Math.random() * 0.4);
+      this.barYc[b] = 0.42 + Math.random() * 0.16;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.fromTop ? -1 : 1) * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barRnd[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    final int nBars = this.bars.getValuei();
+
+    // bars never sit still: they enter, bounce, and bounce until they crash away
+    boolean allArrived = true;
+    boolean allGone = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          allArrived = false;
+          allGone = false;
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            this.barBounce[b] = 0;
+            this.barTgt[b] = (this.fromTop ? 1 : -1) * bounceAmp(b);
+          }
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel, sustained
+          allGone = false;
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            // reverse into a fresh bounce, each with its own reach — no settling
+            ++this.barBounce[b];
+            this.barTgt[b] = -Math.signum(this.barTgt[b]) * bounceAmp(b)
+              * (0.55 + 0.45 * hashd(this.gen * 31 + b * 7 + this.barBounce[b] * 13));
+          }
+          break;
+        }
+        case 3: { // crashing out: the entry run in reverse, off the canvas
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allGone = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          // slow to break loose, accelerating as it pulls away
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1)) * (1 + wow * 0.8);
+          final double dir = this.fromTop ? -1 : 1; // back toward its entry edge
+          this.barPos[b] += dir * v * dt;
+          if (dist < GONE) {
+            allGone = false;
+          }
+          break;
+        }
+      }
+    }
+
+    if (this.mode == 0 && allArrived) { // everyone's in and bouncing
+      this.mode = 1;
+      this.holdT = 0;
+    } else if (this.mode == 1) { // bounce it out, then break for the edges
+      this.holdT += dt;
+      if (this.holdT >= BOUNCE_MS) {
+        this.mode = 2;
+        for (int b = 0; b < MAX_BARS; ++b) {
+          this.barPhase[b] = 3;
+          this.barDelay[b] = Math.random() * 500; // staggered break-loose
+        }
+      }
+    } else if (this.mode == 2 && allGone) { // next color from the opposite edge
+      ++this.gen;
+      launchSet();
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    final int col = LXColor.hsb(
+      (float) (((LXColor.h(getColor()) + HUE_STEPS[this.gen % N_COLORS]) % 360) + 360) % 360,
+      92, 100);
+    final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+
+    for (int b = 0; b < nBars; ++b) {
+      final double len = this.barLen[b];
+      double yc = this.barYc[b];
+      boolean traveling = false;
+      if (this.barPhase[b] == 0 || this.barPhase[b] == 3) {
+        if (this.barPhase[b] == 0 && this.barDelay[b] > 0) continue; // not launched
+        yc += this.barPos[b];
+        traveling = true;
+      } else if (this.barPhase[b] == 1) {
+        yc += this.barPos[b]; // bouncing
+      }
+      // solid column anchored to its entry edge, reaching to its lead end
+      final double leadF = this.fromTop
+        ? (yc + len / 2) * (h - 1)
+        : (yc - len / 2) * (h - 1);
+      if (this.fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+      final int x0 = (int) Math.round(this.barX[b] * w);
+      final int bw = (int) thickC;
+      final double span = this.fromTop
+        ? Math.max(1, leadF)
+        : Math.max(1, (h - 1) - leadF);
+
+      for (int dx = 0; dx < bw; ++dx) {
+        final int x = x0 + dx;
+        final int yStart = this.fromTop ? 0 : (int) Math.floor(leadF);
+        final int yEnd = this.fromTop ? (int) Math.ceil(leadF) : h - 1;
+        for (int yy = yStart; yy <= yEnd; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = this.fromTop ? (yy - leadF) : (leadF - yy);
+          final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+          if (cov <= 0.02) continue;
+          final double back = Math.abs(yy - leadF) / span;
+          int c = col;
+          double bb = cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+            * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + tq));
+          if (traveling && Math.abs(yy - leadF) < 1.5) {
+            c = hot;
+            bb = Math.min(1, bb * 1.5);
+          }
+          addPix(o, x, yy, c, bb);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Crush.java
+++ b/src/main/java/apotheneum/piemonte/Crush.java
@@ -26,17 +26,10 @@ import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Crush extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double DESC_RATE = 0.0006;   // beam descent / ms at speed 1
   private static final double POUR_RATE = 0.00035;  // pour-line descent / ms at speed 1
@@ -58,10 +51,6 @@ public class Crush extends ParameterPattern {
     new BooleanParameter("Strobe", false)
     .setMode(BooleanParameter.Mode.MOMENTARY)
     .setDescription("Strobe the region above the surface line while held");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final GradientUtils.ColorStops stops = new GradientUtils.ColorStops();
 
@@ -96,7 +85,7 @@ public class Crush extends ParameterPattern {
     addParameter("bands", this.bands);
     addParameter("sensitivity", this.sensitivity);
     addParameter("strobe", this.strobe);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void reset(int n) {
@@ -123,14 +112,12 @@ public class Crush extends ParameterPattern {
   }
 
   private boolean detectDrop(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.15 + (1 - sens) * 0.8;
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= 300)
       && (bass > 0.01);
@@ -138,7 +125,7 @@ public class Crush extends ParameterPattern {
     if (beat) {
       this.sinceBeatMs = 0;
     }
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0)
       : 1 - Math.exp(-deltaMs / 220.0);
@@ -233,7 +220,7 @@ public class Crush extends ParameterPattern {
     final boolean strobeOn = this.strobe.isOn()
       && (frac0(this.timeMs * 0.001 * STROBE_HZ) < 0.45);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       draw(Apotheneum.cube.exterior, n, edge, fillTop, beamColor, beamTop, bandH, flashE, amp, strobeOn);
     }

--- a/src/main/java/apotheneum/piemonte/Crush.java
+++ b/src/main/java/apotheneum/piemonte/Crush.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Crush — segmented beams spiral down like a zoetrope drum, orbiting the
+ * structure as they fall, and land band by band into a stacked palette
+ * gradient. Once the canvas is full, the piece lives in pours: on a drop in
+ * the music (or on its own clock in silence), a new gradient pours DOWN from
+ * the top behind a large, churning liquid surface line — ComeUp inverted,
+ * with a taller and more turbulent waterline — repainting the canvas color by
+ * color, pour after pour. A momentary Strobe button flashes only the region
+ * above the surface line.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.GradientUtils;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Crush extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double DESC_RATE = 0.0006;   // beam descent / ms at speed 1
+  private static final double POUR_RATE = 0.00035;  // pour-line descent / ms at speed 1
+  private static final double ORBIT_RATE = 0.00012; // beam orbit, revs / ms at speed 1
+  private static final double GRAD_STEP = 0.382;    // gradient shift per pour (golden)
+  private static final double STROBE_HZ = 9;
+  private static final int POURS_PER_CYCLE = 3;  // pours before the teardown
+  private static final double TEAR_MS = 2800;    // slit-expansion duration
+
+  public final DiscreteParameter bands =
+    new DiscreteParameter("Bands", 8, 2, 24)
+    .setDescription("Number of equal bands that stack up the height");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How easily a drop in the music starts a pour");
+
+  public final BooleanParameter strobe =
+    new BooleanParameter("Strobe", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Strobe the region above the surface line while held");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final GradientUtils.ColorStops stops = new GradientUtils.ColorStops();
+
+  // build state
+  private int settled = 0;
+  private double beamBottom = 1;
+  private double orbit = 0;        // shared zoetrope orbit phase
+  private boolean full = false;
+  private boolean started = false;
+  private int lastN = -1;
+  private double flashMs = 0;
+
+  // pour state
+  private boolean pouring = false;
+  private double pourLevel = 1;    // bottom-up fraction of the surface line
+  private double gradOffset = 0;   // settled gradient scroll
+  private double nextOffset = 0;
+  private double sincePourMs = 0;
+  private int poursDone = 0;
+  private boolean tearing = false;
+  private double tearT = 0;
+
+  // audio (Cope-style)
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+  private double timeMs = 0;
+
+  public Crush(LX lx) {
+    // Base registers color, speed (fall/pour rate), size (surface amplitude + edge).
+    // (Band colors come from the project palette gradient, not the Color param.)
+    super(lx, 0.4, 0, 1, 0.5, 0, 1);
+    addParameter("bands", this.bands);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("strobe", this.strobe);
+    addParameter("target", this.target);
+  }
+
+  private void reset(int n) {
+    this.settled = 0;
+    this.poursDone = 0;
+    this.tearing = false;
+    this.tearT = 0;
+    this.full = false;
+    this.pouring = false;
+    this.gradOffset = 0;
+    this.nextOffset = 0;
+    this.beamBottom = 1.0 - 1.0 / n;
+    this.started = true;
+    this.lastN = n;
+  }
+
+  private int gradient(double lerp) {
+    return this.stops.getColor((float) LXUtils.clamp(frac0(lerp), 0, 1),
+      GradientUtils.BlendFunction.HSVM);
+  }
+
+  private static double frac0(double x) {
+    return x - Math.floor(x);
+  }
+
+  private boolean detectDrop(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.15 + (1 - sens) * 0.8;
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 300)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+    return beat;
+  }
+
+  /** Churning surface line offset (normalized) at column fraction x01. */
+  private double surf(double x01, double amp) {
+    final double t = this.timeMs * 0.001;
+    return amp * (0.50 * Math.sin(2 * Math.PI * (x01 * 3 + t * 0.9))
+                + 0.30 * Math.sin(2 * Math.PI * (x01 * 7 - t * 1.7))
+                + 0.20 * Math.sin(2 * Math.PI * (x01 * 11 + t * 3.1)));
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    final int n = this.bands.getValuei();
+    if (!this.started || n != this.lastN) {
+      reset(n);
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    final boolean drop = detectDrop(deltaMs);
+    final double bandH = 1.0 / n;
+    this.flashMs = Math.max(0, this.flashMs - deltaMs);
+    final double wow = getWow();
+    // Wow = frenzy: the spiral spins harder, pours churn taller and run
+    // faster, and the teardown rips through quicker
+    this.orbit += ORBIT_RATE * speed * deltaMs * (1 + wow * 3);
+
+    // --- build phase: spiraling beams stack up the gradient ---
+    if (!this.full) {
+      double targetBottom = (double) this.settled / n;
+      this.beamBottom -= DESC_RATE * speed * deltaMs;
+      if (this.beamBottom <= targetBottom) {
+        this.beamBottom = targetBottom;
+        this.settled++;
+        this.flashMs = 250;
+        if (this.settled >= n) {
+          this.full = true;
+          this.sincePourMs = 0;
+        } else {
+          this.beamBottom = 1.0 - bandH;
+        }
+      }
+    } else if (!this.pouring) {
+      // full: wait for a drop (or pour on a clock in silence)
+      this.sincePourMs += deltaMs;
+      final boolean quiet = this.levelEnv < 0.04;
+      if (drop || (quiet && this.sincePourMs > 6000)) {
+        this.pouring = true;
+        this.pourLevel = 1.15;
+        this.nextOffset = this.gradOffset + GRAD_STEP;
+      }
+    } else {
+      this.pourLevel -= POUR_RATE * speed * deltaMs * (1 + this.levelEnv * 0.8 + wow * 0.9);
+      final double amp = (0.05 + getSize() * 0.09) * (1 + wow * 0.8);
+      if (this.pourLevel < -amp - 0.05) {
+        this.gradOffset = this.nextOffset;
+        this.pouring = false;
+        this.sincePourMs = 0;
+        if (++this.poursDone >= POURS_PER_CYCLE) {
+          this.tearing = true; // the loop: split, empty, and build again
+          this.tearT = 0;
+        }
+      }
+    }
+    if (this.tearing) {
+      this.tearT += deltaMs * Math.max(0.02, getSpeed()) * 2 * (1 + wow) / TEAR_MS;
+      if (this.tearT >= 1.1) {
+        final double keepOffset = this.gradOffset;
+        reset(this.bands.getValuei());
+        this.gradOffset = keepOffset; // next build lands on fresh palette footing
+      }
+    }
+
+    // refresh palette gradient (in case the swatch changed)
+    int numStops = this.lx.engine.palette.swatch.colors.size();
+    this.stops.setPaletteGradient(this.lx.engine.palette, 0, Math.max(1, numStops));
+
+    final double edge = Math.max(0.01, (0.08 + getSize() * 0.35) * bandH);
+    final double fillTop = (double) this.settled / n;
+    final double beamLerp = (this.settled + 0.5) / n;
+    final int beamColor = this.full ? 0 : gradient(beamLerp);
+    final double beamTop = this.beamBottom + bandH;
+    final double flashE = this.flashMs / 250.0;
+    final double amp = (0.05 + getSize() * 0.09) * (1 + wow * 0.8); // pour surface amplitude
+    final boolean strobeOn = this.strobe.isOn()
+      && (frac0(this.timeMs * 0.001 * STROBE_HZ) < 0.45);
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      draw(Apotheneum.cube.exterior, n, edge, fillTop, beamColor, beamTop, bandH, flashE, amp, strobeOn);
+    }
+    if (t != Target.CUBE) {
+      draw(Apotheneum.cylinder.exterior, n, edge, fillTop, beamColor, beamTop, bandH, flashE, amp, strobeOn);
+    }
+    copyExterior();
+  }
+
+  private void draw(Apotheneum.Orientation o, int n, double edge,
+      double fillTop, int beamColor, double beamTop, double bandH, double flashE,
+      double amp, boolean strobeOn) {
+    final int w = o.width();
+    final int nSegs = 6; // zoetrope segmentation of the falling beam
+    final double gapFrac = 0.22;
+
+    int ci = 0;
+    for (Apotheneum.Column column : o.columns()) {
+      final LXPoint[] points = column.points;
+      final int last = points.length - 1;
+      final double x01 = (double) ci / w;
+      // this column's position within the orbiting segment cycle
+      final double segPhase = frac0((x01 + this.orbit) * nSegs);
+      final boolean inGap = segPhase > (1.0 - gapFrac);
+      final double surfOff = surf(x01, amp);
+
+      for (int j = 0; j < points.length; ++j) {
+        final double vB = (last == 0) ? 0.0 : (double) (last - j) / last;
+        int c = LXColor.BLACK;
+        double surfaceLine;
+
+        if (this.full && this.tearing) {
+          surfaceLine = 1.0;
+          // vertical slits at the orbiting segment boundaries widen until dark
+          final double lit = 1.0 - LXUtils.clamp(this.tearT, 0, 1);
+          if (segPhase < lit) {
+            c = gradient(vB + this.gradOffset);
+            // feathered slit edges
+            final double e2 = LXUtils.clamp((lit - segPhase) / 0.06, 0, 1);
+            c = LXColor.scaleBrightness(c, (float) e2);
+          }
+        } else if (this.full) {
+          if (this.pouring) {
+            final double lineY = this.pourLevel + surfOff;
+            surfaceLine = lineY;
+            if (vB > lineY) {
+              c = gradient(vB + this.nextOffset); // new gradient pouring in above
+            } else {
+              c = gradient(vB + this.gradOffset);
+            }
+            // large churning foam band on the surface line itself
+            final double dLine = Math.abs(vB - lineY);
+            if (dLine < 0.035) {
+              final double f = 1.0 - dLine / 0.035;
+              c = LXColor.lerp(c, LXColor.WHITE, (float) (0.75 * f * f));
+            }
+          } else {
+            surfaceLine = 1.0; // idle full canvas: nothing above
+            c = gradient(vB + this.gradOffset);
+          }
+        } else {
+          surfaceLine = fillTop;
+          if (vB < fillTop) {
+            c = gradient(vB);
+            double gd = Math.abs(vB - fillTop);
+            if (flashE > 0 && gd < bandH * 0.4) {
+              c = LXColor.lerp(c, LXColor.WHITE,
+                (float) (flashE * flashE * smoothstep(bandH * 0.4, 0.0, gd)));
+            }
+          } else if (!inGap && vB >= this.beamBottom && vB <= beamTop) {
+            // spiraling segmented beam: soft edges, hot white head at its bottom
+            double d = Math.min(vB - this.beamBottom, beamTop - vB);
+            double bri = LXUtils.clamp(d / edge, 0, 1);
+            bri = bri * bri * (3 - 2 * bri);
+            // feather segment edges so the orbit reads smooth
+            final double segEdge = Math.min(segPhase, (1.0 - gapFrac) - segPhase) / 0.06;
+            bri *= LXUtils.clamp(segEdge, 0, 1);
+            double head = smoothstep(edge * 2.0, 0.0, vB - this.beamBottom);
+            c = LXColor.lerp(LXColor.scaleBrightness(beamColor, (float) bri),
+              LXColor.WHITE, (float) (0.5 * head * bri));
+          }
+        }
+
+        // strobe: only the region ABOVE the surface line
+        if (strobeOn && vB > surfaceLine) {
+          c = LXColor.lightest(c, LXColor.gray(85));
+        }
+        this.colors[points[j].index] = c;
+      }
+      ++ci;
+    }
+  }
+
+  private static double smoothstep(double e0, double e1, double x) {
+    double t = (x - e0) / (e1 - e0);
+    t = t < 0 ? 0 : (t > 1 ? 1 : t);
+    return t * t * (3 - 2 * t);
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Destination.java
+++ b/src/main/java/apotheneum/piemonte/Destination.java
@@ -22,17 +22,10 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Destination extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double TAU = Math.PI * 2;
   private static final int MAX_RAYS = 16;
@@ -49,10 +42,6 @@ public class Destination extends ParameterPattern {
   public final CompoundParameter flicker =
     new CompoundParameter("Flicker", 0.5, 0, 1)
     .setDescription("How much the light flickers");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -82,7 +71,7 @@ public class Destination extends ParameterPattern {
     addParameter("rays", this.rays);
     addParameter("flicker", this.flicker);
     addParameter("strobe", this.strobe);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -132,7 +121,7 @@ public class Destination extends ParameterPattern {
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/Destination.java
+++ b/src/main/java/apotheneum/piemonte/Destination.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Destination — a blazing point of light at the center of each face, throwing
+ * radial streaks outward with a bright horizontal bar across the middle, the
+ * whole thing flickering like a distant sun seen at the end of a long dark hall.
+ * Each ray carries its own palette hue, and Wow fans the ray hues further apart
+ * into a spectral burst. A "warp destination" glow. Inspired by the LXStudio-TE
+ * FourStar shader.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Destination extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double TAU = Math.PI * 2;
+  private static final int MAX_RAYS = 16;
+  private static final int CYAN = LXColor.rgb(0, 255, 255);
+  private static final int STROBE_COLOR = LXColor.lerp(LXColor.WHITE, CYAN, 0.30f);
+  private static final double RING_GAP = 9.0;     // cells between glitch rings
+  private static final double PULSE_SPEED = 0.045; // ring expansion, cells/ms
+  private static final double SPIN = 0.0002; // ray rotation, rad / ms at speed 1
+
+  public final DiscreteParameter rays =
+    new DiscreteParameter("Rays", 6, 2, MAX_RAYS)
+    .setDescription("Number of light streaks");
+
+  public final CompoundParameter flicker =
+    new CompoundParameter("Flicker", 0.5, 0, 1)
+    .setDescription("How much the light flickers");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    Panel(int[][] idx, int w, int h) { this.idx = idx; this.w = w; this.h = h; }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  private double baseAngle = 0;
+  private double timeMs = 0;
+  public final BooleanParameter strobe =
+    new BooleanParameter("Strobe", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Glitch glow pulses out from the star while held");
+
+  private double strobeEnv = 0;
+  private double pulseClock = 0;
+
+  private final double[] rayFlick = new double[MAX_RAYS];
+  private final int[] rayColor = new int[MAX_RAYS];
+
+  public Destination(LX lx) {
+    // Base registers color (flare tint), speed (spin + flicker rate), size (core/ray reach).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("rays", this.rays);
+    addParameter("flicker", this.flicker);
+    addParameter("strobe", this.strobe);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double angDiff(double a, double b) {
+    double d = Math.abs(a - b) % TAU;
+    return Math.min(d, TAU - d);
+  }
+
+  private static double smoothstep(double e0, double e1, double x) {
+    double t = (x - e0) / (e1 - e0);
+    t = t < 0 ? 0 : (t > 1 ? 1 : t);
+    return t * t * (3 - 2 * t);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    this.timeMs += deltaMs;
+    this.baseAngle += SPIN * speed * deltaMs;
+    final double ts = this.timeMs * 0.001;
+
+    // global flicker + per-ray flicker (computed once per frame)
+    final double flAmt = this.flicker.getValue();
+    double fl = 0.5 + 0.5 * Math.sin(ts * 11 * speed) * Math.sin(ts * 6.7 * speed + 1.3);
+    final double gFlicker = LXUtils.lerp(1.0, 0.35 + 0.65 * fl, flAmt);
+    final int nRays = this.rays.getValuei();
+    for (int n = 0; n < nRays; ++n) {
+      double rf = 0.5 + 0.5 * Math.sin(ts * 9 * speed + n * 2.1) * Math.cos(ts * 5 * speed + n * 1.7);
+      this.rayFlick[n] = LXUtils.lerp(1.0, 0.25 + 0.75 * rf, flAmt);
+    }
+
+    final double size = getSize();
+    final int base = getColor();
+
+    // per-ray palette hues, fanned wider apart by Wow
+    final double wow = getWow();
+    final float baseHue = LXColor.h(base);
+    for (int n = 0; n < nRays; ++n) {
+      this.rayColor[n] = LXColor.hsb((float) ((baseHue + n * (30.0 + 60.0 * wow)) % 360), 85, 100);
+    }
+
+    // SpecialKube-style glitch strobe: cyan-white shockrings pulse outward
+    // from the star while the button is held, strobing and jittering
+    if (this.strobe.isOn()) {
+      this.strobeEnv = 1;
+      this.pulseClock += deltaMs;
+    } else if (this.strobeEnv > 0) {
+      this.strobeEnv = Math.max(0, this.strobeEnv - deltaMs / 600.0);
+      this.pulseClock += deltaMs;
+    }
+    final boolean strobeGate = (this.timeMs % 125.0) < 78; // ~8Hz glitch flicker
+    final double glitchJit = (this.strobeEnv > 0) ? (Math.random() - 0.5) * 2.5 : 0;
+
+    final double coreK = 0.10 + size * 0.22;   // brighter/larger core with Size
+    final double exposure = 0.05 + size * 0.05; // ray angular half-width
+    final double rayFade = 0.55;                // rays fade toward the edge
+    final double step = TAU / nRays;
+
+    for (Panel p : this.panels) {
+      final double cx = p.w * 0.5;
+      final double cy = p.h * 0.5;
+      final double halfDiag = 0.5 * Math.hypot(p.w, p.h);
+      final double bandW = 1.5 + size * 3.5;
+      for (int y = 0; y < p.h; ++y) {
+        double dyp = y - cy;
+        for (int x = 0; x < p.w; ++x) {
+          double dxp = x - cx;
+          double dist = Math.hypot(dxp, dyp) / halfDiag; // 0..~1
+          double ang = Math.atan2(dyp, dxp);
+
+          // bright inverse-distance core
+          double core = coreK / (dist + 0.06);
+
+          // radial streaks, tracking the strongest ray for its color
+          double rayB = 0;
+          double rayMax = 0;
+          int rayC = base;
+          for (int n = 0; n < nRays; ++n) {
+            double rayAng = this.baseAngle + n * step;
+            double ad = angDiff(ang, rayAng);
+            if (ad < exposure) {
+              double tt = 1.0 - ad / exposure;
+              double a = tt * tt * tt * Math.max(0, 1.0 - rayFade * dist);
+              rayB += a * this.rayFlick[n];
+              if (a * this.rayFlick[n] > rayMax) {
+                rayMax = a * this.rayFlick[n];
+                rayC = this.rayColor[n];
+              }
+            }
+          }
+
+          // horizontal light bar
+          double band = LXUtils.clamp(1.0 - Math.abs(dyp) / bandW, 0, 1)
+            * Math.max(0, 1.0 - dist * 0.6);
+
+          // glitch shockrings: concentric cyan-white pulses expanding from the
+          // star, strobing hard and jittering like SpecialKube's special cubes
+          double glitch = 0;
+          if (this.strobeEnv > 0.01 && strobeGate) {
+            final double distC = dist * halfDiag + glitchJit;
+            double dRing = (distC - this.pulseClock * PULSE_SPEED) % RING_GAP;
+            if (dRing < 0) dRing += RING_GAP;
+            dRing = Math.min(dRing, RING_GAP - dRing);
+            final double ring = Math.exp(-dRing * dRing / 2.2);
+            glitch = this.strobeEnv * ring * Math.max(0.25, 1.4 - dist * 1.1);
+          }
+
+          double b = (core + rayB * 0.8 + band * 0.7) * gFlicker;
+          b *= smoothstep(1.05, 0.45, dist); // vignette toward the panel edges
+          if (b <= 0.01 && glitch <= 0.01) continue;
+          b = LXUtils.clamp(b, 0, 1);
+
+          // tint toward the winning ray, then whiten the hot core
+          int cbase = LXColor.lerp(base, rayC, (float) LXUtils.clamp(rayMax * 1.5, 0, 1));
+          int c = LXColor.lerp(cbase, LXColor.WHITE, (float) LXUtils.clamp(core * 1.2, 0, 1));
+          int outC = LXColor.scaleBrightness(c, (float) b);
+          if (glitch > 0.01) {
+            outC = LXColor.lightest(outC,
+              LXColor.scaleBrightness(STROBE_COLOR, (float) LXUtils.clamp(glitch, 0, 1)));
+          }
+          this.colors[p.idx[x][y]] = outC;
+        }
+      }
+    }
+    copyExterior();
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Diabolical.java
+++ b/src/main/java/apotheneum/piemonte/Diabolical.java
@@ -20,16 +20,9 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 
 @LXCategory("Apotheneum/piemonte")
 public class Diabolical extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double ROT = 0.0006;    // rotation (twist) rad/ms at spin 1, speed 1
   private static final double SCROLL = 0.0016; // outward scroll / ms at speed 1
@@ -42,10 +35,6 @@ public class Diabolical extends ParameterPattern {
   public final CompoundParameter spin =
     new CompoundParameter("Spin", 0.4, 0, 1)
     .setDescription("How fast the spiral rotates");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -65,7 +54,7 @@ public class Diabolical extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("quantity", this.quantity);
     addParameter("spin", this.spin);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -110,7 +99,7 @@ public class Diabolical extends ParameterPattern {
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/Diabolical.java
+++ b/src/main/java/apotheneum/piemonte/Diabolical.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Diabolical — thick concentric diamond bands spiral out from the center in a shifting
+ * rainbow, rotating and radiating endlessly, each band whitening to a bright
+ * ridge along its spine. Wow ripples the whole field like a flag in the wind.
+ * A graphics-forward, hypnotic field inspired by the LXStudio-TE SpiralDiamonds
+ * shader.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+
+@LXCategory("Apotheneum/piemonte")
+public class Diabolical extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double ROT = 0.0006;    // rotation (twist) rad/ms at spin 1, speed 1
+  private static final double SCROLL = 0.0016; // outward scroll / ms at speed 1
+  private static final double HUE_SCALE = 26;  // hue degrees per ring
+
+  public final DiscreteParameter quantity =
+    new DiscreteParameter("Quantity", 4, 1, 8)
+    .setDescription("Number of concentric diamond rings");
+
+  public final CompoundParameter spin =
+    new CompoundParameter("Spin", 0.4, 0, 1)
+    .setDescription("How fast the spiral rotates");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    Panel(int[][] idx, int w, int h) { this.idx = idx; this.w = w; this.h = h; }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  private double twist = 0;   // spiral rotation
+  private double scroll = 0;  // outward radial scroll
+  private double timeMs = 0;
+
+  public Diabolical(LX lx) {
+    // Base registers color (base hue), speed (outward scroll), size (zoom).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("quantity", this.quantity);
+    addParameter("spin", this.spin);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double smoothstep(double e0, double e1, double x) {
+    double t = (x - e0) / (e1 - e0);
+    t = t < 0 ? 0 : (t > 1 ? 1 : t);
+    return t * t * (3 - 2 * t);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    this.timeMs += deltaMs;
+    this.twist += ROT * this.spin.getValue() * speed * deltaMs;
+    this.scroll += SCROLL * speed * deltaMs;
+
+    final int qn = this.quantity.getValuei();
+    final double k = 0.6321 * Math.pow(qn, -0.8794); // per-quadrant stitch angle
+    final double cosK = Math.cos(k), sinK = Math.sin(k);
+    final double baseHue = LXColor.h(getColor());
+    final double zoom = 0.6 + getSize() * 1.8;       // Size = feature scale
+    final double wow = getWow();
+    final double wts = this.timeMs * 0.002;
+
+    for (Panel p : this.panels) {
+      final double cx = p.w * 0.5;
+      final double cy = p.h * 0.5;
+      final double s = (0.5 * Math.hypot(p.w, p.h)) / zoom;
+      for (int y = 0; y < p.h; ++y) {
+        double uvyRow = (y - cy) / s;
+        for (int x = 0; x < p.w; ++x) {
+          double uvx = (x - cx) / s;
+          double uvy = uvyRow;
+
+          // Wow = flag-warp: ripple the field like cloth in the wind
+          if (wow > 0.01) {
+            double ox = uvx;
+            uvx -= wow * 0.08 * Math.sin(uvy * 9.0 + wts);
+            uvy += wow * 0.08 * Math.cos(ox * 9.0);
+          }
+
+          // rotated sign vector -> "diamond" metric (spiraling squares)
+          double sx = uvx >= 0 ? 1 : -1;
+          double sy = uvy >= 0 ? 1 : -1;
+          double rsx = sx * cosK - sy * sinK;
+          double rsy = sx * sinK + sy * cosK;
+          double dd = uvx * rsx + uvy * rsy;
+          if (dd < 1e-4) dd = 1e-4;
+
+          double ang = Math.atan2(rsy, rsx);
+          double ringPhase = qn * Math.log(dd) - this.scroll;
+          double dx = Math.abs(Math.sin(ringPhase + ang - this.twist));
+          double band = smoothstep(0.72, 0.48, dx); // thick band
+          band *= band; // deepen the gaps between bands
+          if (band <= 0.01) continue;
+          double ridge = smoothstep(0.30, 0.05, dx); // white ridge at the spine
+
+          double hue = ((baseHue + ringPhase * HUE_SCALE) % 360 + 360) % 360;
+          int c = LXColor.hsb((float) hue, (float) (88 - 50 * ridge), 100);
+          this.colors[p.idx[x][y]] = LXColor.scaleBrightness(c, (float) band);
+        }
+      }
+    }
+    copyExterior();
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Digits.java
+++ b/src/main/java/apotheneum/piemonte/Digits.java
@@ -1,0 +1,371 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Digits — a giant terminal readout: a handful of huge white-hot characters
+ * fill the wall nearly top to bottom, swapping as a group on the beat, over a
+ * dim churning field of small blue log-glyphs. On every swap, full-height red
+ * and blue strand flares ignite through the digits — the front/back curtain
+ * parallax — a red underline bar runs behind the readout, cyan and red debris
+ * streaks tangle at the base, and every few seconds the entire room washes
+ * hard red for a heartbeat. Modeled on the holotrigger glyph-display session.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Digits extends StrandPattern {
+
+  // 4×6 block font, hex digits 0-F: 6 rows of 4-bit masks (MSB = left column)
+  private static final int[][] FONT = {
+    {0b0110,0b1001,0b1001,0b1001,0b1001,0b0110}, // 0
+    {0b0010,0b0110,0b0010,0b0010,0b0010,0b0111}, // 1
+    {0b0110,0b1001,0b0001,0b0010,0b0100,0b1111}, // 2
+    {0b1110,0b0001,0b0110,0b0001,0b1001,0b0110}, // 3
+    {0b1001,0b1001,0b1111,0b0001,0b0001,0b0001}, // 4
+    {0b1111,0b1000,0b1110,0b0001,0b1001,0b0110}, // 5
+    {0b0110,0b1000,0b1110,0b1001,0b1001,0b0110}, // 6
+    {0b1111,0b0001,0b0010,0b0010,0b0100,0b0100}, // 7
+    {0b0110,0b1001,0b0110,0b1001,0b1001,0b0110}, // 8
+    {0b0110,0b1001,0b1001,0b0111,0b0001,0b0110}, // 9
+    {0b0110,0b1001,0b1001,0b1111,0b1001,0b1001}, // A
+    {0b1110,0b1001,0b1110,0b1001,0b1001,0b1110}, // B
+    {0b0110,0b1001,0b1000,0b1000,0b1001,0b0110}, // C
+    {0b1110,0b1001,0b1001,0b1001,0b1001,0b1110}, // D
+    {0b1111,0b1000,0b1110,0b1000,0b1000,0b1111}, // E
+    {0b1111,0b1000,0b1110,0b1000,0b1000,0b1000}, // F
+  };
+  private static final int MAX_BIG = 16;
+  private static final int MAX_BG = 200;
+  private static final int MAX_RAIN = 160;
+  private static final int MAX_FLARES = 6;
+  private static final double SWAP_MS = 420;
+  // UFOAbduction velocity signature for drifting digits: fast entry, slow-motion
+  // center stall, explosive exit off-canvas
+  private static final int MAX_DRIFT = 14;
+  private static final double DV_ENTRY = 0.00135;
+  private static final double DV_STALL = 0.00024;
+  private static final double DV_EXIT = 0.0075;
+  private static final double DSTALL_LO = 0.60;
+  private static final double DSTALL_HI = 0.44;
+  private static final double DEXIT_AT = 0.30;
+
+  public final CompoundParameter glitch =
+    new CompoundParameter("Glitch", 0.4, 0, 1)
+    .setDescription("How corrupted the readout gets");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of re-triggers");
+
+  public final heronarts.lx.parameter.DiscreteParameter drifters =
+    new heronarts.lx.parameter.DiscreteParameter("Drifters", 6, 0, MAX_DRIFT)
+    .setDescription("Digits drifting vertically with a slow-motion center stall");
+
+  private final int[] bigChars = new int[MAX_BIG];
+  private final double[] enterT = new double[MAX_BIG]; // 0..1 slide-in progress
+  private final int[] enterDir = new int[MAX_BIG];     // 0 = appear, -1 top, +1 bottom
+  private final int[] bgChars = new int[MAX_BG];
+  private int glitchSeed = 1;
+  private double retrigger = 0;
+  private double flash = 0;
+  private double floodP = 0;
+  private double floodTimer = 0;
+  // full-height strand flares ignited on swaps
+  private final int[] flareX = new int[MAX_FLARES];
+  private final boolean[] flareRed = new boolean[MAX_FLARES];
+  private double flareEnv = 0;
+
+  private final class Surface {
+    boolean inited;
+    // drifting digits riding the UFOAbduction profile
+    final double[] dy = new double[MAX_DRIFT];
+    final double[] dvf = new double[MAX_DRIFT];  // variance factor
+    final int[] dchar = new int[MAX_DRIFT];
+    final int[] dx = new int[MAX_DRIFT];
+    final boolean[] dup = new boolean[MAX_DRIFT]; // true = rising
+    final boolean[] dalive = new boolean[MAX_DRIFT];
+    final double[] rx = new double[MAX_RAIN];
+    final double[] ry = new double[MAX_RAIN];
+    final double[] rv = new double[MAX_RAIN];
+    final boolean[] rc = new boolean[MAX_RAIN]; // true = cyan, false = red
+    final boolean[] alive = new boolean[MAX_RAIN];
+    void reset() {
+      for (int i = 0; i < MAX_RAIN; ++i) this.alive[i] = false;
+      for (int i = 0; i < MAX_DRIFT; ++i) this.dalive[i] = false;
+      this.inited = true;
+    }
+    void spawnDrifter(int w) {
+      for (int i = 0; i < MAX_DRIFT; ++i) {
+        if (this.dalive[i]) continue;
+        this.dup[i] = Math.random() < 0.5;
+        this.dy[i] = this.dup[i] ? 1.05 : -0.05;
+        this.dvf[i] = 0.8 + Math.random() * 0.4;
+        this.dchar[i] = (int) (Math.random() * 16);
+        this.dx[i] = (int) (Math.random() * w);
+        this.dalive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public Digits(LX lx) {
+    // Base registers color (hue shift), speed (swap rate), size (digit scale).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("glitch", this.glitch);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("drifters", this.drifters);
+    addTargetParameter();
+    for (int i = 0; i < MAX_BIG; ++i) this.bigChars[i] = (int) (Math.random() * 16);
+    for (int i = 0; i < MAX_BG; ++i) this.bgChars[i] = (int) (Math.random() * 16);
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  /** UFOAbduction's measured profile: brisk entry, center stall, exit burst. */
+  private static double driftProfile(double y) {
+    if (y > DSTALL_LO) {
+      final double u = LXUtils.clamp((y - DSTALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(DV_STALL, DV_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > DSTALL_HI) {
+      return DV_STALL;
+    }
+    final double u = LXUtils.clamp((DSTALL_HI - y) / (DSTALL_HI - DEXIT_AT), 0, 1);
+    return LXUtils.lerp(DV_STALL, DV_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+
+    // the big readout swaps as a group (~420ms, or on beats)
+    this.retrigger += deltaMs * speed * 2 * (1 + wow * 0.6);
+    if (this.retrigger >= SWAP_MS || (this.beat && this.beatLevel > 0.35)) {
+      this.retrigger = 0;
+      for (int i = 0; i < MAX_BIG; ++i) {
+        this.bigChars[i] = (int) (Math.random() * 16);
+        // some digits just appear; others slide in from the top or bottom
+        final double r = Math.random();
+        if (r < 0.4) {
+          this.enterDir[i] = 0;
+          this.enterT[i] = 1;
+        } else {
+          this.enterDir[i] = (r < 0.7) ? -1 : 1;
+          this.enterT[i] = 0;
+        }
+      }
+      this.glitchSeed = (int) (Math.random() * 100000) + 1;
+      this.flash = 1;
+      // ignite full-height red/blue strand flares through the digits
+      this.flareEnv = 1;
+      for (int i = 0; i < MAX_FLARES; ++i) {
+        this.flareX[i] = (int) (Math.random() * 200);
+        this.flareRed[i] = (i & 1) == 0;
+      }
+    }
+    // background log field churns per-cell, fast
+    final double p = deltaMs / 140.0;
+    for (int i = 0; i < MAX_BG; ++i) {
+      if (Math.random() < p) {
+        this.bgChars[i] = (int) (Math.random() * 16);
+      }
+    }
+    // rare hard red flood, every ~4-5s
+    this.floodTimer += deltaMs;
+    if (this.floodTimer >= 4200 + hashd((int) this.timeMs) * 1200) {
+      this.floodTimer = 0;
+      this.floodP = 1;
+    }
+    for (int i = 0; i < MAX_BIG; ++i) {
+      if (this.enterT[i] < 1) {
+        this.enterT[i] = Math.min(1, this.enterT[i] + deltaMs / 350.0);
+      }
+    }
+    this.flash *= Math.exp(-deltaMs / 150.0);
+    this.floodP *= Math.exp(-deltaMs / 260.0);
+    this.flareEnv *= Math.exp(-deltaMs / 300.0);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+
+    final double wow = getWow();
+    final double gl = this.glitch.getValue() + wow * 0.5;
+    final double hueShift = LXColor.h(getColor());
+    final int blue = LXColor.hsb((float) (((225 + hueShift) % 360)), 95, 100);
+    final int white = LXColor.lerp(blue, LXColor.WHITE, 0.90f); // white-hot, faint cool edge
+    final int red = LXColor.hsb((float) (((0 + hueShift) % 360) + 360) % 360, 100, 100);
+    final int cyan = LXColor.hsb((float) (((187 + hueShift) % 360)), 90, 100);
+
+    // --- background: dim churning field of small blue log-glyphs ---
+    final int cols = w / 5;
+    final int rows = h / 7;
+    for (int cy = 0; cy < rows; ++cy) {
+      for (int cxI = 0; cxI < cols; ++cxI) {
+        final int gi = (cy * cols + cxI) % MAX_BG;
+        final int[] glyph = FONT[this.bgChars[gi]];
+        final int gx = cxI * 5;
+        final int gy = cy * 7 + 1;
+        final double gb = 0.14 + 0.08 * hashd(gi * 31 + (int) (this.timeMs / 200));
+        for (int row = 0; row < 6; ++row) {
+          final int bits = glyph[row];
+          for (int b2 = 0; b2 < 4; ++b2) {
+            if ((bits & (0b1000 >> b2)) == 0) continue;
+            addPix(o, gx + b2, gy + row, blue, gb);
+          }
+        }
+      }
+    }
+
+    // --- red underline bar behind the readout ---
+    final int barY = (int) (h * 0.62);
+    for (int x = 0; x < w; ++x) {
+      addPix(o, x, barY, red, 0.22 + this.flash * 0.3);
+    }
+
+    // --- foreground: giant white-hot characters, near-full height ---
+    // Size drives the digit scale: small readout by default, giant at full
+    final int scaleY = Math.max(1, (int) Math.round(Math.pow(2, getSize() * 2.6)));
+    final int scaleX = Math.max(1, scaleY / 3); // tall/narrow ~1:3
+    final int bigW = 4 * scaleX + scaleX;       // char cell incl gap
+    final int segW = isCube ? 50 : w;
+    final int segs = Math.max(1, w / segW);
+    final int perSeg = Math.max(1, (segW - 2) / bigW);
+    final int y0 = (h - 6 * scaleY) / 2;
+    final double bright = 0.95 + this.flash * 0.5;
+
+    for (int seg = 0; seg < segs; ++seg) {
+      final int xBase = seg * segW + (segW - perSeg * bigW) / 2;
+      for (int ci = 0; ci < perSeg; ++ci) {
+        final int gi = (seg * perSeg + ci) % MAX_BIG;
+        final int[] glyph = FONT[this.bigChars[gi]];
+        final int cx = xBase + ci * bigW;
+        // glitch: occasional dropped column or lateral jitter
+        final int jit = (hashd(this.glitchSeed + gi * 31) < gl * 0.45)
+          ? ((hashd(this.glitchSeed + gi * 77) < 0.5) ? scaleX : -scaleX) : 0;
+        final int dropCol = (hashd(this.glitchSeed + gi * 131) < gl * 0.5)
+          ? (int) (hashd(this.glitchSeed + gi * 7) * 4) : -1;
+        // slide-in entrance: eased offset from off-canvas (0 for pop-ins)
+        final double et = this.enterT[gi];
+        final double ease = et * et * (3 - 2 * et);
+        final int yOff = (int) Math.round(this.enterDir[gi] * (1.0 - ease) * h * 0.85);
+        for (int row = 0; row < 6; ++row) {
+          final int bits = glyph[row];
+          for (int b2 = 0; b2 < 4; ++b2) {
+            if ((bits & (0b1000 >> b2)) == 0 || b2 == dropCol) continue;
+            for (int sx = 0; sx < scaleX; ++sx) {
+              for (int sy = 0; sy < scaleY; ++sy) {
+                addPix(o, cx + b2 * scaleX + sx + jit, y0 + row * scaleY + sy + yOff, white, bright);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // --- full-height red/blue strand flares through the digits on each swap ---
+    if (this.flareEnv > 0.03) {
+      for (int i = 0; i < MAX_FLARES; ++i) {
+        final int fx = this.flareX[i] % w;
+        final int fc = this.flareRed[i] ? red : blue;
+        for (int y = 0; y < h; ++y) {
+          addPix(o, fx, y, fc, this.flareEnv * 0.55);
+        }
+      }
+    }
+
+    // --- drifting digits: rise or fall with the slow-motion center stall ---
+    final int nDrift = this.drifters.getValuei();
+    int aliveD = 0;
+    for (int i = 0; i < MAX_DRIFT; ++i) if (s.dalive[i]) ++aliveD;
+    if (aliveD < nDrift && Math.random() < deltaMs * 0.002) {
+      s.spawnDrifter(w);
+    }
+    final double dScaleY2 = Math.max(2, (h - 6) / 6 / 2); // half the readout scale
+    final double speedD = Math.max(0.05, getSpeed()) * 2;
+    for (int i = 0; i < MAX_DRIFT; ++i) {
+      if (!s.dalive[i]) continue;
+      // profile is defined for rising travel; mirror it for fallers
+      final double yp = s.dup[i] ? s.dy[i] : 1.0 - s.dy[i];
+      final double vh = driftProfile(yp) * s.dvf[i] * speedD;
+      s.dy[i] += s.dup[i] ? -vh * deltaMs : vh * deltaMs;
+      if (s.dy[i] < -0.12 || s.dy[i] > 1.12) { s.dalive[i] = false; continue; }
+      // slow center = brighter, whiter (the slow-motion moment reads hot)
+      final double stall = 1.0 - LXUtils.clamp(Math.abs(yp - 0.52) / 0.16, 0, 1);
+      final int[] glyph = FONT[s.dchar[i]];
+      final int gy = (int) Math.round(s.dy[i] * (h - 1)) - (int) (3 * dScaleY2);
+      final int sc = (int) dScaleY2;
+      final double db = 0.55 + 0.45 * stall;
+      final int dc = LXColor.lerp(blue, LXColor.WHITE, (float) (0.5 + 0.4 * stall));
+      for (int row = 0; row < 6; ++row) {
+        final int bits = glyph[row];
+        for (int b2 = 0; b2 < 4; ++b2) {
+          if ((bits & (0b1000 >> b2)) == 0) continue;
+          for (int sy2 = 0; sy2 < sc; ++sy2) {
+            final int yy = gy + row * sc + sy2;
+            if (yy < 0 || yy >= h) continue;
+            addPix(o, s.dx[i] + b2, yy, dc, db);
+          }
+        }
+      }
+    }
+
+    // --- cyan/red debris streaks tangled at the base ---
+    final double spawnRate = w * 0.0009 * deltaMs * (1 + this.levelEnv + wow);
+    int toSpawn = (int) spawnRate + ((Math.random() < spawnRate % 1) ? 1 : 0);
+    for (int i = 0; i < MAX_RAIN && toSpawn > 0; ++i) {
+      if (s.alive[i]) continue;
+      s.rx[i] = Math.random() * w;
+      s.ry[i] = h - 7 - Math.random() * 3;
+      s.rv[i] = 0.035 + Math.random() * 0.03;
+      s.rc[i] = Math.random() < 0.5;
+      s.alive[i] = true;
+      --toSpawn;
+    }
+    for (int i = 0; i < MAX_RAIN; ++i) {
+      if (!s.alive[i]) continue;
+      s.ry[i] += s.rv[i] * deltaMs;
+      if (s.ry[i] >= h + 3) { s.alive[i] = false; continue; }
+      comet(o, s.rx[i], s.ry[i], 3.5, s.rc[i] ? cyan : red, 0.8, false);
+    }
+
+    // --- the rare hard flood: everything pulled toward red, whites included ---
+    if (this.floodP > 0.02) {
+      final float amt = (float) (this.floodP * 0.85);
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          final int idx = o.point(x, y).index;
+          this.colors[idx] = LXColor.lerp(this.colors[idx], red, amt);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Downlink.java
+++ b/src/main/java/apotheneum/piemonte/Downlink.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Downlink — the strand curtains run a raw machine-room program: emerald
+ * matrix-rain pours down the columns while the whole room washes through slow
+ * color floods — green, then red, then amber — and sparse blocky data-glyphs
+ * flicker on and re-roll with the beat. Cyan service strips glow along the
+ * floor line. Modeled on the holotrigger green/red studio session.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Downlink extends StrandPattern {
+
+  private static final int MAX_DROPS = 400;
+  private static final int GLYPHS = 10;
+  // green <-> red flood; the downward lerp sweeps through amber mid-fade
+  private static final double[] SCENE_HUES = { 125, 4 };
+  private static final double SCENE_MS = 3200;
+  private static final double XFADE_MS = 1500;
+
+  public final CompoundParameter rain =
+    new CompoundParameter("Rain", 0.6, 0, 1)
+    .setDescription("Matrix-rain density");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of floods and glyph re-rolls");
+
+  private final class Surface {
+    boolean inited;
+    final double[] px = new double[MAX_DROPS];
+    final double[] py = new double[MAX_DROPS];
+    final double[] pv = new double[MAX_DROPS];
+    final boolean[] alive = new boolean[MAX_DROPS];
+    // glyph blocks: column-group rectangles that re-roll on beats
+    final int[] gx = new int[GLYPHS];
+    final int[] gy = new int[GLYPHS];
+    final boolean[] gon = new boolean[GLYPHS];
+    void reset(int w, int h) {
+      for (int i = 0; i < MAX_DROPS; ++i) this.alive[i] = false;
+      for (int i = 0; i < GLYPHS; ++i) rollGlyph(this, i, w, h);
+      this.inited = true;
+    }
+  }
+
+  private static void rollGlyph(Surface s, int i, int w, int h) {
+    s.gx[i] = (int) (Math.random() * w);
+    s.gy[i] = (int) (Math.random() * (h - 8)) + 1;
+    s.gon[i] = Math.random() < 0.65;
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double pulse = 0;
+  private double floodLvl = 0; // asymmetric flood envelope: snap up, breathe down
+
+  public Downlink(LX lx) {
+    // Base registers color (hue shift), speed (rain fall rate), size (glyph scale).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("rain", this.rain);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 200.0);
+    // flood breathes: ~250ms attack, ~1.1s release (reference envelope)
+    final double wow = getWow();
+    final double target = LXUtils.clamp(
+      0.04 + 0.85 * this.levelEnv * this.levelEnv * (1 + wow) + this.pulse * 0.18, 0, 0.95);
+    final double tau = (target > this.floodLvl) ? 250.0 : 1100.0;
+    this.floodLvl += (target - this.floodLvl) * (1 - Math.exp(-deltaMs / tau));
+  }
+
+  /** Current flood hue, crossfading between scene hues on a slow cycle. */
+  private double floodHue() {
+    final double t = this.timeMs / SCENE_MS;
+    final int scene = (int) Math.floor(t);
+    final double into = (t - scene) * SCENE_MS;
+    final double f = LXUtils.clamp(into / XFADE_MS, 0, 1);
+    final double a = SCENE_HUES[((scene - 1) % SCENE_HUES.length + SCENE_HUES.length) % SCENE_HUES.length];
+    final double b = SCENE_HUES[(scene % SCENE_HUES.length + SCENE_HUES.length) % SCENE_HUES.length];
+    double d = ((b - a) % 360 + 360) % 360;
+    if (d > 180) d -= 360;
+    return a + d * f;
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    final int w = o.width();
+    final int h = o.height();
+    if (!s.inited) s.reset(w, h);
+
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final double fh = floodHue() + hueShift;
+    final int scene = LXColor.hsb((float) (((fh % 360) + 360) % 360), 92, 100);
+    // the three color identities are hard-separated in the reference: green
+    // rain and red bars persist over whatever the flood is doing
+    final int rainC = LXColor.hsb((float) (((125 + hueShift) % 360) + 360) % 360, 90, 100);
+    final int glyphC = LXColor.hsb((float) (((4 + hueShift) % 360) + 360) % 360, 95, 100);
+    final int glyphHot = LXColor.hsb((float) (((32 + hueShift) % 360) + 360) % 360, 100, 100);
+
+    // global flood wash: dim ambient that surges toward full on swells
+    final double floodB = LXUtils.clamp(this.floodLvl + wow * 0.10, 0, 0.95);
+    final int floodC = LXColor.scaleBrightness(scene, (float) floodB);
+    for (int x = 0; x < w; ++x) {
+      for (int y = 0; y < h; ++y) {
+        final int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], floodC);
+      }
+    }
+
+    // matrix rain
+    final double dens = this.rain.getValue() * (0.5 + 0.5 * this.levelEnv + wow * 0.6);
+    final double spawnRate = dens * w * 0.0007 * deltaMs;
+    int toSpawn = (int) spawnRate + ((Math.random() < spawnRate % 1) ? 1 : 0);
+    for (int i = 0; i < MAX_DROPS && toSpawn > 0; ++i) {
+      if (s.alive[i]) continue;
+      s.px[i] = (int) (Math.random() * w);
+      s.py[i] = -Math.random() * 5;
+      s.pv[i] = (0.08 + Math.random() * 0.05) * speed; // full drop in ~0.7-1.1s at default
+      s.alive[i] = true;
+      --toSpawn;
+    }
+    final double tail = 16 + getSize() * 12; // reaches the longest staircases
+    for (int i = 0; i < MAX_DROPS; ++i) {
+      if (!s.alive[i]) continue;
+      s.py[i] += s.pv[i] * deltaMs;
+      if (s.py[i] >= h + tail) { s.alive[i] = false; continue; }
+      comet(o, s.px[i], s.py[i], tail, rainC, 0.95, true);
+    }
+
+    // data-bars hold position ~1.2s; only their internal dots churn fast
+    final double rollP = deltaMs / 1200.0;
+    for (int i = 0; i < GLYPHS; ++i) {
+      if (Math.random() < rollP || (this.beat && Math.random() < 0.25 + wow * 0.3)) {
+        rollGlyph(s, i, w, h);
+      }
+    }
+    final int gw = 2 + (int) (getSize() * 1.2);
+    final int gh = 8 + (int) (getSize() * 6);
+    final int tq = (int) (this.timeMs / 120);
+    for (int i = 0; i < GLYPHS; ++i) {
+      if (!s.gon[i]) continue;
+      for (int dx = 0; dx < gw; ++dx) {
+        for (int dy = 0; dy < gh; ++dy) {
+          // dot-matrix bit texture churning inside the persistent bar
+          final double bit = hashd(i * 977 + dx * 31 + dy * 7 + tq);
+          if (bit < 0.35) continue;
+          addPix(o, s.gx[i] + dx, s.gy[i] + dy,
+            (bit > 0.82) ? glyphHot : glyphC, 0.85 + this.pulse * 0.3);
+        }
+      }
+    }
+
+    // warm console ring at the floor line (red/amber segments, never cyan)
+    final int ringAmber = LXColor.hsb((float) (((34 + hueShift) % 360) + 360) % 360, 95, 100);
+    for (int x = 0; x < w; ++x) {
+      final double hh = hashd(x * 53 + (isCube ? 1 : 2));
+      if (hh < 0.45) {
+        final int c = (hashd(x * 17 + 3) < 0.5) ? glyphC : ringAmber;
+        addPix(o, x, h - 1, c, 0.45 + 0.30 * hashd(x * 7 + tq));
+        addPix(o, x, h - 2, c, 0.22);
+      }
+    }
+    // green strand-pile puddles glittering on the floor
+    for (int x = 0; x < w; ++x) {
+      if (hashd(x * 29 + (isCube ? 7 : 9)) < 0.30) {
+        final double b = 0.30 + 0.40 * hashd(x * 11 + tq) + 0.25 * this.levelEnv;
+        addPix(o, x, h - 1, rainC, b);
+        addPix(o, x, h - 2, rainC, b * 0.6);
+        addPix(o, x, h - 3, rainC, b * 0.3);
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Drip.java
+++ b/src/main/java/apotheneum/piemonte/Drip.java
@@ -54,6 +54,7 @@ public class Drip extends StrandPattern {
   private double pulse = 0;
   private double sceneClock = 0;
   private int scene = 0;
+  private int prevScene = 0; // the scene actually showing before the last change
 
   public Drip(LX lx) {
     // Base registers color (hue shift), speed (scene pace + shimmer), size (strand weight).
@@ -98,6 +99,7 @@ public class Drip extends StrandPattern {
         while (jump == this.scene) {
           jump = (int) (Math.random() * SCENES.length);
         }
+        this.prevScene = this.scene; // fade from what was actually showing
         this.scene = jump;
         return;
       } else if (this.beatLevel > 0.45 - sens * 0.15) {
@@ -106,6 +108,7 @@ public class Drip extends StrandPattern {
     }
     if (advanceScene) {
       this.sceneClock = 0;
+      this.prevScene = this.scene;
       this.scene = (this.scene + 1) % SCENES.length;
     }
   }
@@ -125,7 +128,7 @@ public class Drip extends StrandPattern {
     final double hueShift = LXColor.h(getColor());
 
     final double[] cur = SCENES[this.scene];
-    final double[] prev = SCENES[((this.scene - 1) % SCENES.length + SCENES.length) % SCENES.length];
+    final double[] prev = SCENES[this.prevScene];
     final double in = sceneIn();
     final double hue = LXUtils.lerp(prev[0], prev[0] + wrapDeg(cur[0] - prev[0]), in) + hueShift;
     final double sat = LXUtils.lerp(prev[1], cur[1], in);

--- a/src/main/java/apotheneum/piemonte/Drip.java
+++ b/src/main/java/apotheneum/piemonte/Drip.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Drip — standing strands of light hang from the rim to the floor like a
+ * beaded curtain in a cathedral dome, each one scintillating downward so the
+ * light seems to pour without ever falling. At the base every strand bends
+ * into a hook and trails outward along the floor, and a bright fountain
+ * cluster glows at the center of each wall. The room moves through scenes —
+ * green with a red heart, full green flood, blue beaded sparkle, violet dusk,
+ * a gold flood, red matrix, a pale white passage, and near-blackout lulls —
+ * some easing in, some snapping. Modeled on the holotrigger rotunda show.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Drip extends StrandPattern {
+
+  private static final int MAX_STREAMS = 40;
+  // scene legs: { perimeterHue, sat, bright, centerHue, holdMs, snap(0/1) }
+  private static final double[][] SCENES = {
+    { 120, 90, 100,   0,  6000, 0 }, // green columns, red center heart
+    { 130, 90, 100, 130,  3500, 1 }, // full green flood (snaps in)
+    { 225, 88,  95, 205,  7000, 0 }, // blue beaded sparkle, cyan center
+    { 275, 80,  80, 350,  4500, 0 }, // violet dusk, rose center
+    {  48, 95, 100,  48,  3500, 1 }, // gold flood
+    {   0, 92, 100, 225,  6000, 0 }, // red matrix, blue center
+    {   0,  0,  85,   0,  3500, 0 }, // white/lavender passage
+    {   0, 60,   8,   0,  2500, 1 }, // near-blackout lull (red embers)
+  };
+  private static final double XFADE_MS = 1200;
+  private static final double SNAP_MS = 180;
+
+  public final DiscreteParameter streams =
+    new DiscreteParameter("Streams", 16, 6, MAX_STREAMS)
+    .setDescription("Standing strands per surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of shimmer surge");
+
+  private double pulse = 0;
+  private double sceneClock = 0;
+  private int scene = 0;
+
+  public Drip(LX lx) {
+    // Base registers color (hue shift), speed (scene pace + shimmer), size (strand weight).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("streams", this.streams);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 220.0);
+    final double speed = Math.max(0.05, getSpeed());
+    this.sceneClock += deltaMs * speed * 2 * (1 + getWow() * 0.5);
+    final double[] cur = SCENES[this.scene];
+    final double sens = this.sensitivity.getValue();
+
+    // the music drives the style: solid hits advance the scene early, and a
+    // hard drop jumps the journey to a random scene — after a minimum dwell
+    // so the room never thrashes
+    boolean advanceScene = this.sceneClock >= cur[4];
+    if (this.beat && this.sceneClock > 1200) {
+      if (this.beatLevel > 0.80 - sens * 0.2) {
+        // drop: leap somewhere unexpected in the journey
+        this.sceneClock = 0;
+        int jump = this.scene;
+        while (jump == this.scene) {
+          jump = (int) (Math.random() * SCENES.length);
+        }
+        this.scene = jump;
+        return;
+      } else if (this.beatLevel > 0.45 - sens * 0.15) {
+        advanceScene = true; // solid hit: move the journey along now
+      }
+    }
+    if (advanceScene) {
+      this.sceneClock = 0;
+      this.scene = (this.scene + 1) % SCENES.length;
+    }
+  }
+
+  /** Eased 0..1 entry progress into the current scene (fast when it snaps). */
+  private double sceneIn() {
+    final double dur = (SCENES[this.scene][5] > 0.5) ? SNAP_MS : XFADE_MS;
+    final double f = LXUtils.clamp(this.sceneClock / dur, 0, 1);
+    return f * f * (3 - 2 * f);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double hueShift = LXColor.h(getColor());
+
+    final double[] cur = SCENES[this.scene];
+    final double[] prev = SCENES[((this.scene - 1) % SCENES.length + SCENES.length) % SCENES.length];
+    final double in = sceneIn();
+    final double hue = LXUtils.lerp(prev[0], prev[0] + wrapDeg(cur[0] - prev[0]), in) + hueShift;
+    final double sat = LXUtils.lerp(prev[1], cur[1], in);
+    final double sceneBright = LXUtils.lerp(prev[2], cur[2], in) / 100.0;
+    final double cHue = LXUtils.lerp(prev[3], prev[3] + wrapDeg(cur[3] - prev[3]), in) + hueShift;
+    final int colPerim = LXColor.hsb((float) (((hue % 360) + 360) % 360), (float) sat, 100);
+    final int colCenter = LXColor.hsb((float) (((cHue % 360) + 360) % 360),
+      (float) Math.max(sat, 60), 100);
+
+    // strand population scales with scene brightness: floods fill the wall,
+    // blackout lulls collapse to a few dim embers
+    final int count = Math.max(2, (int) Math.round(
+      Math.min(MAX_STREAMS, this.streams.getValuei() + wow * 8) * (0.25 + 0.75 * sceneBright)));
+    final boolean glyphScene = (this.scene == 5 || this.scene == 0); // matrix-textured legs
+    final double shimSurge = 1.0 + this.levelEnv * this.sensitivity.getValue() + this.pulse * 0.4;
+    final int floorY = h - 6;
+
+    for (int i = 0; i < count; ++i) {
+      // fixed even spacing with per-strand jitter: a standing curtain
+      final int cx = (int) ((i + 0.5) * w / count + (hashd(i * 31 + 7) - 0.5) * 3);
+      // center/perimeter bicolor split: strands near each wall's center take the accent
+      final double centerDist = Math.abs(((cx % w) + w) % w % (isCube ? 50 : w)
+        - (isCube ? 25 : w / 2)) / (double) (isCube ? 25 : w / 2);
+      final int col = (centerDist < 0.25) ? colCenter : colPerim;
+
+      for (int y = 0; y <= floorY; ++y) {
+        double b;
+        if (glyphScene) {
+          // blocky code-rain segments descending
+          final int seg = (int) Math.floor((y - this.timeMs * 0.010) / 3.0);
+          b = (hashd(cx * 131 + seg * 977) > 0.45) ? 0.85 : 0.08;
+        } else {
+          // beaded scintillation scrolling down a stationary strand
+          final double spark = hashd(cx * 262147 + (int) Math.floor(y - this.timeMs * 0.012) * 8191);
+          b = (spark > 0.55) ? 0.55 + 0.45 * spark : 0.12;
+        }
+        b *= sceneBright * shimSurge * (0.75 + 0.25 * drip(y, h)) * (0.7 + 0.3 * getSize());
+        addPix(o, cx, y, col, b);
+      }
+
+      // persistent floor hook curling outward
+      final int dir = (hashd(i * 53 + 11) < 0.5) ? -1 : 1;
+      for (int k = 1; k <= 6; ++k) {
+        final double wig = Math.sin(this.timeMs * 0.002 + i * 1.7) * 1.0;
+        final int yy = Math.min(h - 1, floorY + (int) Math.round(k * 0.4 + wig * (k / 6.0)));
+        addPix(o, cx + dir * k, yy, col, sceneBright * (1.0 - k / 8.0) * 0.8);
+      }
+    }
+
+    // fountain cluster glowing at the center of each wall
+    final int nWalls = isCube ? 4 : 1;
+    final int wallW = w / nWalls;
+    for (int wi = 0; wi < nWalls; ++wi) {
+      final int cx0 = wi * wallW + wallW / 2;
+      for (int dx = -3; dx <= 3; ++dx) {
+        for (int y = floorY; y < h; ++y) {
+          final double g = Math.exp(-dx * dx / 4.0) * (0.55 + this.pulse * 0.3);
+          addPix(o, cx0 + dx, y, colCenter, g * sceneBright);
+        }
+      }
+    }
+
+    // waterline scrim: only in the blue scenes, at ~43% height
+    if (this.scene == 2) {
+      final int scrimY = (int) (h * 0.43);
+      final int scrim = LXColor.hsb((float) (((215 + hueShift) % 360)), 80, 100);
+      for (int x = 0; x < w; ++x) {
+        addPix(o, x, scrimY, scrim, 0.22 * in);
+        addPix(o, x, scrimY + 1, scrim, 0.10 * in);
+      }
+    }
+  }
+
+  private static double wrapDeg(double d) {
+    d = ((d % 360) + 360) % 360;
+    return (d > 180) ? d - 360 : d;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/FeelSomething.java
+++ b/src/main/java/apotheneum/piemonte/FeelSomething.java
@@ -19,17 +19,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class FeelSomething extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_STICKS = 64;
   private static final int MAX_SPARKS = 1500;
@@ -46,10 +39,6 @@ public class FeelSomething extends ParameterPattern {
   public final CompoundParameter sparkle =
     new CompoundParameter("Sparkle", 0.5, 0, 1)
     .setDescription("How many sparkles fly off on each bounce");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     int w, h;
@@ -126,7 +115,7 @@ public class FeelSomething extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("sticks", this.sticks);
     addParameter("sparkle", this.sparkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -134,7 +123,7 @@ public class FeelSomething extends ParameterPattern {
     setColors(LXColor.BLACK);
     final double baseHue = LXColor.h(getColor());
     final double dtS = Math.max(0.02, getSpeed()) * deltaMs; // time step
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, dtS, baseHue);
     }

--- a/src/main/java/apotheneum/piemonte/FeelSomething.java
+++ b/src/main/java/apotheneum/piemonte/FeelSomething.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * FeelSomething — colored sticks rain down the surface, and when they strike the
+ * floor they bounce back up, tumbling end over end and throwing off a burst of
+ * bright sparkles. Each bounce loses a little energy until the stick settles and
+ * a fresh one drops from the top.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class FeelSomething extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_STICKS = 64;
+  private static final int MAX_SPARKS = 1500;
+  private static final double GRAV = 0.00010;      // cells / ms^2 (time-scaled by speed)
+  private static final double SPARK_G = 0.00006;
+  private static final double RESTITUTION = 0.68;  // bounce energy kept
+  private static final double MIN_IMPACT = 0.010;  // below this a stick settles + relaunches
+  private static final double HUE_SPREAD = 90;     // per-stick hue variety (degrees)
+
+  public final DiscreteParameter sticks =
+    new DiscreteParameter("Sticks", 24, 4, MAX_STICKS)
+    .setDescription("How many sticks are falling at once");
+
+  public final CompoundParameter sparkle =
+    new CompoundParameter("Sparkle", 0.5, 0, 1)
+    .setDescription("How many sparkles fly off on each bounce");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    int w, h;
+    boolean inited;
+    // sticks
+    final double[] kx = new double[MAX_STICKS];
+    final double[] ky = new double[MAX_STICKS];
+    final double[] kvy = new double[MAX_STICKS];
+    final double[] klf = new double[MAX_STICKS];   // per-stick length factor
+    final double[] kang = new double[MAX_STICKS];
+    final double[] kav = new double[MAX_STICKS];    // angular velocity
+    final double[] khue = new double[MAX_STICKS];   // 0..1 hue offset
+    final boolean[] kbounced = new boolean[MAX_STICKS];
+    // sparks
+    final double[] spx = new double[MAX_SPARKS];
+    final double[] spy = new double[MAX_SPARKS];
+    final double[] spvx = new double[MAX_SPARKS];
+    final double[] spvy = new double[MAX_SPARKS];
+    final double[] splife = new double[MAX_SPARKS];
+    final double[] spmax = new double[MAX_SPARKS];
+    final boolean[] spAlive = new boolean[MAX_SPARKS];
+
+    void ensure(int w, int h) {
+      if (this.inited && this.w == w && this.h == h) {
+        return;
+      }
+      this.w = w;
+      this.h = h;
+      this.inited = true;
+      for (int i = 0; i < MAX_STICKS; ++i) {
+        launch(i, true);
+      }
+      for (int i = 0; i < MAX_SPARKS; ++i) {
+        this.spAlive[i] = false;
+      }
+    }
+
+    void launch(int i, boolean scatter) {
+      this.kx[i] = Math.random() * this.w;
+      this.ky[i] = scatter ? Math.random() * this.h * 0.6 : -(Math.random() * this.h * 0.4) - 4;
+      this.kvy[i] = 0;
+      this.klf[i] = 0.7 + Math.random() * 0.6;
+      this.kang[i] = 0;
+      this.kav[i] = (Math.random() - 0.5) * 0.006; // gentle pre-bounce tumble
+      this.khue[i] = Math.random();
+      this.kbounced[i] = false;
+    }
+
+    /** Emit sparks from (x,y) flung outward along (ox,oy) — used for the stick's ends. */
+    void sparkFrom(double x, double y, double ox, double oy, int count) {
+      for (int c = 0; c < count; ++c) {
+        int idx = -1;
+        for (int k = 0; k < MAX_SPARKS; ++k) {
+          if (!this.spAlive[k]) { idx = k; break; }
+        }
+        if (idx < 0) return;
+        this.spx[idx] = x;
+        this.spy[idx] = y;
+        double eject = 0.02 + Math.random() * 0.045;
+        this.spvx[idx] = ox * eject + (Math.random() - 0.5) * 0.03;
+        this.spvy[idx] = oy * eject - (0.006 + Math.random() * 0.02); // slight upward arc
+        this.spmax[idx] = 300 + Math.random() * 520;
+        this.splife[idx] = this.spmax[idx];
+        this.spAlive[idx] = true;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  public FeelSomething(LX lx) {
+    // Base registers color (base hue), speed (time scale), size (stick length).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("sticks", this.sticks);
+    addParameter("sparkle", this.sparkle);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final double baseHue = LXColor.h(getColor());
+    final double dtS = Math.max(0.02, getSpeed()) * deltaMs; // time step
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, dtS, baseHue);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, dtS, baseHue);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double dtS, double baseHue) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w, h);
+
+    final int count = this.sticks.getValuei();
+    final double len = 3 + getSize() * 10;
+    final double bottom = h - 1;
+    final double wow = getWow();
+    // Wow turns each bounce into a burst storm: more sparks, more shedding.
+    final double sparkAmt = this.sparkle.getValue();
+
+    // --- sticks ---
+    for (int i = 0; i < count; ++i) {
+      s.kvy[i] += GRAV * dtS;
+      s.ky[i] += s.kvy[i] * dtS;
+      s.kang[i] += s.kav[i] * dtS;
+      boolean justBounced = false;
+      double impact = 0;
+      if (s.ky[i] >= bottom) {
+        s.ky[i] = bottom;
+        impact = Math.abs(s.kvy[i]);
+        if (impact < MIN_IMPACT && s.kbounced[i]) {
+          s.launch(i, false); // settled -> drop a fresh one
+        } else {
+          s.kvy[i] = -impact * RESTITUTION;   // bounce up
+          s.kbounced[i] = true;
+          s.kav[i] = (Math.random() - 0.5) * 0.03; // tumble
+          justBounced = true;
+        }
+      }
+
+      final double dirx = Math.sin(s.kang[i]);
+      final double diry = Math.cos(s.kang[i]);
+      final double half = 0.5 * len * s.klf[i];
+      final double ax = s.kx[i] - dirx * half, ay = s.ky[i] - diry * half;
+      final double bx = s.kx[i] + dirx * half, by = s.ky[i] + diry * half;
+
+      // sparkles fly out of the stick's two ends
+      if (justBounced) {
+        int n = LXUtils.constrain(
+          (int) (impact * 1000 * (0.35 + sparkAmt) * (1.0 + wow * 4.0)), 2, (int) (32 + wow * 70));
+        s.sparkFrom(ax, ay, -dirx, -diry, n);
+        s.sparkFrom(bx, by, dirx, diry, n);
+      } else if (s.kbounced[i]) {
+        double rate = 0.20 + sparkAmt * 1.0 + wow * 0.6; // keep shedding off the ends while tumbling
+        int shed = 1 + (int) (wow * 3);
+        if (Math.random() < rate) s.sparkFrom(ax, ay, -dirx, -diry, shed);
+        if (Math.random() < rate) s.sparkFrom(bx, by, dirx, diry, shed);
+      }
+
+      // draw the stick between its two ends, with white-hot tips
+      final int col = LXColor.hsb(
+        (float) (((baseHue + (s.khue[i] - 0.5) * HUE_SPREAD) % 360 + 360) % 360), 90, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.5f);
+      final int steps = (int) Math.ceil(len);
+      for (int k = 0; k <= steps; ++k) {
+        double f = (steps == 0) ? 0 : (double) k / steps;
+        int col2 = (f < 0.15 || f > 0.85) ? hot : col;
+        final double px = ax + (bx - ax) * f;
+        final double py = ay + (by - ay) * f;
+        splat(o, w, h, px, py, 2.3, 0.35, col);   // soft aura around the rod
+        splat(o, w, h, px, py, 1.4, 1.0, col2);   // bold core
+      }
+    }
+
+    // --- sparkles: born white-hot, cooling toward the base hue as they fade ---
+    final int ember = LXColor.hsb((float) baseHue, 90, 100);
+    for (int i = 0; i < MAX_SPARKS; ++i) {
+      if (!s.spAlive[i]) continue;
+      s.splife[i] -= dtS;
+      if (s.splife[i] <= 0) { s.spAlive[i] = false; continue; }
+      s.spvy[i] += SPARK_G * dtS;
+      s.spx[i] += s.spvx[i] * dtS;
+      s.spy[i] += s.spvy[i] * dtS;
+      if (s.spy[i] >= bottom && s.spvy[i] > 0) { s.spAlive[i] = false; continue; }
+      double fade = s.splife[i] / s.spmax[i];
+      double twinkle = 0.55 + 0.45 * Math.random(); // shimmer
+      int sc = LXColor.lerp(ember, LXColor.WHITE, (float) fade);
+      splat(o, w, h, s.spx[i], s.spy[i], 1.05, Math.pow(fade, 1.5) * (0.55 + 0.65 * twinkle), sc);
+    }
+  }
+
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.floor(x - r);
+    int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double dx = xx - x;
+        double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int xi = ((xx % w) + w) % w;
+        int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Ghosted.java
+++ b/src/main/java/apotheneum/piemonte/Ghosted.java
@@ -135,7 +135,9 @@ public class Ghosted extends StrandPattern {
       // groups of consecutive lines share a color: the sweep fires red packs
       // and blue packs as it circles
       final int chunk = (int) (((this.sweep % 1.0) + 1.0) % 1.0 * 8);
-      final int grp = (hashd(chunk * 53 + (int) this.laps * 97) < 0.5) ? 0 : 1;
+      // red<->blue balance drifts on the hue cycle instead of a fixed 50/50
+      final double cyc = 0.5 + 0.5 * Math.sin(2 * Math.PI * this.timeMs / HUE_CYCLE_MS);
+      final int grp = (hashd(chunk * 53 + (int) this.laps * 97) < 0.25 + 0.5 * cyc) ? 0 : 1;
       final double az = ((this.sweep + jitter) % 1.0 + 1.0) % 1.0;
       this.cube.fire(az, grp);
       this.cylinder.fire(az, grp);
@@ -153,9 +155,7 @@ public class Ghosted extends StrandPattern {
     final double hueShift = LXColor.h(getColor());
     final double env = swellEnv();
 
-    // the color field: hot floor core -> white shockwave band -> azure sky,
-    // with the red<->blue balance cycling slowly
-    final double cyc = 0.5 + 0.5 * Math.sin(2 * Math.PI * this.timeMs / HUE_CYCLE_MS);
+    // the color field: hot floor core -> white shockwave band -> azure sky
     final int red = LXColor.hsb((float) (((8 + hueShift) % 360)), 100, 100);
     final int blue = LXColor.hsb((float) (((214 + hueShift) % 360)), 96, 100);
     final int tq = (int) (this.timeMs / 60);

--- a/src/main/java/apotheneum/piemonte/Ghosted.java
+++ b/src/main/java/apotheneum/piemonte/Ghosted.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Ghosted — a starburst floor unrolled onto the walls. Thin dotted comet
+ * lines fire fast from the floor to the sky, launching in a radar sweep that
+ * marches clockwise around the structure — a new line every tenth of a
+ * second, a full lap every few seconds. Each comet accelerates as it climbs,
+ * dragging a dotted tail through the color field: hot red-orange at the
+ * floor, a white shockwave band mid-height, azure up top, the whole balance
+ * slowly cycling red-blue. The field breathes in swells — build, climax,
+ * near-blackout, re-burst. Bipolar Speed reverses the sweep; Wow deepens the
+ * swells and packs the sky. Modeled frame-by-frame on the wave.mp4 floor
+ * piece.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Ghosted extends StrandPattern {
+
+  private static final int MAX_COMETS = 80;
+  // measured: climax heads cross the field in 0.4-0.6s, dim phase ~0.7 heights/s
+  private static final double V_CLIMAX = 0.0033;  // heights per ms
+  private static final double V_DIM = 0.0013;
+  private static final double LAP_MS = 2300;      // sweep lap
+  private static final double SWELL_MS = 5000;    // build->climax->blackout cycle
+  private static final double HUE_CYCLE_MS = 11500;
+  private static final double DOT_PITCH = 2.6;    // dotted-body spacing
+
+  public final DiscreteParameter lines =
+    new DiscreteParameter("Lines", 36, 12, 60)
+    .setDescription("Comet lines fired per sweep lap");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How much the music drives the swells");
+
+  private final class Surface {
+    boolean inited;
+    final double[] x = new double[MAX_COMETS];
+    final double[] y = new double[MAX_COMETS];   // normalized, 1 = floor, 0 = top
+    final double[] vf = new double[MAX_COMETS];
+    final int[] grp = new int[MAX_COMETS]; // 0 = red group, 1 = blue group
+    final boolean[] alive = new boolean[MAX_COMETS];
+    void reset() {
+      for (int i = 0; i < MAX_COMETS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void fire(double x01, int grp) {
+      for (int i = 0; i < MAX_COMETS; ++i) {
+        if (this.alive[i]) continue;
+        this.grp[i] = grp;
+        this.x[i] = x01;
+        this.y[i] = 1.04 + Math.random() * 0.05;
+        this.vf[i] = 0.8 + Math.random() * 0.4;
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double sweep = 0;     // 0..1 azimuth of the radar sweep
+  private double laps = 0;      // unwrapped lap counter (for group hashing)
+  private double spawnAcc = 0;
+  private double swellT = 0;
+
+  public Ghosted(LX lx) {
+    // Base registers color (hue shift), bipolar speed (climb rate + sweep
+    // direction), size (tail length), wow (swell pressure + density).
+    super(lx, 0.5, -1, 1, 0.5, 0, 1);
+    addParameter("lines", this.lines);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Swell envelope: build -> climax -> collapse -> near-black -> re-burst. */
+  private double swellEnv() {
+    final double p = (this.swellT % SWELL_MS) / SWELL_MS;
+    if (p < 0.50) {
+      final double u = p / 0.50;
+      return 0.25 + 0.75 * u * u; // build
+    } else if (p < 0.80) {
+      return 1.0; // climax hold
+    } else if (p < 0.90) {
+      return 1.0 - (p - 0.80) / 0.10 * 0.95; // collapse
+    }
+    return 0.16; // lull: dim but never dead — scattered life persists
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = getSpeed();
+    final double mag = Math.max(0.05, Math.abs(speed));
+    final double wow = getWow();
+    // music pushes the swell clock so climaxes land with the energy
+    final double push = 1.0 + this.levelEnv * this.sensitivity.getValue() * 1.5
+      + (this.beat ? this.beatLevel * 0.6 : 0);
+    this.swellT += deltaMs * mag * 2 * push * (1 + wow * 0.4);
+
+    // radar sweep marches around the structure; sign of Speed sets direction
+    final double lap = LAP_MS / (mag * 2) / (1 + wow * 0.5);
+    this.sweep += (speed >= 0 ? 1 : -1) * deltaMs / lap;
+    this.sweep -= Math.floor(this.sweep);
+    this.laps += deltaMs / lap;
+
+    // sequential firing at the sweep azimuth (~lap / lines interval)
+    final int nLines = Math.min(MAX_COMETS,
+      this.lines.getValuei() + (int) Math.round(wow * 16));
+    final double env = swellEnv();
+    this.spawnAcc += deltaMs * nLines / lap * (0.45 + 0.55 * env);
+    while (this.spawnAcc >= 1) {
+      this.spawnAcc -= 1;
+      final double jitter = (Math.random() - 0.5) * 0.02;
+      // groups of consecutive lines share a color: the sweep fires red packs
+      // and blue packs as it circles
+      final int chunk = (int) (((this.sweep % 1.0) + 1.0) % 1.0 * 8);
+      final int grp = (hashd(chunk * 53 + (int) this.laps * 97) < 0.5) ? 0 : 1;
+      final double az = ((this.sweep + jitter) % 1.0 + 1.0) % 1.0;
+      this.cube.fire(az, grp);
+      this.cylinder.fire(az, grp);
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double mag = Math.max(0.05, Math.abs(getSpeed()));
+    final double wow = getWow();
+    final double hueShift = LXColor.h(getColor());
+    final double env = swellEnv();
+
+    // the color field: hot floor core -> white shockwave band -> azure sky,
+    // with the red<->blue balance cycling slowly
+    final double cyc = 0.5 + 0.5 * Math.sin(2 * Math.PI * this.timeMs / HUE_CYCLE_MS);
+    final int red = LXColor.hsb((float) (((8 + hueShift) % 360)), 100, 100);
+    final int blue = LXColor.hsb((float) (((214 + hueShift) % 360)), 96, 100);
+    final int tq = (int) (this.timeMs / 60);
+
+    // climb speed rides the swell: dim crawl in lulls, racing at climax
+    final double vClimb = LXUtils.lerp(V_DIM, V_CLIMAX, env) * mag * 2;
+    final double tailN = (0.42 + getSize() * 0.55) * (1 + wow * 0.3); // taller lines
+    final double envB = 0.30 + 0.70 * env;
+
+    for (int i = 0; i < MAX_COMETS; ++i) {
+      if (!s.alive[i]) continue;
+      // outward acceleration: slow near the floor, fast approaching the top
+      final double accel = 0.45 + 1.1 * (1.0 - s.y[i]);
+      s.y[i] -= s.vf[i] * vClimb * accel * deltaMs;
+      if (s.y[i] <= -0.12) { s.alive[i] = false; continue; }
+
+      final int x = (int) Math.round(s.x[i] * w);
+      final double headF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final int headY = (int) Math.round(headF);
+      final int tailLen = (int) (tailN * h);
+
+      for (int k = 0; k <= tailLen; ++k) {
+        final int yy = headY + k; // tail trails below, toward the floor
+        if (yy < 0 || yy >= h) continue;
+        // dotted body: dash every DOT_PITCH cells (the head is always lit)
+        if (k > 1) {
+          final double dphase = (k + tq * 0.35) % DOT_PITCH;
+          if (dphase > DOT_PITCH * 0.55) continue;
+        }
+        final double fall = (k == 0) ? 1.0 : Math.exp(-1.6 * k / Math.max(1, tailLen));
+        if (fall < 0.02) break;
+        // comet body carries its group color (red packs, blue packs), with the
+        // white shockwave band still glowing through mid-height
+        final double yn = (double) yy / (h - 1);
+        final int grpC = (s.grp[i] == 0) ? red : blue;
+        int c;
+        if (k == 0) {
+          c = LXColor.WHITE; // white-hot head
+        } else if (yn > 0.40 && yn < 0.55) {
+          final double m = 1.0 - Math.abs(yn - 0.475) / 0.075;
+          c = LXColor.lerp(grpC, LXColor.WHITE, (float) (m * 0.3));
+        } else {
+          c = grpC;
+        }
+        final double bb = fall * envB * (0.75 + 0.25 * hashd(i * 977 + yy * 131 + tq));
+        addPix(o, x, yy, c, bb);
+        addPix(o, x + 1, yy, c, bb * 0.55); // thicker: two-column body
+      }
+    }
+
+    // --- always alive: concentric dotted rings hugging the floor (the
+    // reference's center rings) and scattered twinkle dots through the lulls ---
+    final int ringC = LXColor.lerp(red, LXColor.WHITE, 0.35f);
+    for (int r2 = 0; r2 < 3; ++r2) {
+      final int ry = h - 2 - r2 * 2;
+      if (ry < 0) continue;
+      final double ringB = (0.20 + 0.30 * env) * (1.0 - r2 * 0.22);
+      final double ringSpin = this.timeMs * 0.004 * (1 + r2 * 0.5);
+      for (int x2 = 0; x2 < w; x2 += 3) {
+        final double dp = ((x2 + ringSpin) % 3.0) / 3.0;
+        if (dp > 0.6) continue;
+        addPix(o, x2, ry, ringC, ringB * (0.6 + 0.4 * hashd(x2 * 31 + r2 * 97 + tq)));
+      }
+    }
+    // white shockwave ring at mid-height, swelling with the climax
+    final int shockY = (int) (h * 0.475);
+    final double shockB = 0.06 + 0.24 * env;
+    for (int x2 = 0; x2 < w; x2 += 2) {
+      addPix(o, x2, shockY, LXColor.WHITE, shockB * (0.5 + 0.5 * hashd(x2 * 53 + tq * 3)));
+    }
+    // lull scatter: random dim dots keep the canvas breathing when the swell dips
+    if (env < 0.5) {
+      final int nScatter = (int) (w * h * 0.006 * (1.0 - env));
+      for (int k2 = 0; k2 < nScatter; ++k2) {
+        final int sx3 = (int) (hashd(k2 * 31 + tq * 977) * w);
+        final int sy3 = (int) (hashd(k2 * 53 + tq * 613) * h);
+        final double tw3 = hashd(k2 * 97 + tq * 131);
+        if (tw3 < 0.5) continue;
+        addPix(o, sx3, sy3, (tw3 > 0.9) ? LXColor.WHITE : blue, 0.2 + 0.5 * tw3);
+      }
+    }
+
+    // --- Wow: a blue gradient rises from the floor, radiating upward ---
+    if (wow > 0.05) {
+      final int gradBlue = LXColor.hsb((float) (((215 + hueShift) % 360)), 88, 100);
+      final double gradH = h * (0.25 + 0.5 * wow);
+      for (int y = h - 1; y >= h - (int) gradH && y >= 0; --y) {
+        final double t = (h - 1 - y) / gradH;
+        // upward-radiating pulse waves ride the gradient
+        final double wave = 0.7 + 0.3 * Math.sin(2 * Math.PI * (t * 2.5 - this.timeMs * 0.0007));
+        final double gb = wow * 0.45 * Math.pow(1.0 - t, 1.5) * wave;
+        if (gb < 0.01) break;
+        for (int x = 0; x < w; ++x) {
+          addPix(o, x, y, gradBlue, gb);
+        }
+      }
+
+      // --- white dotted stars stream from top and bottom, crossing mid-air ---
+      final int nStars = (int) (wow * 22);
+      final double starV = 0.00045 * this.timeMs;
+      for (int i2 = 0; i2 < nStars; ++i2) {
+        final int sx = (int) (hashd(i2 * 31 + 7) * w);
+        final double sp = 0.6 + 0.8 * hashd(i2 * 61 + 3);
+        // falling star
+        final double yd = ((hashd(i2 * 97 + 11) + starV * sp) % 1.0) * h;
+        addPix(o, sx, (int) yd, LXColor.WHITE, 0.55 + 0.35 * hashd(i2 + tq));
+        // rising star, offset column so the streams visibly cross
+        final int sx2 = (int) (hashd(i2 * 43 + 17) * w);
+        final double yu = (1.0 - ((hashd(i2 * 53 + 29) + starV * sp) % 1.0)) * h;
+        addPix(o, sx2, (int) yu, LXColor.WHITE, 0.55 + 0.35 * hashd(i2 * 7 + tq));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Liftoff.java
+++ b/src/main/java/apotheneum/piemonte/Liftoff.java
@@ -22,17 +22,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Liftoff extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double RISE_PER_MS = 0.0016; // normalized rise / ms at speed 1
   private static final double FLASH_MS = 260;       // burst flash decay
@@ -44,10 +37,6 @@ public class Liftoff extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How easily the music fires bursts and volleys");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** Per-column launch state. */
   private final class Surface {
@@ -98,19 +87,17 @@ public class Liftoff extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("fade", this.fade);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   /** Returns 0 = no beat, 1 = beat, 2 = drop (volley). */
   private int detect(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= 140)
       && (bass > 0.01);
@@ -119,7 +106,7 @@ public class Liftoff extends ParameterPattern {
     if (beat) {
       this.sinceBeatMs = 0;
     }
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0)
       : 1 - Math.exp(-deltaMs / 220.0);
@@ -138,7 +125,7 @@ public class Liftoff extends ParameterPattern {
     final double rise = RISE_PER_MS * speed * deltaMs * (1.0 + this.levelEnv * 1.2);
     final double fadeMs = LXUtils.lerp(600, 4500, this.fade.getValue());
     final double flashBand = 0.03 + getSize() * 0.12;
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
 
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, rise, deltaMs, fadeMs, flashBand, base, hit);

--- a/src/main/java/apotheneum/piemonte/Liftoff.java
+++ b/src/main/java/apotheneum/piemonte/Liftoff.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Liftoff — on every vertical string a line climbs upward from the floor; at a
+ * random height its head bursts in a bright flash, and the drawn tail lingers,
+ * slowly fading out like an ember trail. Then that string launches again. Each
+ * column runs on its own timing, so the piece crackles like rising fuses.
+ * With music playing, the show syncs to it: kicks detonate the fuses that are
+ * ready and send the next volley up, and the louder it gets the faster
+ * everything climbs. In silence it crackles on its own timing, unchanged.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Liftoff extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double RISE_PER_MS = 0.0016; // normalized rise / ms at speed 1
+  private static final double FLASH_MS = 260;       // burst flash decay
+
+  public final CompoundParameter fade =
+    new CompoundParameter("Fade", 0.5, 0, 1)
+    .setDescription("How long the tail lingers after the burst");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How easily the music fires bursts and volleys");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** Per-column launch state. */
+  private final class Surface {
+    int w;
+    double[] headY;    // current climb height (0 bottom .. 1 top)
+    double[] burstH;   // height at which the head bursts
+    double[] fade;     // tail brightness after burst (1 -> 0)
+    double[] flash;    // burst flash envelope (1 -> 0)
+    double[] riseVar;  // per-column rise-rate factor
+    boolean[] rising;  // true = climbing, false = fading
+
+    void ensure(int w) {
+      if (this.headY != null && this.w == w) {
+        return;
+      }
+      this.w = w;
+      this.headY = new double[w];
+      this.burstH = new double[w];
+      this.fade = new double[w];
+      this.flash = new double[w];
+      this.riseVar = new double[w];
+      this.rising = new boolean[w];
+      for (int x = 0; x < w; ++x) {
+        launch(x);
+        this.headY[x] = Math.random() * this.burstH[x]; // stagger starts
+      }
+    }
+
+    void launch(int x) {
+      this.rising[x] = true;
+      this.headY[x] = 0;
+      this.burstH[x] = 0.35 + Math.random() * 0.65;
+      this.riseVar[x] = 0.6 + Math.random() * 0.8;
+      this.fade[x] = 0;
+      this.flash[x] = 0;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  // audio: kicks detonate ready fuses; drops launch a multi-rocket volley
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+
+  public Liftoff(LX lx) {
+    // Base registers color, speed, size; speed = rise rate, size = burst size.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("fade", this.fade);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  /** Returns 0 = no beat, 1 = beat, 2 = drop (volley). */
+  private int detect(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 140)
+      && (bass > 0.01);
+    double ratio = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+    if (!beat) return 0;
+    return (ratio > 0.60 - sens * 0.15) ? 2 : 1;
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    final int base = getColor();
+    final double speed = Math.max(0.02, getSpeed());
+    final int hit = detect(deltaMs);
+    // louder music -> faster fuses (silence leaves the resting cadence alone)
+    final double rise = RISE_PER_MS * speed * deltaMs * (1.0 + this.levelEnv * 1.2);
+    final double fadeMs = LXUtils.lerp(600, 4500, this.fade.getValue());
+    final double flashBand = 0.03 + getSize() * 0.12;
+    final Target t = this.target.getEnum();
+
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, rise, deltaMs, fadeMs, flashBand, base, hit);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, rise, deltaMs, fadeMs, flashBand, base, hit);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double rise, double deltaMs,
+      double fadeMs, double flashBand, int base, int hit) {
+    final int w = o.width();
+    final int h = o.height();
+    s.ensure(w);
+
+    final double wow = getWow();
+    if (hit == 1) {
+      // kick: detonate fuses that are most of the way up, right on the beat
+      for (int x = 0; x < w; ++x) {
+        if (s.rising[x] && s.headY[x] > 0.45 * s.burstH[x]
+            && Math.random() < 0.45 + wow * 0.3) {
+          s.headY[x] = s.burstH[x];
+        }
+      }
+    } else if (hit == 2) {
+      // the drop: multi-rocket volley — detonate everything ready AND mass-launch
+      for (int x = 0; x < w; ++x) {
+        if (s.rising[x] && s.headY[x] > 0.3 * s.burstH[x]) {
+          s.headY[x] = s.burstH[x]; // cascade of bursts on the drop
+        } else if (!s.rising[x] && Math.random() < 0.65 + wow * 0.3) {
+          s.launch(x); // fresh rockets rise together as the volley
+          s.burstH[x] = 0.55 + Math.random() * 0.45; // volley flies high
+          s.riseVar[x] = 1.1 + Math.random() * 0.5;  // and fast
+        }
+      }
+    }
+
+    // advance each column's state machine
+    for (int x = 0; x < w; ++x) {
+      if (s.rising[x]) {
+        // fuses accelerate as they climb
+        s.headY[x] += rise * s.riseVar[x] * (0.6 + 0.8 * s.headY[x]);
+        if (s.headY[x] >= s.burstH[x]) {
+          s.headY[x] = s.burstH[x];
+          s.rising[x] = false;
+          s.fade[x] = 1;
+          s.flash[x] = 1;
+        }
+      } else {
+        s.fade[x] *= Math.exp(-deltaMs / (0.5 * fadeMs));
+        s.flash[x] -= deltaMs / FLASH_MS;
+        if (s.fade[x] < 0.01) {
+          s.launch(x);
+        }
+      }
+    }
+
+    // render columns
+    for (int x = 0; x < w; ++x) {
+      final LXPoint[] points = o.column(x).points;
+      final int last = points.length - 1;
+      final boolean rising = s.rising[x];
+      final double headY = s.headY[x];
+      final double burstH = s.burstH[x];
+      final double fade = s.fade[x];
+      final double flash = s.flash[x];
+      for (int j = 0; j < points.length; ++j) {
+        final double vB = (last == 0) ? 0.0 : (double) (last - j) / last;
+        int c;
+        if (rising) {
+          // white-hot tip decaying down the drawn tail
+          final double d = headY - vB;
+          if (d >= 0) {
+            double b = 0.25 + 0.75 * Math.exp(-d * 8.0);
+            c = LXColor.scaleBrightness(base, (float) b);
+            if (d < 0.04) {
+              c = LXColor.lerp(c, LXColor.WHITE, (float) (0.8 * (1.0 - d / 0.04)));
+            }
+          } else {
+            c = LXColor.BLACK;
+          }
+        } else {
+          c = (vB <= burstH) ? LXColor.scaleBrightness(base, (float) LXUtils.clamp(fade, 0, 1)) : LXColor.BLACK;
+          if (flash > 0) {
+            double d = Math.abs(vB - burstH);
+            if (d < flashBand) {
+              double fb = flash * Math.pow(1.0 - d / flashBand, 2);
+              c = LXColor.lightest(c, LXColor.scaleBrightness(LXColor.WHITE, (float) fb));
+            }
+          }
+        }
+        this.colors[points[j].index] = c;
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Likes.java
+++ b/src/main/java/apotheneum/piemonte/Likes.java
@@ -151,14 +151,11 @@ public class Likes extends StrandPattern {
 
   /** Onset detector on the top quarter of the spectrum (pitch hits). */
   private boolean detectPitchHit(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    final int nb = Math.max(1, m.numBands);
-    final int q = Math.max(1, nb / 4);
-    final double treb = m.getAveragef(nb - q, q);
+    double treb = this.level.getValue();
     this.trebAvg += (treb - this.trebAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceTrebMs += deltaMs;
     final double threshold = 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
-    final boolean hit = (treb > this.trebAvg * threshold)
+    final boolean hit = pulseHit() || (treb > this.trebAvg * threshold)
       && (treb > this.prevTreb)
       && (this.sinceTrebMs >= 160)
       && (treb > 0.005);

--- a/src/main/java/apotheneum/piemonte/Likes.java
+++ b/src/main/java/apotheneum/piemonte/Likes.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Likes — purple circuitry firing across the strands. On every hit — bass,
+ * pitch, a random clock, or the manual Fire button — traces ignite at random
+ * spots: connected right-angle paths drawing themselves in, dashed and
+ * twinkling with white-hot junctions, each eroding away dot by dot. Turn up
+ * Wow and the traces glitch like SpecialKube, dots strobing between white
+ * and purple; hard hits still bloom the whole field at once.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Likes extends StrandPattern {
+
+  public enum Trigger {
+    BASS,
+    PITCH,
+    RANDOM
+  }
+
+  private static final int MAX_GLYPHS = 20;
+  private static final int MAX_SEGS = 9;       // segments per glyph path
+  private static final double ATTACK_MS = 220; // trace draws itself in
+  private static final double HOLD_MS = 450;
+  private static final double ERODE_MS = 400;  // dots drop out
+  private static final int STRAND_PITCH = 2;   // columns per "strand"
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 6, 2, 12)
+    .setDescription("Glyphs ignited per hit");
+
+  public final EnumParameter<Trigger> trigger =
+    new EnumParameter<Trigger>("Trigger", Trigger.BASS)
+    .setDescription("What fires the circuitry: bass hits, pitch hits, or a random clock");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How easily hits fire");
+
+  public final BooleanParameter fire =
+    new BooleanParameter("Fire", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Manually ignite a burst of traces");
+
+  /** One glyph = a connected right-angle path, precomputed at spawn. */
+  private final class Surface {
+    boolean inited;
+    final int[][] sx0 = new int[MAX_GLYPHS][MAX_SEGS];
+    final int[][] sy0 = new int[MAX_GLYPHS][MAX_SEGS];
+    final int[][] sx1 = new int[MAX_GLYPHS][MAX_SEGS];
+    final int[][] sy1 = new int[MAX_GLYPHS][MAX_SEGS];
+    final int[] nSegs = new int[MAX_GLYPHS];
+    final int[] totalLen = new int[MAX_GLYPHS];
+    final double[] age = new double[MAX_GLYPHS];
+    final int[] seed = new int[MAX_GLYPHS];
+    final boolean[] alive = new boolean[MAX_GLYPHS];
+    void reset() {
+      for (int i = 0; i < MAX_GLYPHS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+
+    /** Build a right-angle trace: vertical runs joined by horizontal jogs. */
+    void spawn(int w, int h) {
+      int gi = -1;
+      for (int i = 0; i < MAX_GLYPHS; ++i) {
+        if (!this.alive[i]) { gi = i; break; }
+      }
+      if (gi < 0) return;
+      int x = (int) (Math.random() * w);
+      int y = 1 + (int) (Math.random() * h * 0.5); // seeds favor the upper strands
+      int n = 0;
+      int total = 0;
+      final int steps = 3 + (int) (Math.random() * 4); // 3-6 runs
+      final boolean block = Math.random() < 0.22;      // occasional closed rectangle
+      for (int k = 0; k < steps && n < MAX_SEGS - 1; ++k) {
+        // vertical run downward
+        final int run = (int) (h * (0.15 + Math.random() * 0.13));
+        final int yEnd = Math.min(h - 1, y + run);
+        this.sx0[gi][n] = x; this.sy0[gi][n] = y;
+        this.sx1[gi][n] = x; this.sy1[gi][n] = yEnd;
+        total += yEnd - y; ++n;
+        y = yEnd;
+        if (y >= h - 1) break;
+        // horizontal jog 1-3 strand pitches, either direction
+        final int jog = STRAND_PITCH * (1 + (int) (Math.random() * 3))
+          * (Math.random() < 0.5 ? 1 : -1);
+        this.sx0[gi][n] = x; this.sy0[gi][n] = y;
+        this.sx1[gi][n] = x + jog; this.sy1[gi][n] = y;
+        total += Math.abs(jog); ++n;
+        x = x + jog;
+      }
+      if (block && n < MAX_SEGS) {
+        // close a small rectangle off the last corner
+        final int bw = STRAND_PITCH * (2 + (int) (Math.random() * 2));
+        this.sx0[gi][n] = x; this.sy0[gi][n] = Math.max(0, y - 6);
+        this.sx1[gi][n] = x + bw; this.sy1[gi][n] = Math.max(0, y - 6);
+        total += bw; ++n;
+      }
+      this.nSegs[gi] = n;
+      this.totalLen[gi] = Math.max(1, total);
+      this.age[gi] = 0;
+      this.seed[gi] = (int) (Math.random() * 1000000);
+      this.alive[gi] = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double trebAvg, prevTreb, sinceTrebMs = 1e9;
+  private double randomTimer = 0;
+  private boolean fireWasOn = false;
+  private double bloom = 0;
+
+  public Likes(LX lx) {
+    // Base registers color (circuit tint), speed (lifecycle pace), size (dash scale).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("trigger", this.trigger);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("fire", this.fire);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Onset detector on the top quarter of the spectrum (pitch hits). */
+  private boolean detectPitchHit(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    final int nb = Math.max(1, m.numBands);
+    final int q = Math.max(1, nb / 4);
+    final double treb = m.getAveragef(nb - q, q);
+    this.trebAvg += (treb - this.trebAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceTrebMs += deltaMs;
+    final double threshold = 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+    final boolean hit = (treb > this.trebAvg * threshold)
+      && (treb > this.prevTreb)
+      && (this.sinceTrebMs >= 160)
+      && (treb > 0.005);
+    this.prevTreb = treb;
+    if (hit) this.sinceTrebMs = 0;
+    return hit;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double wow = getWow();
+    final boolean pitchHit = detectPitchHit(deltaMs);
+
+    boolean fire = false;
+    // manual ignition: button edge fires in any trigger mode
+    final boolean fireBtn = this.fire.isOn();
+    if (fireBtn && !this.fireWasOn) {
+      fire = true;
+    }
+    this.fireWasOn = fireBtn;
+    switch (this.trigger.getEnum()) {
+      case BASS: fire |= this.beat; break;
+      case PITCH: fire |= pitchHit; break;
+      case RANDOM:
+        this.randomTimer -= deltaMs;
+        if (this.randomTimer <= 0) {
+          this.randomTimer = 700 + Math.random() * 700; // ~0.7-1.4s, like the reference
+          fire = true;
+        }
+        break;
+    }
+
+    if (fire) {
+      final boolean mega = (this.beatLevel > 0.75 - wow * 0.25) || (wow > 0.85);
+      final int n = this.density.getValuei() + (int) Math.round(wow * 4)
+        + (mega ? MAX_GLYPHS : 0);
+      spawnBurst(this.cube, Apotheneum.cube.exterior, n);
+      spawnBurst(this.cylinder, Apotheneum.cylinder.exterior, n);
+      if (mega) this.bloom = 1;
+    }
+    this.bloom *= Math.exp(-deltaMs / 300.0);
+  }
+
+  private void spawnBurst(Surface s, Apotheneum.Orientation o, int n) {
+    if (!s.inited) s.reset();
+    for (int k = 0; k < n; ++k) {
+      s.spawn(o.width(), o.height());
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final int purple = LXColor.hsb((float) (((278 + hueShift) % 360)), 92, 100);
+    final int dimPurple = LXColor.hsb((float) (((262 + hueShift) % 360)), 85, 100); // violet low end
+    final int hot = LXColor.lerp(purple, LXColor.WHITE, 0.7f);
+    // Wow: SpecialKube-style glitch — dots strobe between white and purple
+    final double glitchAmt = getWow();
+    final double gt = this.timeMs * (0.02 + glitchAmt * 0.04);
+    final boolean strobeOn = ((this.timeMs * 0.001 * (6.0 + glitchAmt * 4.0)) % 1.0)
+      < (0.12 + glitchAmt * 0.14);
+    final int tq = (int) (this.timeMs / 90); // ~11Hz dot twinkle
+    final double dashOn = 0.5 + getSize() * 0.2; // mark:gap near 1:1
+    final double lifeSpeed = speed * 2;
+
+    for (int g = 0; g < MAX_GLYPHS; ++g) {
+      if (!s.alive[g]) continue;
+      s.age[g] += deltaMs * lifeSpeed;
+      final double age = s.age[g];
+      final double total = ATTACK_MS + HOLD_MS + ERODE_MS;
+      if (age >= total) { s.alive[g] = false; continue; }
+
+      // attack: the trace draws in along its path; erode: dots drop out
+      final double reveal = LXUtils.clamp(age / ATTACK_MS, 0, 1);
+      final double erode = LXUtils.clamp((age - ATTACK_MS - HOLD_MS) / ERODE_MS, 0, 1);
+      final int drawLen = (int) Math.ceil(s.totalLen[g] * reveal);
+
+      int walked = 0;
+      for (int seg = 0; seg < s.nSegs[g]; ++seg) {
+        final int dx = Integer.signum(s.sx1[g][seg] - s.sx0[g][seg]);
+        final int dy = Integer.signum(s.sy1[g][seg] - s.sy0[g][seg]);
+        final int len = Math.abs(s.sx1[g][seg] - s.sx0[g][seg])
+          + Math.abs(s.sy1[g][seg] - s.sy0[g][seg]);
+        for (int k = 0; k <= len; ++k) {
+          if (walked + k > drawLen) break;
+          // dashed 1:1 mark-space texture
+          final double dashPhase = ((walked + k) % 6) / 6.0;
+          if (dashPhase > dashOn) continue;
+          // erosion: dots drop out one by one
+          if (erode > 0 && hashd(s.seed[g] + (walked + k) * 131) < erode) continue;
+          final int x = s.sx0[g][seg] + dx * k;
+          final int y = s.sy0[g][seg] + dy * k;
+          if (y < 0 || y >= h) continue;
+          // per-dot twinkle + brightness jitter
+          final double tw = 0.55 + 0.45 * hashd(s.seed[g] + (walked + k) * 977 + tq * 7);
+          double b = tw * (1.0 - erode * 0.4) * (0.85 + this.bloom * 0.5);
+          // white-hot: junctions (segment ends) and the drawing head
+          final boolean junction = (k == 0 || k == len);
+          final boolean head = (walked + k) >= drawLen - 2 && reveal < 1;
+          int c = (junction || head) ? hot : (tw < 0.72 ? dimPurple : purple);
+          if (glitchAmt > 0.05) {
+            // glitch flicker: dots flip white<->purple, harder with the dial
+            final double gflip = hashd(s.seed[g] + (walked + k) * 613 + (int) (gt * 10));
+            if (strobeOn && gflip < 0.35 + glitchAmt * 0.4) {
+              c = LXColor.WHITE;
+              b *= 1.3;
+            } else if (gflip > 0.94 - glitchAmt * 0.2) {
+              c = LXColor.lerp(LXColor.WHITE, purple, 0.35f);
+            }
+          }
+          addPix(o, x, y, c, LXUtils.clamp(b, 0, 1));
+        }
+        walked += len;
+      }
+    }
+
+    // faint lingering room spill after blooms
+    if (this.bloom > 0.05) {
+      final int spill = LXColor.scaleBrightness(purple, (float) (this.bloom * 0.18));
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          final int idx = o.point(x, y).index;
+          this.colors[idx] = LXColor.lightest(this.colors[idx], spill);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/LockedIn.java
+++ b/src/main/java/apotheneum/piemonte/LockedIn.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * LockedIn — sets of thick bars lock into the center of the canvas, one color
+ * at a time. Each bar is a solid column anchored to its entry edge, growing
+ * toward the middle with the UFOAbduction feel — fast travel, decelerating on
+ * approach — then bouncing on the same velocity model, each bar on its own
+ * clock and reach, before freezing in place. Sets alternate bottom and top
+ * entries, each at a new horizontal offset, cycling through five colors and
+ * layering endlessly: the stack never fades — new sets keep locking in over
+ * the old, and only when a color comes back around does its previous layer
+ * yield to the fresh one rising from the edge. Beats punch the bounces; Wow
+ * adds bounce reach and shimmer.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class LockedIn extends StrandPattern {
+
+  private static final int N_COLORS = 5;    // hues cycled across sets
+  private static final int MAX_LAYERS = 10; // frozen sets kept on the canvas
+  private static final int MAX_BARS = 16;
+  // UFOAbduction-style approach: quick entry, deceleration into the center
+  private static final double V_ENTER = 0.0016;  // heights/ms far from rest
+  private static final double V_NEAR = 0.00030;  // crawl arriving at center
+  private static final double BOUNCE_DECAY = 0.78; // per-bounce settle
+  private static final double RELAUNCH_MS = 450;   // breath between sets
+  private static final double[] HUE_STEPS = { 0, 52, 125, 205, 288 };
+
+  public final DiscreteParameter bars =
+    new DiscreteParameter("Bars", 9, 4, MAX_BARS)
+    .setDescription("Bars per color set");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How hard beats punch the bounce");
+
+  // layered set state (normalized; shared across surfaces)
+  private final double[][] layX = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layLen = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] layYc = new double[MAX_LAYERS][MAX_BARS];
+  private final double[][] lenVar = new double[MAX_LAYERS][MAX_BARS];
+  private final int[] layerHue = new int[MAX_LAYERS];
+  private final boolean[] layerFromTop = new boolean[MAX_LAYERS];
+  private final boolean[] layerLive = new boolean[MAX_LAYERS];
+
+  private int gen = 0;           // total sets launched
+  private int activeLayer = -1;  // layer currently animating, -1 = between sets
+  private double pauseMs = 0;
+  private double bopKick = 0;
+  private boolean laidOut = false;
+
+  // per-bar independent motion within the active set
+  private final int[] barPhase = new int[MAX_BARS];  // 0 enter, 1 bounce, 2 frozen
+  private final double[] barPos = new double[MAX_BARS];
+  private final double[] barDelay = new double[MAX_BARS];
+  private final double[] barVf = new double[MAX_BARS];
+  private final double[] barBopPh = new double[MAX_BARS];
+  private final double[] barTgt = new double[MAX_BARS];   // current bounce target
+  private final int[] barBounce = new int[MAX_BARS];      // reversals remaining
+
+  public LockedIn(LX lx) {
+    // Base registers color (wheel anchor), speed (pace), size (bar thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bars", this.bars);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  /** Per-bar bounce reach: base + Wow + beat punch, widely varied per bar. */
+  private double bounceAmp(int l, int b) {
+    return (0.09 + getWow() * 0.06
+      + this.bopKick * 0.05 * this.sensitivity.getValue())
+      * (0.45 + 1.15 * hashd(l * 97 + b * 31));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Launch the next set: claim a layer (recycling the oldest) and arm bars. */
+  private void launchSet() {
+    final int l = this.gen % MAX_LAYERS;
+    this.activeLayer = l;
+    this.layerHue[l] = this.gen % N_COLORS;
+    this.layerFromTop[l] = (this.gen & 1) == 1; // alternate bottom / top
+    this.layerLive[l] = true;
+    final double off = Math.random(); // per-set horizontal offset
+    for (int b = 0; b < MAX_BARS; ++b) {
+      this.layX[l][b] = (off + (double) b / MAX_BARS
+        + (Math.random() - 0.5) * 0.02) % 1.0;
+      this.layLen[l][b] = 0.14 + Math.random() * 0.30; // varied reach
+      this.layYc[l][b] = 0.42 + Math.random() * 0.16;  // tips around center
+      this.lenVar[l][b] = 0.8 + Math.random() * 0.4;
+      this.barPhase[b] = 0;
+      this.barPos[b] = (this.layerFromTop[l] ? -1 : 1)
+        * (1.05 + Math.random() * 0.30);
+      this.barDelay[b] = Math.random() * 900;
+      this.barVf[b] = 0.7 + Math.random() * 0.6;
+      this.barBopPh[b] = Math.random();
+      this.barTgt[b] = 0;
+      this.barBounce[b] = 0;
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.laidOut) {
+      this.gen = 0;
+      launchSet();
+      this.laidOut = true;
+    }
+    final double speed = Math.max(0.05, getSpeed());
+    final double dt = deltaMs * speed * 2;
+
+    if (this.beat) {
+      this.bopKick = 1;
+    }
+    this.bopKick *= Math.exp(-deltaMs / 260.0);
+
+    if (this.activeLayer < 0) { // between sets: breathe, then launch the next
+      this.pauseMs -= dt;
+      if (this.pauseMs <= 0) {
+        launchSet();
+      }
+      return;
+    }
+
+    final int l = this.activeLayer;
+    final int nBars = this.bars.getValuei();
+    boolean allFrozen = true;
+    for (int b = 0; b < nBars; ++b) {
+      switch (this.barPhase[b]) {
+        case 0: { // entering: decelerate on approach, independently
+          if (this.barDelay[b] > 0) {
+            this.barDelay[b] -= dt;
+            allFrozen = false;
+            break;
+          }
+          final double dist = Math.abs(this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] -= Math.signum(this.barPos[b]) * v * dt;
+          if (dist < 0.015) {
+            this.barPos[b] = 0;
+            this.barPhase[b] = 1;
+            // momentum carries into the first bounce, past the rest point
+            this.barBounce[b] = 3 + (int) (this.barBopPh[b] * 3);
+            this.barTgt[b] = (this.layerFromTop[l] ? 1 : -1) * bounceAmp(l, b);
+          }
+          allFrozen = false;
+          break;
+        }
+        case 1: { // bouncing: same velocity model as the entry travel
+          final double dist = Math.abs(this.barTgt[b] - this.barPos[b]);
+          final double v = this.barVf[b] * LXUtils.lerp(V_NEAR, V_ENTER,
+            LXUtils.clamp(dist / 0.45, 0, 1));
+          this.barPos[b] += Math.signum(this.barTgt[b] - this.barPos[b]) * v * dt;
+          if (dist < 0.008) {
+            if (--this.barBounce[b] <= 0) {
+              // ease home and freeze
+              if (Math.abs(this.barPos[b]) < 0.008) {
+                this.barPos[b] = 0;
+                this.barPhase[b] = 2;
+              } else {
+                this.barTgt[b] = 0;
+                this.barBounce[b] = 1;
+              }
+            } else {
+              // reverse, each bounce a little smaller
+              this.barTgt[b] = -Math.signum(this.barTgt[b])
+                * bounceAmp(l, b)
+                * Math.pow(BOUNCE_DECAY, 6 - this.barBounce[b]);
+            }
+          }
+          allFrozen = false;
+          break;
+        }
+      }
+    }
+    if (allFrozen) { // set locked; the stack stays — queue the next set
+      ++this.gen;
+      this.activeLayer = -1;
+      this.pauseMs = RELAUNCH_MS;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double hueShift = LXColor.h(getColor());
+    final int nBars = this.bars.getValuei();
+    final double thickC = Math.max(2, (2.5 + getSize() * 5) * (isCube ? 1.6 : 1.0));
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int l = 0; l < MAX_LAYERS; ++l) {
+      if (!this.layerLive[l]) continue;
+      final boolean active = (l == this.activeLayer);
+      final boolean fromTop = this.layerFromTop[l];
+      final int col = LXColor.hsb(
+        (float) (((hueShift + HUE_STEPS[this.layerHue[l]]) % 360) + 360) % 360, 92, 100);
+      final int hot = LXColor.lerp(col, LXColor.WHITE, 0.55f);
+      final double genB = active ? 1.0 : 0.82;
+
+      for (int b = 0; b < nBars; ++b) {
+        final double xN = this.layX[l][b];
+        final double len = this.layLen[l][b] * this.lenVar[l][b];
+        double yc = this.layYc[l][b];
+        boolean entering = false;
+        if (active) {
+          if (this.barPhase[b] == 0) {
+            if (this.barDelay[b] > 0) continue; // not launched yet
+            yc += this.barPos[b]; // still traveling in
+            entering = true;
+          } else if (this.barPhase[b] == 1) {
+            yc += this.barPos[b]; // bouncing on the entry velocity model
+          }
+        }
+        // solid column anchored to its entry edge, reaching to its lead end:
+        // bottom-entering bars fill floor-to-lead, top-entering sky-to-lead
+        final double leadF = fromTop
+          ? (yc + len / 2) * (h - 1)   // lead end grows downward from the sky
+          : (yc - len / 2) * (h - 1);  // lead end grows upward from the floor
+        if (fromTop ? (leadF < -1) : (leadF > h)) continue;
+
+        final int x0 = (int) Math.round(xN * w);
+        final int bw = (int) thickC;
+        final double span = fromTop
+          ? Math.max(1, leadF)
+          : Math.max(1, (h - 1) - leadF);
+
+        for (int dx = 0; dx < bw; ++dx) {
+          final int x = x0 + dx;
+          final int yStart = fromTop ? 0 : (int) Math.floor(leadF);
+          final int yEnd = fromTop ? (int) Math.ceil(leadF) : h - 1;
+          for (int yy = yStart; yy <= yEnd; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final double dOut = fromTop ? (yy - leadF) : (leadF - yy);
+            final double cov = LXUtils.clamp(1.0 - Math.max(0, dOut), 0, 1);
+            if (cov <= 0.02) continue;
+            // brightest at the lead end, easing back toward the anchor edge
+            final double back = Math.abs(yy - leadF) / span;
+            int c = col;
+            double bb = genB * cov * (0.55 + 0.45 * Math.pow(1.0 - back, 0.8))
+              * (0.85 + 0.15 * hashd(x * 131 + yy * 7 + (active ? tq : 0)));
+            if (entering && Math.abs(yy - leadF) < 1.5) {
+              c = hot;
+              bb = Math.min(1, bb * 1.5);
+            }
+            addPix(o, x, yy, c, bb);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Nice.java
+++ b/src/main/java/apotheneum/piemonte/Nice.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Nice — the multi-color orb chamber from the holotrigger arcade reference. Glowing circles in vivid mixed colors —
+ * golden yellows, oranges, ice blues, magentas, greens — float among the
+ * strands at varied sizes and heights, each with a white-hot core, a soft
+ * speckled body, and light spilling down the strands beneath it. Every orb
+ * rides the UFOAbduction velocity signature: a fast beam up from the floor,
+ * a long slow-motion hover through the center of the room, then a burst out
+ * the top as a fresh orb is born below. Orbs throb like lanterns as they
+ * hover; beats kick their glow and hatch extras. Wow packs the room with
+ * more orbs and hardens the throb toward a flicker.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Nice extends StrandPattern {
+
+  private static final int MAX_ORBS = 40;
+  // UFOAbduction's measured rise profile: fast entry, center stall, exit burst
+  private static final double V_ENTRY = 0.00135;
+  private static final double V_STALL = 0.00024;
+  private static final double V_EXIT = 0.0075;
+  private static final double STALL_LO = 0.60;
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;
+  // the reference's color families: golds, oranges, ice blues, magentas, greens
+  private static final double[] FAMILY_HUES = { 46, 24, 205, 315, 135, 190 };
+
+  public final DiscreteParameter orbs =
+    new DiscreteParameter("Orbs", 14, 4, MAX_ORBS)
+    .setDescription("Orbs floating in the chamber");
+
+  // one shared simulation in normalized coordinates, rendered to both surfaces
+  private final double[] ox = new double[MAX_ORBS];
+  private final double[] oy = new double[MAX_ORBS];
+  private final double[] or = new double[MAX_ORBS];   // radius, fraction of height
+  private final double[] ohue = new double[MAX_ORBS];
+  private final double[] ovf = new double[MAX_ORBS];  // speed variance
+  private final double[] oph = new double[MAX_ORBS];  // throb phase
+  private final boolean[] alive = new boolean[MAX_ORBS];
+  private double kick = 0;
+  private int seed = 1;
+
+  public Nice(LX lx) {
+    // Base registers color (hue shift), speed (rise pace), size (orb radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("orbs", this.orbs);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** UFOAbduction's rise profile: fast entry, center stall, exit burst. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private void spawn(int i) {
+    ++this.seed;
+    this.ox[i] = hashd(this.seed * 97 + i * 13);
+    this.oy[i] = 1.06 + hashd(this.seed * 61 + 7) * 0.25; // below the floor
+    this.or[i] = 0.05 + hashd(this.seed * 31 + 3) * 0.10; // varied sizes
+    // mostly family colors with the occasional wildcard, like the reference
+    final double pick = hashd(this.seed * 53 + 11);
+    this.ohue[i] = (pick < 0.85)
+      ? FAMILY_HUES[(int) (hashd(this.seed * 17 + 5) * FAMILY_HUES.length)]
+        + (hashd(this.seed * 7 + 1) - 0.5) * 18
+      : hashd(this.seed * 41 + 9) * 360;
+    this.ovf[i] = 0.7 + hashd(this.seed * 23 + 15) * 0.6;
+    this.oph[i] = hashd(this.seed * 89 + 21) * Math.PI * 2;
+    this.alive[i] = true;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+
+    if (this.beat) {
+      this.kick = 1;
+    }
+    this.kick *= Math.exp(-deltaMs / 260.0);
+
+    // population target; Wow packs the room, beats hatch a couple extra
+    final int want = Math.min(MAX_ORBS, (int) (this.orbs.getValuei()
+      * (1 + wow * 0.7) + this.kick * 2));
+    int count = 0;
+    for (int i = 0; i < MAX_ORBS; ++i) {
+      if (this.alive[i]) ++count;
+    }
+    for (int i = 0; i < MAX_ORBS && count < want; ++i) {
+      if (!this.alive[i]) {
+        spawn(i);
+        ++count;
+      }
+    }
+
+    // each orb rides the abduction profile up through the chamber
+    for (int i = 0; i < MAX_ORBS; ++i) {
+      if (!this.alive[i]) continue;
+      this.oy[i] -= this.ovf[i] * riseProfile(this.oy[i]) * speed * 2 * deltaMs;
+      if (this.oy[i] <= -0.12) {
+        this.alive[i] = false; // out the top; a fresh orb hatches below
+      }
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double hueShift = LXColor.h(getColor());
+    final double sizeF = 0.6 + getSize() * 1.1;
+    final int tq = (int) (this.timeMs / 80);
+    final double glowKick = 1 + this.kick * 0.35 + this.levelEnv * 0.25;
+
+    for (int i = 0; i < MAX_ORBS; ++i) {
+      if (!this.alive[i]) continue;
+      final double yp = this.oy[i];
+      final boolean stalled = (yp <= STALL_LO && yp >= STALL_HI);
+
+      final float hue = (float) (((this.ohue[i] + hueShift) % 360 + 360) % 360);
+      final int body = LXColor.hsb(hue, 92, 100);
+      final int core = LXColor.lerp(body, LXColor.WHITE, 0.55f);
+
+      // lantern throb while hovering; Wow hardens it toward a flicker
+      double throb = 1.0;
+      if (stalled) {
+        final double sIn = Math.sin(this.timeMs * (0.004 + wow * 0.006) + this.oph[i]);
+        throb = 0.78 + 0.22 * sIn;
+        if (wow > 0.6 && hashd(i * 131 + tq * 7) < (wow - 0.6) * 0.9) {
+          throb *= 0.35; // hard flicker drops at high Wow
+        }
+      }
+
+      final double cy = yp * (h - 1);
+      final double R = this.or[i] * h * sizeF;
+      final int cx = (int) (this.ox[i] * w);
+      final int iR = (int) Math.ceil(R);
+
+      // the orb: white-hot core, colored body, soft speckled edge
+      for (int dy = -iR; dy <= iR; ++dy) {
+        final int yy = (int) Math.round(cy) + dy;
+        if (yy < 0 || yy >= h) continue;
+        for (int dx = -iR; dx <= iR; ++dx) {
+          final double d = Math.sqrt(dx * dx + dy * dy) / R;
+          if (d > 1) continue;
+          final double g = Math.exp(-d * d * 2.6);
+          // strand speckle: vertical thread texture inside the orb
+          final double sp = 0.72 + 0.28 * hashd((cx + dx) * 131 + yy * 7 + tq);
+          final int c = (d < 0.30) ? core : body;
+          addPix(o, cx + dx, yy, c,
+            Math.min(1, g * sp * throb * glowKick));
+        }
+      }
+
+      // light spilling down the strands beneath the orb
+      final int spill = (int) (R * 2.5);
+      for (int k = 1; k <= spill; ++k) {
+        final int yy = (int) Math.round(cy) + iR + k;
+        if (yy >= h) break;
+        final double f = Math.exp(-1.8 * k / spill);
+        if (f < 0.03) break;
+        for (int dx = -iR / 2; dx <= iR / 2; ++dx) {
+          final double tw = 0.5 + 0.5 * hashd((cx + dx) * 977 + yy * 53 + tq * 3);
+          addPix(o, cx + dx, yy, body, f * 0.30 * tw * throb);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Origami.java
+++ b/src/main/java/apotheneum/piemonte/Origami.java
@@ -22,17 +22,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Origami extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double HUE_STEP = 47;      // per-layer hue advance
   private static final double MIN_REMAIN = 0.13;  // below this, the next fold finishes the layer
@@ -50,10 +43,6 @@ public class Origami extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How dramatic the music shift must be to fold");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -85,7 +74,7 @@ public class Origami extends ParameterPattern {
     addParameter("fold", this.fold);
     addParameter("audio", this.audio);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -146,14 +135,12 @@ public class Origami extends ParameterPattern {
   }
 
   private boolean detectDrop(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.25 + (1 - sens) * 0.9; // demands a real shift, not every beat
-    boolean drop = (bass > this.bassAvg * threshold)
+    boolean drop = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= FOLD_REFRACT_MS)
       && (bass > 0.01);
@@ -197,7 +184,7 @@ public class Origami extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/Origami.java
+++ b/src/main/java/apotheneum/piemonte/Origami.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Origami — the surface is a sheet of paper ruled with drifting diagonal lines
+ * in one color. Hit the Fold button (or let a dramatic swell in the music do
+ * it) and the sheet creases: the remaining area folds in half upon itself,
+ * the flap sweeping over and dissolving to reveal a new layer beneath — a new
+ * color, lines running the other way. Folds keep halving the old layer until
+ * it's gone, then the folding continues on the next layer, a new color with
+ * every crease. Wow makes each fold flash harder and crease brighter.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Origami extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double HUE_STEP = 47;      // per-layer hue advance
+  private static final double MIN_REMAIN = 0.13;  // below this, the next fold finishes the layer
+  private static final double FOLD_REFRACT_MS = 900;
+
+  public final BooleanParameter fold =
+    new BooleanParameter("Fold", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Fold the sheet: collapse half the current layer");
+
+  public final BooleanParameter audio =
+    new BooleanParameter("Audio", true)
+    .setDescription("Let dramatic shifts in the music trigger folds");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How dramatic the music shift must be to fold");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    Panel(int[][] idx, int w, int h) { this.idx = idx; this.w = w; this.h = h; }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  // global fold state, shared by all panels so the whole piece creases together
+  private int layer = 0;
+  private double lo = 0, hi = 1;      // remaining old-layer interval on the fold axis
+  private double foldT = -1;          // <0 idle, else 0..1 animation progress
+  private int foldSide = 0;           // 0: fold left/top half over; 1: right/bottom
+  private double crease = 0.5;
+  private boolean finalFold = false;
+  private double drift = 0;
+  private double timeMs = 0;
+  private boolean foldWasOn = false;
+
+  // bass-onset state (Cope-style detector, longer refractory for "dramatic" shifts)
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+
+  public Origami(LX lx) {
+    // Base registers color (layer-0 tint), speed (drift + fold tempo), size (line
+    // spacing/thickness), wow (fold drama).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("fold", this.fold);
+    addParameter("audio", this.audio);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Stripe angle for a layer: alternating diagonals with per-layer character. */
+  private static double layerAngle(int layer) {
+    double base = ((layer & 1) == 0) ? 45 : -45;
+    return Math.toRadians(base + (hashd(layer * 31 + 7) - 0.5) * 18);
+  }
+
+  private int layerColor(int layer) {
+    float baseHue = LXColor.h(getColor());
+    float hue = (float) (((baseHue + layer * HUE_STEP) % 360 + 360) % 360);
+    return LXColor.hsb(hue, 85, 100);
+  }
+
+  /** True if this layer folds along the horizontal axis (vertical creases). */
+  private static boolean axisHoriz(int layer) {
+    return hashd(layer * 53 + 3) < 0.5;
+  }
+
+  private boolean detectDrop(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.25 + (1 - sens) * 0.9; // demands a real shift, not every beat
+    boolean drop = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= FOLD_REFRACT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (drop) {
+      this.sinceBeatMs = 0;
+    }
+    return drop;
+  }
+
+  private void startFold() {
+    final double remain = this.hi - this.lo;
+    if (remain <= MIN_REMAIN) {
+      // last sliver: fold the whole thing over its far edge and finish the layer
+      this.finalFold = true;
+      this.foldSide = 0;
+      this.crease = this.hi;
+    } else {
+      this.finalFold = false;
+      // alternate which side folds in, tracked by interval midpoint parity
+      this.foldSide = (hashd(this.layer * 97 + (int) (remain * 1000)) < 0.5) ? 0 : 1;
+      this.crease = 0.5 * (this.lo + this.hi);
+    }
+    this.foldT = 0;
+  }
+
+  private void commitFold() {
+    if (this.finalFold) {
+      this.layer++;
+      this.lo = 0;
+      this.hi = 1;
+    } else if (this.foldSide == 0) {
+      this.lo = this.crease;
+    } else {
+      this.hi = this.crease;
+    }
+    this.foldT = -1;
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    this.timeMs += deltaMs;
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    this.drift += deltaMs * speed * 0.0004;
+
+    // --- triggers: UI button edge, or a dramatic musical shift ---
+    final boolean btn = this.fold.isOn();
+    final boolean btnEdge = btn && !this.foldWasOn;
+    this.foldWasOn = btn;
+    final boolean drop = detectDrop(deltaMs) && this.audio.isOn();
+    if (this.foldT < 0 && (btnEdge || drop)) {
+      startFold();
+    }
+
+    // --- advance fold animation ---
+    final double foldDur = 700.0 / ((0.4 + speed * 1.2) * (1.0 + wow * 0.5));
+    if (this.foldT >= 0) {
+      this.foldT += deltaMs / foldDur;
+      if (this.foldT >= 1) {
+        commitFold();
+      }
+    }
+
+    final int colOld = layerColor(this.layer);
+    final int colNew = layerColor(this.layer + 1);
+    final double angOld = layerAngle(this.layer);
+    final double angNew = layerAngle(this.layer + 1);
+    final boolean horiz = axisHoriz(this.layer);
+    final double period = 3 + getSize() * 10;
+    final double duty = 0.32;
+
+    final double ft = this.foldT;
+    final double cosF = (ft >= 0) ? Math.cos(Math.PI * ft) : 1;
+    final double lift = (ft >= 0) ? Math.sin(Math.PI * ft) : 0; // flap catching the light
+    final double flapGlint = lift * (0.45 + wow * 0.75);
+    final double creaseGlow = (ft >= 0) ? (0.6 + wow * 0.9) * Math.sin(Math.PI * Math.min(1, ft * 1.15)) : 0;
+
+    for (Panel p : this.panels) {
+      final double diag = 1.0 / Math.max(1, (horiz ? p.w : p.h) - 1);
+      for (int x = 0; x < p.w; ++x) {
+        for (int y = 0; y < p.h; ++y) {
+          final double a = (horiz ? x : y) * diag; // fold-axis coordinate, 0..1
+          int c;
+          double b;
+          double sampleA = a;      // where on the sheet we sample the old pattern
+          boolean showOld;
+          double glint = 0;
+
+          if (ft < 0) {
+            showOld = (a >= this.lo && a <= this.hi);
+          } else if (this.foldSide == 0) {
+            // flap [lo, crease] folds rightward over the crease
+            final double flapEdge = this.crease - (this.crease - this.lo) * cosF;
+            if (cosF > 0.02 && a >= flapEdge && a < this.crease) {
+              showOld = true; // foreshortened flap still lifting
+              sampleA = this.crease - (this.crease - a) / cosF;
+              glint = flapGlint;
+            } else if (cosF < -0.02 && a >= this.crease && a <= this.crease - (this.crease - this.lo) * cosF) {
+              showOld = true; // mirrored flap landing on the far side
+              sampleA = this.crease - (a - this.crease) / (-cosF);
+              glint = flapGlint;
+            } else {
+              showOld = !this.finalFold && (a >= this.crease && a <= this.hi);
+            }
+          } else {
+            // flap [crease, hi] folds leftward over the crease
+            final double flapEdge = this.crease + (this.hi - this.crease) * cosF;
+            if (cosF > 0.02 && a > this.crease && a <= flapEdge) {
+              showOld = true;
+              sampleA = this.crease + (a - this.crease) / cosF;
+              glint = flapGlint;
+            } else if (cosF < -0.02 && a <= this.crease && a >= this.crease + (this.hi - this.crease) * cosF) {
+              showOld = true;
+              sampleA = this.crease + (this.crease - a) / (-cosF);
+              glint = flapGlint;
+            } else {
+              showOld = (a >= this.lo && a <= this.crease);
+            }
+          }
+
+          // absorb the flap into the sheet at the very end of the fold
+          double flapAlpha = 1;
+          if (glint > 0 && ft > 0.78) {
+            flapAlpha = LXUtils.clamp((1 - ft) / 0.22, 0, 1);
+            if (flapAlpha <= 0) {
+              showOld = false;
+            }
+          }
+
+          // stripes: sample the appropriate layer's ruled sheet
+          final double sx = (horiz ? sampleA / diag : x);
+          final double sy = (horiz ? y : sampleA / diag);
+          if (showOld) {
+            b = sheet(sx, sy, angOld, period, duty, p, 1);
+            c = colOld;
+          } else {
+            b = sheet(x, y, angNew, period, duty, p, -1);
+            c = colNew;
+          }
+
+          if (glint > 0 && showOld) {
+            b = (b + glint) * flapAlpha + (1 - flapAlpha) * b;
+            c = LXColor.lerp(c, LXColor.WHITE, (float) LXUtils.clamp(glint * 0.6, 0, 1));
+          }
+          // white-hot crease line while folding
+          if (creaseGlow > 0) {
+            final double dc = Math.abs(a - this.crease);
+            if (dc < 0.035) {
+              final double g = creaseGlow * (1 - dc / 0.035);
+              b = Math.max(b, g);
+              c = LXColor.lerp(c, LXColor.WHITE, (float) LXUtils.clamp(g, 0, 1));
+            }
+          }
+
+          if (b <= 0.004) continue;
+          final int idx = p.idx[x][y];
+          this.colors[idx] = LXColor.lightest(this.colors[idx],
+            LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+        }
+      }
+    }
+
+    copyExterior();
+  }
+
+  /** Ruled-paper brightness at (x,y): diagonal lines over a soft color-gradient fill. */
+  private double sheet(double x, double y, double angle, double period, double duty,
+      Panel p, int driftDir) {
+    final double s = (x * Math.cos(angle) + y * Math.sin(angle)) / period + this.drift * driftDir;
+    final double v = s - Math.floor(s);
+    // soft gradient fill so the layer reads as a colored sheet, lines on top
+    final double grad = 0.10 + 0.20 * (y / (double) Math.max(1, p.h - 1));
+    if (v < duty) {
+      // gamma-shaped line profile with a bright core
+      final double u = 1 - Math.abs(v / duty * 2 - 1);
+      return Math.max(grad, 0.35 + 0.65 * u * u);
+    }
+    return grad;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Overclock.java
+++ b/src/main/java/apotheneum/piemonte/Overclock.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Overclock — a dense fixed curtain of vertical strands shimmers with light
+ * streaming downward into a bright pool at the floor, while a circuit maze of
+ * horizontal traces and right-angle jogs glows near the hang line, slowly
+ * re-routing itself. The whole room breathes between emerald and azure in long
+ * sustained phases — each handover fading through near-black and blooming back
+ * in the new color, passing through cyan on the way. Modeled on the
+ * holotrigger Shimmer Hammer program.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Overclock extends StrandPattern {
+
+  private static final int MAX_PACKETS = 12;
+  private static final double HUE_A = 125; // emerald
+  private static final double HUE_B = 210; // azure
+  private static final double CYCLE_MS = 8000; // full green->blue->green breath
+  private static final double JOG_INTERVAL_MS = 1500;
+  private static final int STRAND_SPACING = 5; // fixed curtain pitch
+
+  public final DiscreteParameter traces =
+    new DiscreteParameter("Traces", 6, 2, MAX_PACKETS)
+    .setDescription("Circuit traces re-routing in the top maze");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of the swell");
+
+  private final class Surface {
+    boolean inited;
+    // maze traces confined to the hang line
+    final double[] px = new double[MAX_PACKETS];
+    final double[] py = new double[MAX_PACKETS];
+    final double[] pv = new double[MAX_PACKETS];
+    final double[] jogT = new double[MAX_PACKETS];
+    final int[] jx0 = new int[MAX_PACKETS];
+    final int[] jx1 = new int[MAX_PACKETS];
+    final int[] jy = new int[MAX_PACKETS];
+    final double[] jenv = new double[MAX_PACKETS];
+    void reset(int w, int h) {
+      for (int i = 0; i < MAX_PACKETS; ++i) {
+        this.px[i] = Math.random() * w;
+        this.py[i] = Math.random() * h * 0.28;
+        this.pv[i] = (0.002 + Math.random() * 0.0025) * (Math.random() < 0.5 ? 1 : -1);
+        this.jogT[i] = Math.random() * JOG_INTERVAL_MS;
+        this.jenv[i] = 0;
+      }
+      this.inited = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double pulse = 0;
+
+  public Overclock(LX lx) {
+    // Base registers color (hue shift), speed (breath pace), size (shimmer depth).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("traces", this.traces);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (this.beat) {
+      this.pulse = 1;
+    }
+    this.pulse *= Math.exp(-deltaMs / 190.0);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    final int w = o.width();
+    final int h = o.height();
+    if (!s.inited) s.reset(w, h);
+
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+
+    // sustained green<->blue breath with plateaus at each pole; handovers pass
+    // through cyan AND through a near-black trough
+    final double cyc = (this.timeMs * speed * 2) % CYCLE_MS / CYCLE_MS;
+    double c = 0.5 - 0.5 * Math.cos(2 * Math.PI * cyc);
+    final double mix = c * c * (3 - 2 * c);
+    final double crossover = 1 - Math.abs(mix - 0.5) * 2;
+    final double breath = LXUtils.lerp(1.0, 0.15, crossover * crossover);
+    final double hue = LXUtils.lerp(HUE_A, HUE_B, mix) + hueShift;
+    final int col = LXColor.hsb((float) (((hue % 360) + 360) % 360), 92, 100);
+    final double gain = breath * (1.0 + this.pulse * 0.15) * (0.6 + 0.4 * this.levelEnv + wow * 0.3);
+    final int tq = (int) (this.timeMs / 70);
+
+    // fixed dense strand curtain: shimmer scrolls downward, draining into the pool
+    final double shimDepth = 0.35 + getSize() * 0.30;
+    for (int bx = STRAND_SPACING / 2; bx < w; bx += STRAND_SPACING) {
+      final int jitter = (int) ((hashd(bx * 31 + 7) - 0.5) * 2);
+      final int x = bx + jitter;
+      for (int y = 0; y < h; ++y) {
+        // downward-scrolling seed: light streams toward the floor
+        final double sh = (1 - shimDepth) + shimDepth * hashd(x * 131 + (y - tq) * 7);
+        double b = 0.30 * gain * sh * drip(y, h);
+        // the base pool drains last: bottom rows lean on pool() with less breath-gating
+        b += (0.5 * pool(y, h)) * sh * (0.4 + 0.6 * breath) * (1.0 + this.pulse * 0.2);
+        addPix(o, x, y, col, b);
+      }
+    }
+
+    // circuit maze near the hang line: slow traces with right-angle re-routes
+    final int count = Math.min(MAX_PACKETS, this.traces.getValuei() + (int) Math.round(wow * 3));
+    final int mazeH = (int) (h * 0.30);
+    for (int i = 0; i < count; ++i) {
+      s.py[i] += s.pv[i] * speed * deltaMs;
+      if (s.py[i] < 0) { s.py[i] = 0; s.pv[i] = -s.pv[i]; }
+      else if (s.py[i] > mazeH) { s.py[i] = mazeH; s.pv[i] = -s.pv[i]; }
+
+      s.jogT[i] -= deltaMs;
+      if (s.jogT[i] <= 0) {
+        s.jogT[i] = JOG_INTERVAL_MS * (0.6 + Math.random()) / (1 + wow);
+        if (Math.random() < 0.6) {
+          final int dx = (3 + (int) (Math.random() * 6)) * (Math.random() < 0.5 ? 1 : -1);
+          s.jx0[i] = (int) s.px[i];
+          s.jx1[i] = (int) s.px[i] + dx;
+          s.jy[i] = (int) s.py[i];
+          s.jenv[i] = 1;
+          s.px[i] = ((s.px[i] + dx) % w + w) % w;
+        }
+      }
+
+      // short vertical trace segment
+      for (int k = 0; k <= 4; ++k) {
+        final double b = gain * 0.9 * Math.exp(-0.5 * k);
+        addPix(o, (int) s.px[i], (int) s.py[i] - k, col, b);
+        addPix(o, (int) s.px[i] + 1, (int) s.py[i] - k, col, b * 0.5);
+      }
+      // glowing right-angle bridge from the last re-route
+      if (s.jenv[i] > 0.02) {
+        final int lo = Math.min(s.jx0[i], s.jx1[i]);
+        final int hi2 = Math.max(s.jx0[i], s.jx1[i]);
+        for (int x = lo; x <= hi2; ++x) {
+          addPix(o, x, s.jy[i], col, s.jenv[i] * gain * 0.85);
+          addPix(o, x, s.jy[i] + 1, col, s.jenv[i] * gain * 0.35);
+        }
+        s.jenv[i] *= Math.exp(-deltaMs / 600.0); // traces linger
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Overflow.java
+++ b/src/main/java/apotheneum/piemonte/Overflow.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Overflow — a top-lit strand screen: a segmented band of equalizer blocks
+ * hangs in the upper-middle of the curtains, each block its own bar of red or
+ * green, reconfiguring like letterforms every few hundred milliseconds. The
+ * field swings between green-dominant and red-dominant, pulses with the beat,
+ * floods the whole room green on drops, and occasionally sends a full-height
+ * red strand running down into the glowing floor pools coiled at the base.
+ * Modeled on the holotrigger green/red cascade program.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Overflow extends StrandPattern {
+
+  private static final int MAX_RUNS = 10;
+  private static final double GREEN_HUE = 130;
+  private static final double RED_HUE = 12;
+
+  public final DiscreteParameter drips =
+    new DiscreteParameter("Drips", 4, 0, MAX_RUNS)
+    .setDescription("Full-height red strand runs at once");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of the pulse and flood");
+
+  private final class Surface {
+    boolean inited;
+    // full-height red runs feeding floor pools
+    final int[] rx = new int[MAX_RUNS];
+    final double[] rlife = new double[MAX_RUNS];
+    final boolean[] alive = new boolean[MAX_RUNS];
+    void reset() {
+      for (int i = 0; i < MAX_RUNS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double flashEnv = 0;
+  private double beatPulse = 0;
+  private double lfo = 0;
+
+  public Overflow(LX lx) {
+    // Base registers color (hue shift), speed (block reconfigure tempo), size (band height).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("drips", this.drips);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    this.lfo += deltaMs * 0.0004 * speed; // red/green dominance swing ~1-2s
+    if (this.beat) {
+      this.beatPulse = 1;
+      if (this.beatLevel > 0.5 || this.levelEnv > 0.55) {
+        this.flashEnv = 1; // the drop: whole room floods green
+      }
+    }
+    this.beatPulse *= Math.exp(-deltaMs / 150.0);
+    this.flashEnv *= Math.exp(-deltaMs / 700.0); // sustained, ambient
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((GREEN_HUE + hueShift) % 360)), 95, 100);
+    final int red = LXColor.hsb((float) (((RED_HUE + hueShift) % 360)), 98, 100);
+    final int tq = (int) (this.timeMs / 90);
+
+    // audio-grown band anchored in the upper-middle; the floor stays dark
+    final double env = LXUtils.clamp(
+      Math.max(this.levelEnv * (1.2 + wow * 0.5), 0.35) + this.beatLevel * 0.15, 0, 1);
+    final double bandCenter = h * 0.30;
+    final double bandH = h * (0.10 + (0.14 + getSize() * 0.24) * env);
+    final double pulse = 0.55 + 0.45 * this.beatPulse;
+    // whole-field red<->green dominance swing; mid-swing = checkerboard
+    final double redBias = 0.5 + 0.45 * Math.sin(2 * Math.PI * this.lfo * 0.5);
+
+    final int blockW = Math.max(3, w / 25);
+    final int blockQ = (int) (this.timeMs * speed / 420); // blocks reconfigure ~2.4/s
+    for (int x = 0; x < w; ++x) {
+      final int bx = x / blockW;
+      final boolean isRed = hashd(bx * 131 + blockQ * 977) < redBias;
+      // per-block equalizer heights, top and bottom independently jittered
+      final double hUp = bandH * (0.35 + 0.65 * hashd(bx * 7 + blockQ * 53));
+      final double hDn = bandH * (0.35 + 0.65 * hashd(bx * 11 + blockQ * 29));
+      final int c = isRed ? red : green;
+      final double shim = 0.88 + 0.12 * hashd(x * 131 + tq * 7);
+      final int y0 = Math.max(0, (int) (bandCenter - hUp));
+      final int y1 = Math.min(h - 1, (int) (bandCenter + hDn));
+      for (int y = y0; y <= y1; ++y) {
+        final double dy = (y < bandCenter)
+          ? 1.0 - (bandCenter - y) / Math.max(1.0, hUp)
+          : 1.0 - (y - bandCenter) / Math.max(1.0, hDn);
+        final double b = (0.30 + 0.70 * dy * dy) * shim * pulse;
+        addPix(o, x, y, c, b);
+      }
+    }
+
+    // full-height red strand runs feeding floor pools
+    final int maxRuns = this.drips.getValuei();
+    int alive = 0;
+    for (int i = 0; i < MAX_RUNS; ++i) if (s.alive[i]) ++alive;
+    if (alive < maxRuns && Math.random() < deltaMs * (0.0008 + this.beatLevel * 0.004)) {
+      for (int i = 0; i < MAX_RUNS; ++i) {
+        if (!s.alive[i]) {
+          s.rx[i] = (int) (Math.random() * w);
+          s.rlife[i] = 900 + Math.random() * 1200;
+          s.alive[i] = true;
+          break;
+        }
+      }
+    }
+    for (int i = 0; i < MAX_RUNS; ++i) {
+      if (!s.alive[i]) continue;
+      s.rlife[i] -= deltaMs;
+      if (s.rlife[i] <= 0) { s.alive[i] = false; continue; }
+      final double rb = Math.min(1, s.rlife[i] / 300.0); // fade out at the end
+      for (int y = (int) bandCenter; y < h; ++y) {
+        final double tw2 = 0.7 + 0.3 * hashd(s.rx[i] * 31 + y * 7 + tq);
+        addPix(o, s.rx[i], y, red, rb * tw2 * 0.85);
+      }
+      // bright pool where the run meets the floor
+      for (int dx = -2; dx <= 2; ++dx) {
+        addPix(o, s.rx[i] + dx, h - 1, red, rb * (0.8 - 0.2 * Math.abs(dx)));
+        addPix(o, s.rx[i] + dx, h - 2, red, rb * (0.5 - 0.12 * Math.abs(dx)));
+      }
+    }
+
+    // big coiled floor pools, colored by the block above them
+    for (int p = 0; p < 6; ++p) {
+      final double dir = (p % 2 == 0) ? 1 : -1;
+      final double px = (hashd(p * 97 + 5) * w + dir * this.timeMs * 0.002) % w;
+      final int bx = (((int) px % w) + w) % w / blockW;
+      final int pc = (hashd(bx * 131 + blockQ * 977) < redBias) ? red : green;
+      for (int dx = -8; dx <= 8; ++dx) {
+        final double g = Math.exp(-dx * dx / 18.0);
+        addPix(o, (int) px + dx, h - 1, pc, g * 0.65);
+        addPix(o, (int) px + dx, h - 2, pc, g * 0.40);
+        addPix(o, (int) px + dx, h - 3, pc, g * 0.18);
+      }
+    }
+
+    // the drop: sustained ambient green flood filling even the dark rows
+    if (this.flashEnv > 0.01) {
+      final int fc = LXColor.scaleBrightness(green,
+        (float) (this.flashEnv * (0.55 + wow * 0.35)));
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          final int idx = o.point(x, y).index;
+          this.colors[idx] = LXColor.lightest(this.colors[idx], fc);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -33,9 +33,22 @@ package apotheneum.piemonte;
 import apotheneum.ApotheneumPattern;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
 
 public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Shared render-target selector: both structures, cube only, or cylinder only. */
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  /** Created by addTargetParameter(); null when a pattern doesn't opt in. */
+  public EnumParameter<Target> target;
 
   /** Primary hue (degrees) — the single dial that steers pattern color. */
   public final CompoundParameter hue =
@@ -53,6 +66,36 @@ public abstract class ParameterPattern extends ApotheneumPattern {
   public final CompoundParameter wow =
     new CompoundParameter("Wow", 0, 0, 1)
     .setDescription("Extra flourish / special-effect intensity");
+
+  /**
+   * External audio inputs. Nothing in these patterns samples the LX audio
+   * meter — installation volume is expected to change, which would rescale
+   * every internally-analyzed level. Instead the envelope-follower step runs
+   * in the audio program (e.g. Ableton feeding the show-control M4L device),
+   * which sends a volume-stable signal here over OSC/MIDI modulation.
+   */
+  public final CompoundParameter level =
+    new CompoundParameter("Level", 0, 0, 1)
+    .setDescription("Audio level input — map an external envelope follower (OSC/MIDI)");
+
+  public final BooleanParameter pulse =
+    new BooleanParameter("Pulse", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Beat trigger input — map an external beat source (OSC/MIDI)");
+
+  // --- audio state derived from the external inputs, once per frame ---
+  private boolean prevPulse;
+  private double prevLevel, sinceBeatMs = 1e9;
+  /** Slow-average of the level input; useful for contrast ratios. */
+  protected double levelAvg;
+  /** True on the frame a beat fires (Pulse edge, or a Level onset). */
+  protected boolean beat;
+  /** Normalized beat strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Level input shaped by a 25ms attack / 220ms release envelope. */
+  protected double levelEnv;
+  /** Accumulated pattern time in ms. */
+  protected double timeMs = 0;
 
   /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
   protected ParameterPattern(LX lx) {
@@ -82,6 +125,94 @@ public abstract class ParameterPattern extends ApotheneumPattern {
     addParameter("speed", this.speed);
     addParameter("size", this.size);
     addParameter("wow", this.wow);
+    addParameter("level", this.level);
+    addParameter("pulse", this.pulse);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addTargetParameter(Target.BOTH);
+  }
+
+  /** Target with a pattern-specific default. */
+  protected void addTargetParameter(Target def) {
+    this.target = new EnumParameter<Target>("Target", def)
+      .setDescription("Which structures to render to");
+    addParameter("target", this.target);
+  }
+
+  /** Current target; BOTH when the pattern doesn't expose the selector. */
+  protected Target getTarget() {
+    return (this.target != null) ? this.target.getEnum() : Target.BOTH;
+  }
+
+  /** Beat threshold multiplier for Level onsets; override to wire a Sens param. */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  /**
+   * Advance the derived audio state from the external Level/Pulse inputs.
+   * StrandPattern calls this automatically each frame; patterns that extend
+   * ParameterPattern directly call it at the top of render().
+   */
+  protected void stepAudio(double deltaMs) {
+    this.timeMs += deltaMs;
+    final double lvl = this.level.getValue();
+
+    // attack/release envelope + slow average for contrast ratios
+    final double alpha = (lvl > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (lvl - this.levelEnv) * alpha;
+    this.levelAvg += (lvl - this.levelAvg) * (1 - Math.exp(-deltaMs / 2000.0));
+
+    // beats: a Pulse edge always fires; Level onsets fire when it climbs
+    // clear of its own slow average (volume-stable, since the follower is
+    // upstream of any installation volume changes)
+    this.sinceBeatMs += deltaMs;
+    final boolean p = this.pulse.isOn();
+    final boolean pulseEdge = p && !this.prevPulse;
+    this.prevPulse = p;
+    final boolean onset = (lvl > this.levelAvg * beatThreshold())
+      && (lvl > this.prevLevel)
+      && (this.sinceBeatMs >= 130)
+      && (lvl > 0.01);
+    this.prevLevel = lvl;
+    this.beat = pulseEdge || onset;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = pulseEdge ? 1.0
+      : LXUtils.clamp((lvl / Math.max(1e-4, this.levelAvg) - 1.0) / 1.5, 0, 1);
+  }
+
+  /**
+   * Pseudo-spectrum: the level envelope spread across n bands with slow
+   * per-band drift, so band-indexed visuals keep independent motion without
+   * sampling the internal meter.
+   */
+  protected double band(int i, int n) {
+    final double drift = 0.5 + 0.5 * Math.sin(
+      this.timeMs * (0.0009 + 0.0008 * phash(i * 31 + n * 7)) + i * 2.1);
+    return this.levelEnv * (0.45 + 0.55 * drift);
+  }
+
+  private boolean prevPulseLocal;
+
+  /** True exactly once per Pulse press; for patterns running bespoke detectors. */
+  protected boolean pulseHit() {
+    final boolean p = this.pulse.isOn();
+    final boolean edge = p && !this.prevPulseLocal;
+    this.prevPulseLocal = p;
+    return edge;
+  }
+
+  private static double phash(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
   }
 
   // Convenience getters. Subclasses can also tweak the

--- a/src/main/java/apotheneum/piemonte/ParameterPattern.java
+++ b/src/main/java/apotheneum/piemonte/ParameterPattern.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2026- Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * Created by patrick piemonte
+ *
+ * ParameterPattern — an intermediate base (ApotheneumPattern → ParameterPattern
+ * → your pattern) that fixes a consistent leading parameter order: hue,
+ * speed, size, wow. Every pattern that extends it gets those four controls in
+ * the same place. Subclasses extend this, then add their own parameters (and
+ * any extra colors) after super(...). Kept self-contained so
+ * last-minute changes don't ripple across other authors' content.
+ *
+ * "Wow" is a shared performance macro in the spirit of LXStudio-TE's WOW knobs:
+ * a 0..1 "extra flourish" each pattern interprets in its own way. It defaults to
+ * 0 (inert), so a pattern that ignores it is unaffected and its resting look is
+ * unchanged; patterns that read getWow() add a special-effect layer as it rises.
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.ApotheneumPattern;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+
+public abstract class ParameterPattern extends ApotheneumPattern {
+
+  /** Primary hue (degrees) — the single dial that steers pattern color. */
+  public final CompoundParameter hue =
+    new CompoundParameter("Hue", 0, 0, 360)
+    .setDescription("Primary hue")
+    .setWrappable(true);
+
+  /** Animation speed. Range/polarity set per-subclass via the constructor. */
+  public final CompoundParameter speed;
+
+  /** Element size. Range set per-subclass via the constructor. */
+  public final CompoundParameter size;
+
+  /** Shared "wow" performance macro (0..1). Defaults to 0 (inert). */
+  public final CompoundParameter wow =
+    new CompoundParameter("Wow", 0, 0, 1)
+    .setDescription("Extra flourish / special-effect intensity");
+
+  /** Defaults: bipolar speed -1..1 (0.4), size 0..1 (0.5). */
+  protected ParameterPattern(LX lx) {
+    this(lx, 0.4, -1, 1, 0.5, 0, 1);
+  }
+
+  /**
+   * CompoundParameter ranges are immutable after construction, so subclasses
+   * pass their desired speed/size ranges here. Speed becomes bipolar when its
+   * minimum is negative.
+   */
+  protected ParameterPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx);
+
+    this.speed = new CompoundParameter("Speed", speedDef, speedMin, speedMax)
+      .setDescription("Animation speed");
+    if (speedMin < 0) {
+      this.speed.setPolarity(CompoundParameter.Polarity.BIPOLAR);
+    }
+    this.size = new CompoundParameter("Size", sizeDef, sizeMin, sizeMax)
+      .setDescription("Element size");
+
+    // Canonical leading order: hue, speed, size, wow. Subclasses add the rest.
+    addParameter("hue", this.hue);
+    addParameter("speed", this.speed);
+    addParameter("size", this.size);
+    addParameter("wow", this.wow);
+  }
+
+  // Convenience getters. Subclasses can also tweak the
+  // inherited params directly, e.g. this.speed.setExponent(2) or
+  // this.size.setUnits(LXParameter.Units.INTEGER), in their constructor.
+
+  /** Resolved primary color for this frame — the Hue knob at full strength. */
+  protected int getColor() {
+    return LXColor.hsb(this.hue.getValuef() % 360, 100, 100);
+  }
+
+  /** Current speed value (bipolar when the configured minimum is negative). */
+  protected double getSpeed() {
+    return this.speed.getValue();
+  }
+
+  /** Current size value. */
+  protected double getSize() {
+    return this.size.getValue();
+  }
+
+  /** Current "wow" macro value (0..1); 0 means the flourish is off. */
+  protected double getWow() {
+    return this.wow.getValue();
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ParticleWave.java
+++ b/src/main/java/apotheneum/piemonte/ParticleWave.java
@@ -21,17 +21,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class ParticleWave extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int STAR_COLOR = LXColor.hsb(225, 35, 100);
   private static final int CLUSTER_COLOR = LXColor.lerp(STAR_COLOR, LXColor.WHITE, 0.45f);
@@ -48,10 +41,6 @@ public class ParticleWave extends ParameterPattern {
     new BooleanParameter("Strobe", false)
     .setMode(BooleanParameter.Mode.MOMENTARY)
     .setDescription("Light tiny dark-purple particles in the negative space while held");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private final class Surface {
     // sparkle-cluster pool (storm surge bursts in the void)
@@ -92,7 +81,7 @@ public class ParticleWave extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("density", this.density);
     addParameter("strobe", this.strobe);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private static double hash(int x, int y, int t) {
@@ -113,9 +102,7 @@ public class ParticleWave extends ParameterPattern {
     this.phase += deltaMs * 0.00035 * speed * (1.0 + wow * 0.9);
 
     // audio envelopes for the dynamically scaling grains
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    final int nb = Math.max(1, m.numBands);
-    final double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    final double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     if (bass > this.bassAvg * 1.35 && bass > this.prevBass
@@ -125,7 +112,7 @@ public class ParticleWave extends ParameterPattern {
     }
     this.prevBass = bass;
     this.beatPulse *= Math.exp(-deltaMs / 220.0);
-    final double level = m.getAveragef(0, nb);
+    final double level = this.level.getValue();
     final double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0) : 1 - Math.exp(-deltaMs / 220.0);
     this.levelEnv += (level - this.levelEnv) * alpha;
@@ -137,7 +124,7 @@ public class ParticleWave extends ParameterPattern {
       this.strobeEnv = Math.max(0, this.strobeEnv - deltaMs / 400.0);
     }
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, deltaMs, speed, wow);
     }

--- a/src/main/java/apotheneum/piemonte/ParticleWave.java
+++ b/src/main/java/apotheneum/piemonte/ParticleWave.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * ParticleWave — a vast rolling swell of shimmering grains sweeps around the
+ * structure as a thick undulating band: a sea of glitter surging through a dark
+ * starfield. The band's edges dissolve into loose grains, a foamy white crest
+ * sparkles along the boundary, and sparse cool stars twinkle in the void.
+ * Turning up Wow whips the sea into a storm: taller swells, faster roll, hotter
+ * foam, and bursts of blue sparkle clusters in the dark.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class ParticleWave extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int STAR_COLOR = LXColor.hsb(225, 35, 100);
+  private static final int CLUSTER_COLOR = LXColor.lerp(STAR_COLOR, LXColor.WHITE, 0.45f);
+  private static final double STAR_DENSITY = 0.016;
+  private static final int MAX_CLUSTERS = 16;
+  private static final int CLUSTER_GLINTS = 16;
+  private static final double TAU = Math.PI * 2;
+
+  public final CompoundParameter density =
+    new CompoundParameter("Density", 0.65, 0.2, 1)
+    .setDescription("Grain density of the particle sea");
+
+  public final BooleanParameter strobe =
+    new BooleanParameter("Strobe", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Light tiny dark-purple particles in the negative space while held");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private final class Surface {
+    // sparkle-cluster pool (storm surge bursts in the void)
+    final double[] cx = new double[MAX_CLUSTERS];
+    final double[] cy = new double[MAX_CLUSTERS];
+    final double[] clife = new double[MAX_CLUSTERS];
+    final double[] cmax = new double[MAX_CLUSTERS];
+    final int[] cseed = new int[MAX_CLUSTERS];
+    final boolean[] calive = new boolean[MAX_CLUSTERS];
+
+    void spawnCluster(int w, int h) {
+      for (int i = 0; i < MAX_CLUSTERS; ++i) {
+        if (!this.calive[i]) {
+          this.cx[i] = Math.random() * w;
+          this.cy[i] = Math.random() * h;
+          this.cmax[i] = 700 + Math.random() * 700;
+          this.clife[i] = this.cmax[i];
+          this.cseed[i] = (int) (Math.random() * 100000);
+          this.calive[i] = true;
+          return;
+        }
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double timeMs = 0;
+  private double phase = 0;
+  // audio: dynamic grain scaling rides the level and the beat
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+  private double beatPulse = 0;
+  private double strobeEnv = 0;
+
+  public ParticleWave(LX lx) {
+    // Base registers color (grain tint), speed (roll rate), size (band thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("strobe", this.strobe);
+    addParameter("target", this.target);
+  }
+
+  private static double hash(int x, int y, int t) {
+    int h = x * 374761393 + y * 668265263 + t * 1274126177;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    // the swell rolls around the structure; storms roll faster
+    this.phase += deltaMs * 0.00035 * speed * (1.0 + wow * 0.9);
+
+    // audio envelopes for the dynamically scaling grains
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    final int nb = Math.max(1, m.numBands);
+    final double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    if (bass > this.bassAvg * 1.35 && bass > this.prevBass
+        && this.sinceBeatMs >= 140 && bass > 0.01) {
+      this.sinceBeatMs = 0;
+      this.beatPulse = 1;
+    }
+    this.prevBass = bass;
+    this.beatPulse *= Math.exp(-deltaMs / 220.0);
+    final double level = m.getAveragef(0, nb);
+    final double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0) : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+
+    // strobe: full while held, quick decay after release
+    if (this.strobe.isOn()) {
+      this.strobeEnv = 1;
+    } else if (this.strobeEnv > 0) {
+      this.strobeEnv = Math.max(0, this.strobeEnv - deltaMs / 400.0);
+    }
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, deltaMs, speed, wow);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, deltaMs, speed, wow);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double deltaMs, double speed, double wow) {
+    final int w = o.width();
+    final int h = o.height();
+
+    final int base = getColor();
+    final int glint = LXColor.lerp(base, LXColor.WHITE, 0.65f);
+    final int foam = LXColor.lerp(base, LXColor.WHITE, 0.85f);
+    final double dens = this.density.getValue();
+
+    // storm surge: taller swell, thicker foam
+    final double amp = h * 0.18 * (1.0 + wow * 1.2);
+    final double thick = h * (0.12 + getSize() * 0.28);
+    final double foamW = 1.6 + wow * 1.8;
+    final double drift = 0.16 * Math.sin(this.timeMs * 8.0e-5 * (0.5 + speed));
+    final double ph = this.phase;
+
+    // shimmer quanta: grains flicker fast, stars twinkle slow
+    final int tq = (int) (this.timeMs / 50);
+    final int tqs = (int) (this.timeMs / 400);
+
+    // slow corner rocking: the wave's ends at each face corner drift up and
+    // down at their own gentle pace, tilting the band across every face
+    final double segW = w / 4.0;
+    final double rockAmp = h * 0.12;
+    final double rt = this.timeMs * 2.2e-4 * (0.5 + speed);
+
+    for (int x = 0; x < w; ++x) {
+      final double u = (double) x / w;
+      final int seg = Math.min(3, (int) (x / segW));
+      final double su = x / segW - seg;
+      final double se = su * su * (3 - 2 * su); // ease between the two corners
+      final double c0 = Math.sin(rt + seg * 1.9);
+      final double c1 = Math.sin(rt + ((seg + 1) % 4) * 1.9);
+      final double rock = rockAmp * LXUtils.lerp(c0, c1, se);
+      // three traveling sine octaves shape the swell
+      final double yc = h * (0.5 + drift) + rock + amp * (
+          0.60 * Math.sin(TAU * (u * 2 - ph))
+        + 0.25 * Math.sin(TAU * (u * 5 + ph * 1.7))
+        + 0.15 * Math.sin(TAU * (u * 9 - ph * 2.3)));
+      final double th = thick * (0.75 + 0.25 * Math.sin(TAU * (u * 3 + ph * 0.8)));
+
+      for (int y = 0; y < h; ++y) {
+        final double dRaw = Math.abs(y - yc) - th; // signed distance outside the band
+        // granular dissolving edge: jitter the boundary per-pixel
+        final double d = dRaw + (hash(x, y, tq >> 2) - 0.5) * 3.0;
+
+        int c;
+        double b;
+        if (d < 0) {
+          // inside the sea: hashed glitter shimmer
+          final double g = hash(x, y, tq);
+          if (g > dens) continue; // unlit grain this instant
+          final double v = g / dens;
+          b = 0.22 + 0.78 * v * v * v;
+          c = (v > 0.965) ? LXColor.WHITE : ((v > 0.8) ? glint : base);
+          // feather deep pixels slightly less than the fringe
+          final double edge = LXUtils.clamp(-d / 3.0, 0, 1);
+          b *= 0.55 + 0.45 * edge;
+        } else {
+          // strobe: tiny dark-purple particles fill the negative space
+          if (this.strobeEnv > 0.02 && ((int) (this.timeMs / 90) & 1) == 0) {
+            final double sp = hash(x, y, tq + 7717);
+            if (sp < 0.14) {
+              final int purple = LXColor.hsb(275, 92, 48);
+              final int idx2 = o.point(x, y).index;
+              this.colors[idx2] = LXColor.lightest(this.colors[idx2],
+                LXColor.scaleBrightness(purple,
+                  (float) (this.strobeEnv * (0.5 + 0.5 * (sp / 0.14)))));
+            }
+          }
+          // the void: sparse, spatially-stable stars with a slow twinkle
+          final double rs = hash(x, y, 0);
+          if (rs >= STAR_DENSITY) continue;
+          final double tw = 0.35 + 0.65 * hash(x, y, tqs + 7919);
+          b = tw * (0.30 + 0.70 * (rs / STAR_DENSITY));
+          c = STAR_COLOR;
+        }
+
+        // foam crest: white-hot sparkle hugging the boundary
+        if (Math.abs(dRaw) < foamW) {
+          final double ff = 1.0 - Math.abs(dRaw) / foamW;
+          final double fg = hash(x, y, tq + 4241);
+          if (fg < 0.5 + wow * 0.3) {
+            b = Math.max(b, ff * (0.7 + wow * 0.8) * (0.5 + 0.5 * fg / 0.8));
+            c = foam;
+          }
+        }
+
+        if (b <= 0) continue;
+        final int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1));
+      }
+    }
+
+    // --- hero grains: discrete particles riding the swell, scaling with the music ---
+    final int nHero = 20;
+    for (int i = 0; i < nHero; ++i) {
+      final int gx = (int) (hash(i * 61 + 13, 5, 0) * w);
+      final double gu01 = (double) gx / w;
+      // sample the band center at this column (same math as the pixel loop)
+      final int gseg = Math.min(3, (int) (gx / segW));
+      final double gsu = gx / segW - gseg;
+      final double gse = gsu * gsu * (3 - 2 * gsu);
+      final double gc0 = Math.sin(rt + gseg * 1.9);
+      final double gc1 = Math.sin(rt + ((gseg + 1) % 4) * 1.9);
+      final double gRock = rockAmp * LXUtils.lerp(gc0, gc1, gse);
+      final double gyc = h * (0.5 + drift) + gRock + amp * (
+          0.60 * Math.sin(TAU * (gu01 * 2 - ph))
+        + 0.25 * Math.sin(TAU * (gu01 * 5 + ph * 1.7))
+        + 0.15 * Math.sin(TAU * (gu01 * 9 - ph * 2.3)));
+      final double gth = thick * (0.75 + 0.25 * Math.sin(TAU * (gu01 * 3 + ph * 0.8)));
+      final double gy = gyc + (hash(i * 89 + 7, 9, 0) * 2 - 1) * gth * 0.7;
+      // the music scales them: level swells all, beats pop a shifting subset
+      final double gr = (0.7 + hash(i * 37 + 3, 2, 0) * 0.9)
+        * (1.0 + this.levelEnv * 1.8 + this.beatPulse * 2.2 * hash(i * 53 + 1, (int) (this.timeMs / 500), 0));
+      final double gb = 0.45 + 0.55 * this.levelEnv + this.beatPulse * 0.3;
+      final int gcol = (hash(i * 71 + 9, 4, 0) > 0.7) ? LXColor.WHITE : glint;
+      final int y0g = (int) Math.max(0, Math.floor(gy - gr));
+      final int y1g = (int) Math.min(h - 1, Math.ceil(gy + gr));
+      for (int yy = y0g; yy <= y1g; ++yy) {
+        for (int xx = (int) Math.floor(gx - gr); xx <= (int) Math.ceil(gx + gr); ++xx) {
+          final double dd = Math.hypot(xx - gx, yy - gy);
+          if (dd > gr) continue;
+          final double uG = 1.0 - dd / (gr + 0.5);
+          final int xig = ((xx % w) + w) % w;
+          final int idx3 = o.point(xig, yy).index;
+          this.colors[idx3] = LXColor.lightest(this.colors[idx3],
+            LXColor.scaleBrightness(gcol, (float) LXUtils.clamp(uG * uG * gb, 0, 1)));
+        }
+      }
+    }
+
+    // --- storm sparkle clusters bursting in the void ---
+    if (Math.random() < deltaMs * (0.0002 + wow * 0.005)) {
+      s.spawnCluster(w, h);
+    }
+    for (int i = 0; i < MAX_CLUSTERS; ++i) {
+      if (!s.calive[i]) continue;
+      s.clife[i] -= deltaMs;
+      if (s.clife[i] <= 0) { s.calive[i] = false; continue; }
+      final double fade = s.clife[i] / s.cmax[i];
+      final double spread = 2.0 + (1.0 - fade) * 5.0; // glints scatter outward as it dies
+      for (int k = 0; k < CLUSTER_GLINTS; ++k) {
+        final double gx = s.cx[i] + (hash(s.cseed[i], k, 11) - 0.5) * 2 * spread;
+        final double gy = s.cy[i] + (hash(s.cseed[i], k, 37) - 0.5) * 2 * spread;
+        final int yy = (int) Math.round(gy);
+        if (yy < 0 || yy >= h) continue;
+        final int xi = (((int) Math.round(gx)) % w + w) % w;
+        final double twk = 0.4 + 0.6 * hash(s.cseed[i] + k, tq, 53);
+        final double gb = fade * fade * twk;
+        if (gb <= 0.02) continue;
+        final int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(CLUSTER_COLOR, (float) LXUtils.clamp(gb, 0, 1)));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/PlayaStrobe.java
+++ b/src/main/java/apotheneum/piemonte/PlayaStrobe.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * PlayaStrobe — UFOAbduction stripped to pure white. Blocks of white light
+ * beam up the lanes with the measured velocity signature — fast entry, a
+ * slow-motion crawl through the center, a burst out the top — and as each
+ * block enters the center of its border it strobes briefly, a hard little
+ * flutter before it glides on. Around them, thin white lines spin
+ * horizontally like a cyclone, shearing faster near the top rim as the vortex
+ * slowly climbs. The operator's Strobe button still fires the full-structure
+ * pulsating white burst that decays away after release. Wow feeds the cyclone
+ * and hardens every strobe.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class PlayaStrobe extends StrandPattern {
+
+  private static final int MAX_HEADS = 64;
+  private static final int MAX_LINES = 16;
+  private static final int WHITE_SOFT = LXColor.hsb(210, 6, 100); // barely-cool white
+  // UFOAbduction's measured rise profile
+  private static final double V_ENTRY = 0.00135;
+  private static final double V_STALL = 0.00024;
+  private static final double V_EXIT = 0.0075;
+  private static final double STALL_LO = 0.60;
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;
+  private static final double IDLE_WAVE_MS = 900;
+  private static final double STALL_STROBE_MS = 320; // brief flutter entering the stall
+  private static final double DECAY_MS = 1500;       // button strobe fade-out
+  private static final double STROBE_DUTY = 0.45;
+  private static final double CYCLONE_REV_S = 0.30;
+
+  public final DiscreteParameter lanes =
+    new DiscreteParameter("Lanes", 12, 6, 24)
+    .setDescription("Lanes the white blocks beam up");
+
+  public final BooleanParameter strobe =
+    new BooleanParameter("Strobe", false)
+    .setMode(BooleanParameter.Mode.MOMENTARY)
+    .setDescription("Fire a pulsating white strobe burst; hold to sustain");
+
+  public final CompoundParameter rate =
+    new CompoundParameter("Rate", 9, 2, 16)
+    .setDescription("Strobe pulse rate in flashes per second");
+
+  private final class Surface {
+    boolean inited;
+    final int[] lane = new int[MAX_HEADS];
+    final double[] y = new double[MAX_HEADS];
+    final double[] vf = new double[MAX_HEADS];      // variance factor
+    final double[] stallMs = new double[MAX_HEADS]; // time spent in the stall band
+    final boolean[] alive = new boolean[MAX_HEADS];
+    void reset() {
+      for (int i = 0; i < MAX_HEADS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void spawn(int lane) {
+      for (int i = 0; i < MAX_HEADS; ++i) {
+        if (this.alive[i]) continue;
+        this.lane[i] = lane;
+        this.y[i] = 1.02 + Math.random() * 0.10;
+        this.vf[i] = 0.8 + Math.random() * 0.4;
+        this.stallMs[i] = 0;
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double waveTimer = 0;
+  private double strobeEnv = 0;
+  private double cyclone = 0; // shared spin phase
+
+  public PlayaStrobe(LX lx) {
+    // Base registers color (unused: pure white), speed (rise + spin), size (block thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("lanes", this.lanes);
+    addParameter("strobe", this.strobe);
+    addParameter("rate", this.rate);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** UFOAbduction's rise profile: fast entry, center stall, exit burst. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    this.cyclone += deltaMs * 0.001 * CYCLONE_REV_S * speed * 2 * (1 + wow * 0.5);
+    this.cyclone -= Math.floor(this.cyclone);
+
+    // beat-locked launch waves with an idle cadence fallback
+    this.waveTimer += deltaMs * speed * 2;
+    if ((this.beat && this.beatLevel > 0.15) || this.waveTimer >= IDLE_WAVE_MS) {
+      this.waveTimer = 0;
+      final double strength = LXUtils.clamp(
+        this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.2, 1);
+      launchWave(this.cube, strength);
+      launchWave(this.cylinder, strength);
+    }
+
+    // operator strobe: full while held, decaying burst after release
+    if (this.strobe.isOn()) {
+      this.strobeEnv = 1;
+    } else if (this.strobeEnv > 0) {
+      this.strobeEnv = Math.max(0, this.strobeEnv - deltaMs / DECAY_MS);
+    }
+  }
+
+  private void launchWave(Surface s, double strength) {
+    if (!s.inited) s.reset();
+    final int n = this.lanes.getValuei();
+    for (int l = 0; l < n; ++l) {
+      if (hashd(l * 641 + (int) (this.timeMs * 3)) > 0.35 + strength * 0.55) continue;
+      s.spawn(l);
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    final int nLanes = this.lanes.getValuei();
+    final double laneW = (double) w / nLanes;
+    final int tq = (int) (this.timeMs / 70);
+
+    // --- white blocks beaming up, fluttering as they enter the center stall ---
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!s.alive[i]) continue;
+      final double yp = s.y[i];
+      final boolean inStall = (yp <= STALL_LO && yp >= STALL_HI);
+      // Wow = slow-motion: the drops decelerate and stretch into long streaks
+      s.y[i] -= s.vf[i] * riseProfile(yp) * speed * 2 * deltaMs * (1.0 - wow * 0.65);
+      if (s.y[i] <= -0.08) { s.alive[i] = false; continue; }
+      if (inStall) {
+        s.stallMs[i] += deltaMs;
+      }
+
+      final double vNorm = LXUtils.clamp(riseProfile(yp) / V_ENTRY, 0, 1.2);
+      final double thickN = LXUtils.lerp(0.10 * (0.6 + getSize() * 0.9), 0.045, Math.min(1, vNorm))
+        * (1.0 + wow * 0.6); // stretched bodies in slow motion
+      final int thick = Math.max(2, (int) Math.round(thickN * h));
+      final double tailN = LXUtils.clamp(vNorm * 0.8 * (1.0 + wow * 2.0), 0.12, 1.6);
+      final int tail = (int) Math.round(tailN * h);
+
+      // the brief strobe as the block enters its center stall
+      double gate = 1.0;
+      if (inStall && s.stallMs[i] < STALL_STROBE_MS * (1 + wow * 0.8)) {
+        gate = (((int) (this.timeMs / 45)) & 1) == 0 ? 1.35 : 0.12; // ~11Hz flutter
+      }
+
+      final int x0 = (int) (s.lane[i] * laneW);
+      final int x1 = Math.min(w - 1, (int) ((s.lane[i] + 1) * laneW) - 2);
+      final double leadF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final double trailF = leadF + (thick - 1);
+      for (int x = x0; x <= x1; ++x) {
+        for (int yy = (int) Math.floor(leadF) - 1; yy <= (int) Math.ceil(trailF) + 1; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = (yy < leadF) ? (leadF - yy) : ((yy > trailF) ? (yy - trailF) : 0);
+          final double cov = LXUtils.clamp(1.0 - dOut, 0, 1);
+          if (cov <= 0.02) continue;
+          final double u = LXUtils.clamp(1.0 - (yy - leadF) / Math.max(1, thick), 0, 1);
+          addPix(o, x, yy, (u > 0.5) ? LXColor.WHITE : WHITE_SOFT,
+            gate * (0.55 + 0.45 * u) * cov);
+        }
+        // tail streams below the block
+        for (int k = 1; k <= tail; ++k) {
+          final int yy = (int) Math.round(trailF) + k;
+          if (yy >= h) break;
+          final double fFall = Math.exp(-2.0 * k / tail);
+          if (fFall < 0.02) break;
+          addPix(o, x, yy, WHITE_SOFT, gate * fFall * 0.7);
+        }
+      }
+    }
+
+    // --- the cyclone: thin white lines shearing around the canvas ---
+    final int nLines = 8 + (int) Math.round(wow * (MAX_LINES - 8));
+    final double rise = (this.timeMs * 0.00002 * speed) % 1.0;
+    for (int i = 0; i < nLines; ++i) {
+      final double band = hashd(i * 53 + 11); // 0 = top .. 1 = lower
+      final double segLen = 0.18 + 0.22 * hashd(i * 97 + 3);
+      // higher lines spin faster: cyclone shear
+      final double spin = this.cyclone * (1.0 + (1.0 - band) * 1.2) + hashd(i * 31 + 7);
+      final double xc = (spin - Math.floor(spin)) * w;
+      final int x0 = (int) Math.floor(xc);
+      final double xf = xc - x0;
+      final int yTop = (int) ((((band * 0.55 - rise * 0.3) % 1.0) + 1.0) % 1.0 * h);
+      final int yBot = Math.min(h - 1, yTop + (int) (segLen * h));
+      for (int yy = yTop; yy <= yBot; ++yy) {
+        final double tw = 0.55 + 0.45 * hashd(i * 977 + yy * 131 + tq * 3);
+        addPix(o, x0, yy, WHITE_SOFT, 0.8 * tw * (1 - xf));
+        addPix(o, x0 + 1, yy, WHITE_SOFT, 0.8 * tw * xf);
+      }
+    }
+
+    // --- operator strobe: full-structure pulsating burst (original behavior) ---
+    if (this.strobeEnv > 0) {
+      final double hz = this.rate.getValue() * (1.0 + wow * 0.7);
+      if ((this.timeMs * 0.001 * hz) % 1.0 < STROBE_DUTY) {
+        final int flash = LXColor.scaleBrightness(LXColor.WHITE,
+          (float) (this.strobeEnv * this.strobeEnv));
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            final int idx = o.point(x, y).index;
+            this.colors[idx] = LXColor.lightest(this.colors[idx], flash);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Pressure.java
+++ b/src/main/java/apotheneum/piemonte/Pressure.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Pressure — a two-channel color organ on the strand curtains: the columns
+ * gate hard between near-black and saturated washes, each column committed to
+ * either red or green, identities re-rolled with every major pulse. Fast
+ * attack, slow release — the whole rig breathes dark-bright-dark like a
+ * warehouse PA. Where red columns overdrive they bleed amber, and everything
+ * pools on the floor line. Modeled on the holotrigger red/green pulse program.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Pressure extends StrandPattern {
+
+  private static final int MAX_GROUPS = 32;
+
+  public final DiscreteParameter columns =
+    new DiscreteParameter("Columns", 7, 3, 16)
+    .setDescription("Curtain panels around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of the gate");
+
+  // per-group state, shared across surfaces so cube and cylinder pulse together
+  private final double[] energy = new double[MAX_GROUPS];
+  private final boolean[] isRed = new boolean[MAX_GROUPS];
+  private final boolean[] firing = new boolean[MAX_GROUPS];
+  private int beatCount = 0;
+  private int lastIdlePulse = -1;
+  private double rotPhase = 0; // slow orbit of the curtain wall around the gravity axis
+  private boolean inited = false;
+
+  public Pressure(LX lx) {
+    // Base registers color (hue shift), speed (idle breathe tempo), size (unused softness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("columns", this.columns);
+    addParameter("sensitivity", this.sensitivity);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    if (!this.inited) {
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(i * 17 + 3) < 0.4;
+        this.firing[i] = true;
+        this.energy[i] = 0.4;
+      }
+      this.inited = true;
+    }
+
+    final double wow = getWow();
+    // the whole curtain wall slowly orbits the vertical axis; Wow spins it up,
+    // and each hit gives the drum a small extra shove
+    final double speedR = Math.max(0.05, getSpeed());
+    this.rotPhase += deltaMs * speedR * 2 * 0.00003 * (1 + wow * 2);
+    if (this.beat) {
+      this.rotPhase += 0.004 * this.beatLevel;
+    }
+    this.rotPhase -= Math.floor(this.rotPhase);
+    if (this.beat) {
+      ++this.beatCount;
+      // green is home; a red minority coexists, re-rolled per pulse; rare all-red wall
+      double redFrac = 0.25 + this.beatLevel * 0.15 + wow * 0.1;
+      if (hashd(this.beatCount * 13 + 5) < 0.12) {
+        redFrac = 0.85;
+      }
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(this.beatCount * 977 + i * 31) < redFrac;
+        this.firing[i] = true; // the gate is temporal (whole field), not spatial
+      }
+    }
+
+    // idle gate in silence: hard on/off square at the reference's ~0.7s cadence
+    final double speed = Math.max(0.05, getSpeed());
+    final boolean quiet = this.levelEnv < 0.05;
+    final double idleCycle = this.timeMs * speed * 2 / 700.0;
+    final int idlePulse = (int) idleCycle;
+    if (quiet && idlePulse != this.lastIdlePulse) {
+      this.lastIdlePulse = idlePulse;
+      for (int i = 0; i < MAX_GROUPS; ++i) {
+        this.isRed[i] = hashd(idlePulse * 977 + i * 31) < 0.30;
+        this.firing[i] = true;
+      }
+    }
+    final double idleGate = ((idleCycle - idlePulse) < 0.55) ? 0.95 : 0.04;
+
+    // whole-field gate: fast attack, ~250ms release into a held near-black trough
+    final double aAtk = 1 - Math.exp(-deltaMs / 30.0);
+    final double target = quiet
+      ? idleGate
+      : LXUtils.clamp(0.20 + this.levelEnv * 1.0 + this.beatLevel * 0.5 + wow * 0.2, 0, 1.3);
+    for (int i = 0; i < MAX_GROUPS; ++i) {
+      // tiny per-curtain release offset so transitions show a lagging curtain or two
+      final double aRel = 1 - Math.exp(-deltaMs / ((270.0 - wow * 90) * (1.0 + 0.15 * hashd(i * 7))));
+      double a = (target > this.energy[i]) ? aAtk : aRel;
+      this.energy[i] += (target - this.energy[i]) * a;
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final int n = this.columns.getValuei();
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((112 + hueShift) % 360)), 98, 100);
+    final int yellow = LXColor.hsb((float) (((78 + hueShift) % 360)), 95, 100);
+    final int red = LXColor.hsb((float) (((2 + hueShift) % 360)), 100, 100);
+    final int amber = LXColor.hsb((float) (((30 + hueShift) % 360)), 92, 100);
+    final int ember = LXColor.hsb((float) (((24 + hueShift) % 360)), 90, 100);
+    final int tq = (int) (this.timeMs / 80);
+
+    for (int x = 0; x < w; ++x) {
+      // panel coordinates rotate around the gravity axis
+      final double xr = (((double) x / w + this.rotPhase) % 1.0) * n;
+      final int g = Math.min(n - 1, (int) xr);
+      final double e = this.energy[g];
+      // dark wall gap between discrete curtain panels
+      final double gpos = xr - g;
+      if (gpos < 0.10 || gpos > 0.90) continue;
+      if (e > 0.01) {
+        final double shim = 0.90 + 0.10 * hashd(x * 131 + tq * 7);
+        int c = this.isRed[g] ? red : green;
+        // overdrive bleeds: red toward amber, green toward yellow-green
+        if (e > 0.85) {
+          final float od = (float) LXUtils.clamp((e - 0.85) * 4, 0, 1);
+          c = this.isRed[g] ? LXColor.lerp(red, amber, od) : LXColor.lerp(green, yellow, od);
+        }
+        final int hot = LXColor.lerp(c, LXColor.WHITE, 0.35f);
+        for (int y = 0; y < h; ++y) {
+          double b = e * drip(y, h) * shim;
+          b += e * pool(y, h);
+          if (b <= 0.01) continue;
+          // the hottest point is the floor, not the truss
+          addPix(o, x, y, (e > 1.0 && y >= h - 3) ? hot : c, b);
+        }
+      }
+    }
+
+    // persistent warm floor ember: alive even in the blackest troughs
+    for (int x = 0; x < w; ++x) {
+      final double fb = 0.14 * (0.7 + 0.3 * hashd(x * 37 + tq));
+      addPix(o, x, h - 1, ember, fb);
+      addPix(o, x, h - 2, ember, fb * 0.45);
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Radiate.java
+++ b/src/main/java/apotheneum/piemonte/Radiate.java
@@ -26,17 +26,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Radiate extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_RAYS = 90;
   private static final double SCENE_MS = 6700;   // per palette scene (~40s arc / 6)
@@ -54,10 +47,6 @@ public class Radiate extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How easily the music blooms and fills the room");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.CYLINDER)
-    .setDescription("Which structures to render to");
 
   // per-ray state
   private final double[] rx = new double[MAX_RAYS];   // column position (fixed)
@@ -81,7 +70,7 @@ public class Radiate extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("rays", this.rays);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter(Target.CYLINDER);
   }
 
   private static double hashd(int n) {
@@ -99,23 +88,14 @@ public class Radiate extends ParameterPattern {
     this.inited = true;
   }
 
-  private double band(int i, int n) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    int lo = i * nb / n;
-    int hi = Math.max(lo + 1, (i + 1) * nb / n);
-    return m.getAveragef(lo, hi - lo);
-  }
 
   private boolean detect(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= 140)
       && (bass > 0.01);
@@ -123,7 +103,7 @@ public class Radiate extends ParameterPattern {
     if (beat) {
       this.sinceBeatMs = 0;
     }
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double aUp = 1 - Math.exp(-deltaMs / 25.0);
     double aDn = 1 - Math.exp(-deltaMs / 220.0);
     this.levelEnv += (level - this.levelEnv) * ((level > this.levelEnv) ? aUp : aDn);
@@ -170,7 +150,7 @@ public class Radiate extends ParameterPattern {
       : 1 - Math.exp(-deltaMs / 2000.0);
     this.floodEnv += (floodTarget - this.floodEnv) * fa;
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CUBE) {
       renderField(Apotheneum.cylinder.exterior, deltaMs);
       copyCylinderExterior();

--- a/src/main/java/apotheneum/piemonte/Radiate.java
+++ b/src/main/java/apotheneum/piemonte/Radiate.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Radiate — you stand where the performer sat, on a floor of
+ * LED dots: dotted rays fan outward all around you — up the walls, since out
+ * on the floor is up on the cylinder — their dot-chains crawling slowly
+ * outward, faster on the bass. Dotted rings hug the center below them, red
+ * against the cool rays. On every hit a wavefront of brightness blooms from
+ * the center to the rim in under half a second; energetic sections keep the
+ * whole room saturated in sustained color, and between sections everything
+ * collapses to a sparse starfield of twinkling white-blue dots. The palette
+ * steps through the reference's arc: red, emerald, teal, blue, a split
+ * red/blue ring, and a magenta haze. Modeled on the ksawerykomputery studio
+ * floor piece.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Radiate extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_RAYS = 90;
+  private static final double SCENE_MS = 6700;   // per palette scene (~40s arc / 6)
+  private static final double SCENE_XFADE = 1500;
+  private static final double DUO = -1000;       // red/blue split ring scene
+  private static final double DOT_SPACING = 2.6; // cells between ray dots
+  private static final double BLOOM_MS = 400;    // center->rim wavefront
+  // scene hues matching the reference arc: red, emerald, teal, blue, duo, magenta
+  private static final double[] SCENES = { 358, 124, 180, 228, DUO, 292 };
+
+  public final DiscreteParameter rays =
+    new DiscreteParameter("Rays", 56, 12, MAX_RAYS)
+    .setDescription("How many dotted rays fan around the cylinder");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How easily the music blooms and fills the room");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.CYLINDER)
+    .setDescription("Which structures to render to");
+
+  // per-ray state
+  private final double[] rx = new double[MAX_RAYS];   // column position (fixed)
+  private final double[] rlen = new double[MAX_RAYS]; // 0.85..1.0 coordinated length
+  private final double[] binMag = new double[MAX_RAYS];
+  private boolean inited = false;
+
+  // audio
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+  private double bassEnv = 0;
+  private double floodEnv = 0;   // sustained section fill (slow release)
+  private double bloomT = -1;    // center->rim wavefront progress, <0 idle
+  private double pulse = 0;
+  private double timeMs = 0;
+  private double dotFlow = 0;    // outward crawl of the dot chains
+  private double ringFlow = 0;
+
+  public Radiate(LX lx) {
+    // Base registers color (global hue shift), speed (crawl rate), size (dot size/spacing).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("rays", this.rays);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void initRays() {
+    for (int i = 0; i < MAX_RAYS; ++i) {
+      this.rx[i] = hashd(i * 7 + 1); // normalized 0..1 around any surface
+      this.rlen[i] = 0.85 + 0.15 * hashd(i * 31 + 11);
+    }
+    this.inited = true;
+  }
+
+  private double band(int i, int n) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    int lo = i * nb / n;
+    int hi = Math.max(lo + 1, (i + 1) * nb / n);
+    return m.getAveragef(lo, hi - lo);
+  }
+
+  private boolean detect(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 140)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    double level = m.getAveragef(0, nb);
+    double aUp = 1 - Math.exp(-deltaMs / 25.0);
+    double aDn = 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * ((level > this.levelEnv) ? aUp : aDn);
+    this.bassEnv += (bass - this.bassEnv) * ((bass > this.bassEnv) ? aUp : aDn);
+    return beat;
+  }
+
+  private double sceneHue(int which) {
+    return SCENES[((which % SCENES.length) + SCENES.length) % SCENES.length];
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    if (!this.inited) {
+      initRays();
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    final boolean beat = detect(deltaMs);
+
+    // outward crawl of dot chains: slow at rest, faster on bass
+    this.dotFlow += deltaMs * speed * (0.004 + this.bassEnv * 0.02) * DOT_SPACING;
+    this.ringFlow += deltaMs * speed * (0.002 + this.bassEnv * 0.012);
+
+    if (beat) {
+      this.pulse = 1;
+      if (this.bloomT < 0) {
+        this.bloomT = 0; // fire a center->rim brightness wavefront
+      }
+    }
+    this.pulse *= Math.exp(-deltaMs / 160.0);
+    if (this.bloomT >= 0) {
+      this.bloomT += deltaMs / BLOOM_MS;
+      if (this.bloomT >= 1.2) this.bloomT = -1;
+    }
+    // sustained section fill: fast attack, ~2s release into the breakdown
+    final double floodTarget = LXUtils.clamp(this.levelEnv * (1.4 + wow * 0.4), 0, 1);
+    final double fa = (floodTarget > this.floodEnv)
+      ? 1 - Math.exp(-deltaMs / 120.0)
+      : 1 - Math.exp(-deltaMs / 2000.0);
+    this.floodEnv += (floodTarget - this.floodEnv) * fa;
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CUBE) {
+      renderField(Apotheneum.cylinder.exterior, deltaMs);
+      copyCylinderExterior();
+    }
+    if (t != Target.CYLINDER) {
+      renderField(Apotheneum.cube.exterior, deltaMs);
+      copyCubeExterior();
+    }
+  }
+
+  private void renderField(Apotheneum.Orientation o, double deltaMs) {
+    final int w = o.width();
+    final int h = o.height();
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+
+    // palette scenes stepping through the reference arc
+    final double hueShift = LXColor.h(getColor());
+    final double sceneT = this.timeMs / SCENE_MS;
+    final int scene = (int) Math.floor(sceneT);
+    final double xfade = LXUtils.clamp((sceneT - scene) * SCENE_MS / SCENE_XFADE, 0, 1);
+    final double huePrev = sceneHue(scene - 1);
+    final double hueCur = sceneHue(scene);
+    final boolean duoNow = (hueCur == DUO);
+    final double resolvedPrev = (huePrev == DUO) ? 228 : huePrev;
+    final double resolvedCur = duoNow ? 228 : hueCur;
+    final double hueMain = LXUtils.lerp(resolvedPrev,
+      resolvedPrev + wrapDeg(resolvedCur - resolvedPrev), xfade) + hueShift;
+    final int col = LXColor.hsb((float) (((hueMain % 360) + 360) % 360), 88, 100);
+    final int hot = LXColor.lerp(col, LXColor.WHITE, 0.6f);
+    final int ringRed = LXColor.hsb((float) (((358 + hueShift) % 360)), 95, 100);
+    final int duoRed = ringRed;
+    final int duoBlue = LXColor.hsb((float) (((222 + hueShift) % 360)), 92, 100);
+
+    final boolean breakdown = this.levelEnv < 0.06;
+    final int count = Math.min(MAX_RAYS, this.rays.getValuei() + (int) Math.round(wow * 20));
+    final int nBins = Math.max(8, count / 3);
+    final double aBin = 1 - Math.exp(-deltaMs / 90.0);
+    final double dotR = 0.5 + getSize() * 0.8;
+    final double spacing = DOT_SPACING + getSize() * 1.5;
+    final double bloomFront = (this.bloomT >= 0) ? (1.0 - this.bloomT) * h : -100;
+    final double fieldB = (0.40 + 0.60 * this.floodEnv) * (1.0 + this.pulse * 0.35);
+
+    if (!breakdown) {
+      // --- dotted radial rays: bottom (center) to top (rim) ---
+      for (int i = 0; i < count; ++i) {
+        this.binMag[i] += (band(i % nBins, nBins) - this.binMag[i]) * aBin;
+        // coordinated length: the field grows and shrinks together
+        final double len = h * LXUtils.clamp(
+          0.30 + 0.65 * this.floodEnv + 0.10 * LXUtils.clamp(this.binMag[i] * 2, 0, 1), 0, 1)
+          * this.rlen[i];
+        final int x = (int) Math.round(this.rx[i] * w);
+        // DUO scene: red/blue opposition split by a slowly rotating boundary
+        int rayCol = col, rayHot = hot;
+        if (duoNow) {
+          final boolean redSide = ((this.rx[i] + this.timeMs * 0.00006) % 1.0) < 0.5;
+          rayCol = redSide ? duoRed : duoBlue;
+          rayHot = LXColor.lerp(rayCol, LXColor.WHITE, 0.6f);
+        }
+        for (int y = h - 1; y >= h - (int) len && y >= 0; --y) {
+          // dotted chain: lit only on the dot cells, crawling outward (upward)
+          final double sdot = ((h - 1 - y) + this.dotFlow) / spacing;
+          final double f = sdot - Math.floor(sdot);
+          if (f > 0.5) continue;
+          double b = fieldB * (0.45 + 0.55 * (1.0 - (double) (h - 1 - y) / Math.max(1, len)));
+          // bloom wavefront sweeping center->rim
+          if (bloomFront > -50) {
+            final double d = y - bloomFront;
+            b *= 1.0 + 1.2 * Math.exp(-d * d / 18.0);
+          }
+          // white-hot core only on the innermost dots
+          final int c = (h - 1 - y < spacing * 2) ? rayHot : rayCol;
+          splat(o, w, h, x, y, dotR, b, c);
+        }
+      }
+
+      // --- dotted concentric rings hugging the center (bottom region) ---
+      final int nRings = 3;
+      final double ringGap = h * 0.055;
+      final double ringB = fieldB * (0.5 + 0.5 * this.floodEnv);
+      final int ringDotStep = 3;
+      final double duoSpin = duoNow ? this.timeMs * 0.004 : 0;
+      for (int r = 0; r < nRings; ++r) {
+        final double ry = (r * ringGap + this.ringFlow * ringGap) % (h * 0.24);
+        final int yy = h - 2 - (int) Math.round(ry);
+        for (int x = 0; x < w; x += ringDotStep) {
+          int c = ringRed;
+          if (duoNow) {
+            c = (((x + (int) duoSpin) / (w / 4)) % 2 == 0) ? duoRed : duoBlue;
+          }
+          splat(o, w, h, x, yy, dotR, ringB * (0.8 - r * 0.18), c);
+        }
+      }
+
+      // --- sustained chromatic section fill (ambient, saturated) ---
+      if (this.floodEnv > 0.05) {
+        final double haze = (hueCur == 292 || huePrev == 292) ? 0.55 : 0.30;
+        final int fc = LXColor.scaleBrightness(
+          LXColor.hsb((float) (((hueMain % 360) + 360) % 360), 75, 100),
+          (float) (this.floodEnv * this.floodEnv * haze));
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            final int idx = o.point(x, y).index;
+            this.colors[idx] = LXColor.lightest(this.colors[idx], fc);
+          }
+        }
+      }
+
+      // --- center bloom at the floor line on hits ---
+      if (this.pulse > 0.05) {
+        for (int y = h - 5; y < h; ++y) {
+          final double g = this.pulse * (0.8 + wow * 0.5) * Math.exp(-(h - 1 - y) / 1.8);
+          for (int x = 0; x < w; ++x) {
+            splat(o, w, h, x, y, 0.8, g * 0.5, hot);
+          }
+        }
+      }
+    } else {
+      // --- starfield breakdown: sparse random white-blue twinkles ---
+      final int star = LXColor.hsb(210, 30, 100);
+      final int tq = (int) (this.timeMs / 180);
+      final int nStars = (int) (w * h * 0.012);
+      for (int k = 0; k < nStars; ++k) {
+        final int sx = (int) (hashd(k * 31 + tq * 977) * w);
+        final int sy = (int) (hashd(k * 53 + tq * 613) * h);
+        final double tw = hashd(k * 97 + tq * 131);
+        if (tw < 0.45) continue;
+        splat(o, w, h, sx, sy, 0.8, 0.25 + 0.75 * tw, (tw > 0.92) ? LXColor.WHITE : star);
+      }
+    }
+
+  }
+
+  private static double wrapDeg(double d) {
+    d = ((d % 360) + 360) % 360;
+    return (d > 180) ? d - 360 : d;
+  }
+
+  /** Soft dot; x wraps, y clips. */
+  private void splat(Apotheneum.Orientation o, int w, int h, double x, double y,
+      double r, double bright, int color) {
+    if (bright <= 0.004) return;
+    final int y0 = (int) Math.max(0, Math.floor(y - r));
+    final int y1 = (int) Math.min(h - 1, Math.ceil(y + r));
+    final int x0 = (int) Math.floor(x - r);
+    final int x1 = (int) Math.ceil(x + r);
+    for (int yy = y0; yy <= y1; ++yy) {
+      final double dy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        final double dx = xx - x;
+        final double dd = Math.sqrt(dx * dx + dy * dy);
+        if (dd > r + 0.5) continue;
+        final double u = 1.0 - dd / (r + 0.5);
+        final double f = u * u * bright;
+        if (f <= 0.004) continue;
+        final int xi = ((xx % w) + w) % w;
+        final int idx = o.point(xi, yy).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(color, (float) LXUtils.clamp(f, 0, 1)));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/ReUp.java
+++ b/src/main/java/apotheneum/piemonte/ReUp.java
@@ -19,17 +19,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class ReUp extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double REUP_PER_MS = 0.0016; // fade-back rate at speed 1
   private static final double MIN_BEAT_MS = 110;    // debounce between hits
@@ -37,10 +30,6 @@ public class ReUp extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("Beat sensitivity (higher = triggers more easily)");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   /** Per-surface column brightness (0=dark .. 1=lit), fading back toward 1. */
   private final class Surface {
@@ -73,19 +62,17 @@ public class ReUp extends ParameterPattern {
     // Base registers color, speed, size; speed = re-up rate, size = knockout group size.
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private boolean detectBeat(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
     this.sinceBeatMs += deltaMs;
 
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= MIN_BEAT_MS)
       && (bass > 0.01);
@@ -108,7 +95,7 @@ public class ReUp extends ParameterPattern {
     final double wow = getWow();
     final double reup = REUP_PER_MS * Math.max(0.02, getSpeed()) * deltaMs * (1 + wow * 1.2);
     final int base = getColor();
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
 
     if (t != Target.CYLINDER) {
       step(this.cube, Apotheneum.cube.exterior, reup, beat, this.beatLevel, base);

--- a/src/main/java/apotheneum/piemonte/ReUp.java
+++ b/src/main/java/apotheneum/piemonte/ReUp.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * ReUp — every vertical string is lit solid. On each bass hit, a random group of
+ * strings is knocked dark; they then fade — "re-up" — back to full, while new
+ * groups drop out on the next hits. Louder hits knock out wider groups. An
+ * audio-reactive curtain that keeps rebuilding itself.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class ReUp extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double REUP_PER_MS = 0.0016; // fade-back rate at speed 1
+  private static final double MIN_BEAT_MS = 110;    // debounce between hits
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Beat sensitivity (higher = triggers more easily)");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  /** Per-surface column brightness (0=dark .. 1=lit), fading back toward 1. */
+  private final class Surface {
+    int w;
+    float[] bright;
+    void ensure(int w) {
+      if (this.bright == null || this.w != w) {
+        this.w = w;
+        this.bright = new float[w];
+        java.util.Arrays.fill(this.bright, 1f);
+      }
+    }
+    void knockout(int start, int len) {
+      for (int k = 0; k < len; ++k) {
+        this.bright[((start + k) % this.w + this.w) % this.w] = 0f;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+
+  // beat detection state
+  private double bassAvg = 0;
+  private double prevBass = 0;
+  private double sinceBeatMs = 0;
+  private double beatLevel = 0;
+
+  public ReUp(LX lx) {
+    // Base registers color, speed, size; speed = re-up rate, size = knockout group size.
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  private boolean detectBeat(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4)); // low quarter of the spectrum
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0)); // slow moving average
+    this.sinceBeatMs += deltaMs;
+
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;          // sens up -> easier
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= MIN_BEAT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    return beat;
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    boolean beat = detectBeat(deltaMs);
+
+    // Wow = mayhem: wider knockouts, faster re-up, and hard hits black out
+    // the entire curtain in one sweep
+    final double wow = getWow();
+    final double reup = REUP_PER_MS * Math.max(0.02, getSpeed()) * deltaMs * (1 + wow * 1.2);
+    final int base = getColor();
+    final Target t = this.target.getEnum();
+
+    if (t != Target.CYLINDER) {
+      step(this.cube, Apotheneum.cube.exterior, reup, beat, this.beatLevel, base);
+    }
+    if (t != Target.CUBE) {
+      step(this.cylinder, Apotheneum.cylinder.exterior, reup, beat, this.beatLevel, base);
+    }
+    copyExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation o, double reup, boolean beat, double level, int base) {
+    final int w = o.width();
+    s.ensure(w);
+
+    // fade columns back up
+    for (int i = 0; i < w; ++i) {
+      if (s.bright[i] < 1f) {
+        s.bright[i] = (float) Math.min(1.0, s.bright[i] + reup);
+      }
+    }
+    // on a beat, knock out a random contiguous group (wider with louder hits + Size)
+    if (beat) {
+      final double wowK = getWow();
+      if (wowK > 0.5 && level > 0.7) {
+        s.knockout(0, w); // total blackout wave: the whole curtain re-ups at once
+      } else {
+        double frac = (0.04 + (0.06 + getSize() * 0.30) * level) * (1 + wowK * 1.5);
+        int len = Math.max(1, (int) (w * frac));
+        int start = (int) (Math.random() * w);
+        s.knockout(start, len);
+        // extra clusters for a busier feel as Wow rises
+        if (Math.random() < 0.5 * level + wowK * 0.4) {
+          s.knockout((int) (Math.random() * w), Math.max(1, len / 2));
+        }
+        if (wowK > 0.3 && Math.random() < wowK * 0.5) {
+          s.knockout((int) (Math.random() * w), Math.max(1, len / 2));
+        }
+      }
+    }
+
+    // render solid columns at their current brightness (gamma for perceptual fade)
+    for (int x = 0; x < w; ++x) {
+      float b = s.bright[x];
+      if (b <= 0f) continue;
+      float disp = (float) (b * b);
+      int c = LXColor.scaleBrightness(base, disp);
+      for (LXPoint p : o.column(x).points) {
+        this.colors[p.index] = c;
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Replies.java
+++ b/src/main/java/apotheneum/piemonte/Replies.java
@@ -77,6 +77,7 @@ public class Replies extends ParameterPattern {
     double[] pos;       // numSeq * dotsPer, in [0,1)
     double[] vel;       // numSeq * dotsPer, signed unit-ish factor
     double[] cooldown;  // per sequence (ms)
+    boolean[] wasHit;   // per sequence: overlapped last frame (edge trigger)
     double[] flashEnv;  // per sequence (0..1)
     double[] flashPos;  // per sequence, in [0,1)
     double energy;      // exterior reply energy (0..1)
@@ -97,6 +98,7 @@ public class Replies extends ParameterPattern {
       this.pos = new double[numSeq * dotsPer];
       this.vel = new double[numSeq * dotsPer];
       this.cooldown = new double[numSeq];
+      this.wasHit = new boolean[numSeq];
       this.flashEnv = new double[numSeq];
       this.flashPos = new double[numSeq];
       this.energy = 0;
@@ -192,7 +194,11 @@ public class Replies extends ParameterPattern {
           }
         }
       }
-      if (hit && s.cooldown[q] <= 0) {
+      // fire on the transition into overlap only — sustained proximity
+      // (e.g. two dots parked together at Speed 0) must not refire forever
+      final boolean entered = hit && !s.wasHit[q];
+      s.wasHit[q] = hit;
+      if (entered && s.cooldown[q] <= 0) {
         s.cooldown[q] = COOLDOWN_MS;
         s.flashEnv[q] = 1.0;
         s.flashPos[q] = hitPos;
@@ -218,6 +224,9 @@ public class Replies extends ParameterPattern {
       }
     }
 
+    // actual travel direction carries speed's sign too, not just vel's
+    final double dir = (step < 0) ? -1 : 1;
+
     // --- draw cylinder dots + burst flashes ---
     if (drawDots)
     for (int q = 0; q < numSeq; ++q) {
@@ -232,7 +241,7 @@ public class Replies extends ParameterPattern {
         for (int k = 0; k < dotsPer; ++k) {
           final double rel = wrapDelta(pj - s.pos[o + k]);
           // tail trails behind the dot's direction of travel
-          final double g = (s.vel[o + k] >= 0) ? -rel : rel;
+          final double g = (s.vel[o + k] * dir >= 0) ? -rel : rel;
           if (g >= 0 && g < tailLen) {
             final double bk = Math.pow(1.0 - g / tailLen, gamma);
             if (bk > dotBright) {

--- a/src/main/java/apotheneum/piemonte/Replies.java
+++ b/src/main/java/apotheneum/piemonte/Replies.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Replies — glowing dots glide along the cylinder's rings or columns, each
+ * trailing a soft afterglow. When two dots collide they burst — and the cube
+ * answers: the face looking toward the collision flickers in reply, the outer
+ * chamber echoing the inner one. Wow chains the bursts into cascades that
+ * ripple around the cylinder and set multiple faces talking at once.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LinkedColorParameter;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Replies extends ParameterPattern {
+
+  public enum Axis {
+    RINGS,
+    COLUMNS
+  }
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double SPEED_SCALE = 0.0006; // loop fraction per ms at speed 1
+  private static final double EPS = 0.012;          // collision proximity (loop fraction)
+  private static final double COOLDOWN_MS = 220;    // per-sequence burst debounce
+  private static final double FLASH_MS = 300;       // interior burst-flash decay
+
+  public final EnumParameter<Axis> axis =
+    new EnumParameter<Axis>("Axis", Axis.RINGS)
+    .setDescription("Whether dots travel along rings (around) or columns (vertical)");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("BOTH = full call-and-response; CYLINDER = dots only; CUBE = replies only");
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 3, 2, 9)
+    .setDescription("Dots per sequence (need 2+ to collide)");
+
+  public final CompoundParameter tail =
+    new CompoundParameter("Tail", 0.5, 0.05, 1)
+    .setDescription("Afterglow length behind each dot");
+
+  public final CompoundParameter reply =
+    new CompoundParameter("Reply", 0.5, 0, 1)
+    .setDescription("How long the cube's flicker lingers after a burst");
+
+  // Inherited `color` (from ParameterPattern) is the interior dot color.
+  public final LinkedColorParameter exteriorColor =
+    new LinkedColorParameter("Outer")
+    .setDescription("Cube flicker color (the reply)");
+
+  /** Per-structure dot simulation + exterior reply state. */
+  private final class Surface {
+    boolean rings;
+    int dotsPer;
+    int numSeq;
+    double[] pos;       // numSeq * dotsPer, in [0,1)
+    double[] vel;       // numSeq * dotsPer, signed unit-ish factor
+    double[] cooldown;  // per sequence (ms)
+    double[] flashEnv;  // per sequence (0..1)
+    double[] flashPos;  // per sequence, in [0,1)
+    double energy;      // exterior reply energy (0..1)
+    // smoothed flicker: hold a random target, ease toward it (no white-noise strobe)
+    double flickerLp = 1;
+    double flickerTarget = 1;
+    double flickerMs = 0;
+
+    boolean matches(boolean rings, int dotsPer, int numSeq) {
+      return this.pos != null && this.rings == rings
+        && this.dotsPer == dotsPer && this.numSeq == numSeq;
+    }
+
+    void init(boolean rings, int dotsPer, int numSeq) {
+      this.rings = rings;
+      this.dotsPer = dotsPer;
+      this.numSeq = numSeq;
+      this.pos = new double[numSeq * dotsPer];
+      this.vel = new double[numSeq * dotsPer];
+      this.cooldown = new double[numSeq];
+      this.flashEnv = new double[numSeq];
+      this.flashPos = new double[numSeq];
+      this.energy = 0;
+      for (int i = 0; i < this.pos.length; ++i) {
+        this.pos[i] = Math.random();
+        double mag = 0.4 + 0.6 * Math.random();
+        this.vel[i] = (Math.random() < 0.5 ? -mag : mag);
+      }
+    }
+  }
+
+  private final Surface cylinder = new Surface();
+  private final double[] faceEnergy = new double[4]; // per cube face reply
+
+  public Replies(LX lx) {
+    // Base registers color (interior dots), speed, size; we add the rest.
+    super(lx, 0.4, -1, 1, 0.5, 0, 1);
+    addParameter("exteriorColor", this.exteriorColor);
+    addParameter("axis", this.axis);
+    addParameter("target", this.target);
+    addParameter("density", this.density);
+    addParameter("tail", this.tail);
+    addParameter("reply", this.reply);
+    // setMode after addParameter: the parameter needs its parent/LX set first.
+    this.exteriorColor.setMode(LinkedColorParameter.Mode.PALETTE);
+  }
+
+  private static double frac(double x) {
+    return x - Math.floor(x);
+  }
+
+  private static double wrapDelta(double d) {
+    return d - Math.rint(d); // nearest, → [-0.5, 0.5]
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final boolean rings = this.axis.getEnum() == Axis.RINGS;
+    final int dotsPer = this.density.getValuei();
+    final Target t = this.target.getEnum();
+    final int dotBase = getColor();
+    final int replyBase = this.exteriorColor.calcColor();
+
+    // the show lives on the cylinder; the cube answers
+    step(this.cylinder, Apotheneum.cylinder.exterior, rings, dotsPer, deltaMs,
+      dotBase, replyBase, t);
+    copyCylinderExterior();
+  }
+
+  private void step(Surface s, Apotheneum.Orientation cyl,
+      boolean rings, int dotsPer, double deltaMs, int interiorBase, int exteriorBase,
+      Target t) {
+
+    final Apotheneum.Sequence[] sequences = rings ? cyl.rings() : cyl.columns();
+    final int numSeq = sequences.length;
+    if (!s.matches(rings, dotsPer, numSeq)) {
+      s.init(rings, dotsPer, numSeq);
+    }
+
+    final double speed = getSpeed();
+    final double step = speed * SPEED_SCALE * deltaMs;
+    // Widen the collision window so fast dots can't tunnel past each other.
+    final double eps = Math.max(EPS, 1.5 * Math.abs(step));
+    final double gap = 1.0 / dotsPer;
+    final double tailLen = this.tail.getValue() * gap;
+    final double gamma = LXUtils.lerp(3.0, 0.5, getSize());
+    // Wow = chain reactions: bursts flare wider and echo across the surface
+    final double wow = getWow();
+    final double flashRadius = Math.min(0.1 + wow * 0.15, (1.5 + wow * 2.5) * gap);
+
+    // --- advance + collide ---
+    int bursts = 0;
+    final boolean drawDots = (t != Target.CUBE);
+    final boolean doReply = (t != Target.CYLINDER);
+    for (int q = 0; q < numSeq; ++q) {
+      final int o = q * dotsPer;
+      for (int k = 0; k < dotsPer; ++k) {
+        s.pos[o + k] = frac(s.pos[o + k] + s.vel[o + k] * step);
+      }
+      s.cooldown[q] = Math.max(0, s.cooldown[q] - deltaMs);
+      s.flashEnv[q] = Math.max(0, s.flashEnv[q] - deltaMs / FLASH_MS);
+
+      boolean hit = false;
+      double hitPos = 0;
+      for (int a = 0; a < dotsPer && !hit; ++a) {
+        for (int b = a + 1; b < dotsPer; ++b) {
+          if (Math.abs(wrapDelta(s.pos[o + a] - s.pos[o + b])) < eps) {
+            hit = true;
+            hitPos = s.pos[o + a];
+            break;
+          }
+        }
+      }
+      if (hit && s.cooldown[q] <= 0) {
+        s.cooldown[q] = COOLDOWN_MS;
+        s.flashEnv[q] = 1.0;
+        s.flashPos[q] = hitPos;
+        // the cube face looking toward this collision answers
+        final double azimuth = rings ? hitPos : ((double) q / numSeq);
+        this.faceEnergy[((int) Math.floor(azimuth * 4 + 0.5)) % 4] = 1.0;
+        // echo: a burst ripples into a neighboring sequence at high Wow
+        if (wow > 0.25 && Math.random() < wow * 0.7) {
+          final int q2 = (q + 1 + (int) (Math.random() * 3)) % s.flashEnv.length;
+          s.flashEnv[q2] = Math.max(s.flashEnv[q2], 0.7);
+          s.flashPos[q2] = Math.random();
+        }
+        ++bursts;
+      }
+    }
+
+    // --- reply energy decays per cube face ---
+    final double decayMs = LXUtils.lerp(150, 1400, this.reply.getValue());
+    for (int fi = 0; fi < 4; ++fi) {
+      this.faceEnergy[fi] *= Math.exp(-deltaMs / (0.5 * decayMs));
+      if (this.faceEnergy[fi] < 0.01) {
+        this.faceEnergy[fi] = 0;
+      }
+    }
+
+    // --- draw cylinder dots + burst flashes ---
+    if (drawDots)
+    for (int q = 0; q < numSeq; ++q) {
+      final int o = q * dotsPer;
+      final LXPoint[] points = sequences[q].points;
+      final int len = points.length;
+      final double flEnv = s.flashEnv[q];
+      final double flPos = s.flashPos[q];
+      for (int j = 0; j < len; ++j) {
+        final double pj = (double) j / len;
+        double dotBright = 0;
+        for (int k = 0; k < dotsPer; ++k) {
+          final double rel = wrapDelta(pj - s.pos[o + k]);
+          // tail trails behind the dot's direction of travel
+          final double g = (s.vel[o + k] >= 0) ? -rel : rel;
+          if (g >= 0 && g < tailLen) {
+            final double bk = Math.pow(1.0 - g / tailLen, gamma);
+            if (bk > dotBright) {
+              dotBright = bk;
+            }
+          }
+        }
+        int c = LXColor.scaleBrightness(interiorBase, (float) dotBright);
+        if (flEnv > 0) {
+          final double fd = Math.abs(wrapDelta(pj - flPos));
+          if (fd < flashRadius) {
+            final double fb = flEnv * Math.pow(1.0 - fd / flashRadius, 2);
+            c = LXColor.lightest(c, LXColor.scaleBrightness(LXColor.WHITE, (float) fb));
+          }
+        }
+        this.colors[points[j].index] = c;
+      }
+    }
+
+    // --- the cube answers: flickering wash on the faces that were addressed ---
+    s.flickerMs += deltaMs;
+    if (s.flickerMs > 80) {
+      s.flickerMs = 0;
+      s.flickerTarget = 0.35 + 0.65 * Math.random();
+    }
+    s.flickerLp += (s.flickerTarget - s.flickerLp) * Math.min(1.0, deltaMs / 60.0);
+    if (doReply) {
+      for (int fi = 0; fi < 4; ++fi) {
+        if (this.faceEnergy[fi] <= 0) continue;
+        final int c = LXColor.scaleBrightness(exteriorBase,
+          (float) (this.faceEnergy[fi] * s.flickerLp));
+        setColor(Apotheneum.cube.exterior.faces[fi], c);
+        if (Apotheneum.hasInterior) {
+          setColor(Apotheneum.cube.interior.faces[fi], c);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/SafteyThird.java
+++ b/src/main/java/apotheneum/piemonte/SafteyThird.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * SafteyThird — a bold dead smiley across the whole piece, in the full-facade spirit
+ * of Ex Machina. One huge grinning face per cube facade (two around the
+ * cylinder): a bright disc textured with slow Ex Machina-style radial
+ * shimmer bands, X X eyes cut dark into the glow, and a wide smile arc.
+ * The face tilts gently side to side and pulses on beats. Wow sends it
+ * over the edge: the X eyes flash hot red, the face jitters, and hard
+ * strobe frames drop out of the disc. Hue steers the face color live;
+ * Squiggle waves the smile into a wobbling scrawl and Rotate spins the
+ * whole face.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class SafteyThird extends StrandPattern {
+
+  // face geometry in normalized disc coordinates (r = 1 at the rim)
+  private static final double EYE_X = 0.38, EYE_Y = -0.26;
+  private static final double EYE_R = 0.17;    // reach of each X arm
+  private static final double EYE_W = 0.075;   // X stroke half-width
+  private static final double MOUTH_CY = 0.02; // smile arc circle center (y)
+  private static final double MOUTH_R = 0.55;  // smile arc radius
+  private static final double MOUTH_W = 0.07;  // smile stroke half-width
+  private static final double MOUTH_MIN_Y = 0.30; // only the lower arc shows
+
+  public final CompoundParameter bands =
+    new CompoundParameter("Bands", 2.2, 0.5, 6.0)
+    .setDescription("Radial shimmer band frequency inside the face");
+
+  public final CompoundParameter squiggle =
+    new CompoundParameter("Squiggle", 0, 0, 1)
+    .setDescription("Waves the smile into an animated squiggle");
+
+  public final CompoundParameter rotate =
+    new CompoundParameter("Rotate", 0, -60, 60)
+    .setUnits(CompoundParameter.Units.DEGREES)
+    .setPolarity(CompoundParameter.Polarity.BIPOLAR)
+    .setDescription("Degrees/second the whole face spins; negative reverses");
+
+  private double shimmer = 0;
+  private double tilt = 0;
+  private double spin = 0;
+  private double squigPhase = 0;
+  private double kick = 0;
+
+  public SafteyThird(LX lx) {
+    // Base registers color (face color), speed (shimmer/tilt pace), size (face radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("bands", this.bands);
+    addParameter("squiggle", this.squiggle);
+    addParameter("rotate", this.rotate);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    this.shimmer += deltaMs * 0.0005 * speed * 2;
+    this.tilt = 0.10 * Math.sin(this.timeMs * 0.0009 * speed * 2);
+    this.spin += deltaMs * 0.001 * Math.toRadians(this.rotate.getValue());
+    this.spin %= (2 * Math.PI);
+    this.squigPhase += deltaMs * 0.006 * speed * 2;
+    if (this.beat) {
+      this.kick = 1;
+    }
+    this.kick *= Math.exp(-deltaMs / 280.0);
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double bandF = this.bands.getValue();
+    final int tq = (int) (this.timeMs / 70);
+
+    final int face = getColor();
+    final int rimC = LXColor.scaleBrightness(face, 0.72f);
+    final int redX = LXColor.hsb(2, 98, 100);
+
+    // Wow chaos: eye flashes, face jitter, strobe dropout frames
+    final boolean eyesHot = wow > 0.15 && ((tq / 3) % 4 == 0 || wow > 0.8);
+    final int jitter = (wow > 0.4 && hashd(tq * 7) < wow * 0.5)
+      ? (int) ((hashd(tq * 13) - 0.5) * wow * 6) : 0;
+    final boolean dropFrame = wow > 0.6 && hashd(tq * 31 + 5) < (wow - 0.6) * 0.6;
+    if (dropFrame) {
+      return; // hard strobe blackout frame
+    }
+
+    final int nFaces = isCube ? 4 : 2; // one per cube facade, two on the cylinder
+    final int half = w / (2 * nFaces);
+    final double R = Math.min(half, h * 0.5) * (0.62 + getSize() * 0.55)
+      * (1 + this.kick * 0.06);
+    final double cy = h * 0.48;
+    final double ang = this.tilt + this.spin;
+    final double cosT = Math.cos(ang), sinT = Math.sin(ang);
+    final double squig = this.squiggle.getValue();
+
+    for (int f = 0; f < nFaces; ++f) {
+      final int cx = (int) ((f + 0.5) * w / (double) nFaces) + jitter;
+      for (int dx = -half; dx < half; ++dx) {
+        final int x = ((cx + dx) % w + w) % w;
+        for (int y = 0; y < h; ++y) {
+          // head-tilt rotation into normalized face coordinates
+          final double rx = (dx * cosT - (y - cy) * sinT) / R;
+          final double ry = (dx * sinT + (y - cy) * cosT) / R;
+          final double r = Math.sqrt(rx * rx + ry * ry);
+          if (r > 1.03) continue;
+          final double edge = LXUtils.clamp((1.0 - r) * R + 1.0, 0, 1);
+
+          // X X eyes: diagonal cross strokes, mirrored left/right
+          final double eu = Math.abs(Math.abs(rx) - EYE_X);
+          final double ev = ry - EYE_Y;
+          final boolean inEyeBox = eu < EYE_R && Math.abs(ev) < EYE_R;
+          final boolean inX = inEyeBox
+            && Math.abs(eu - Math.abs(ev)) < EYE_W;
+
+          // the smile: lower arc of an offset circle; Squiggle waves it
+          final double rm = Math.sqrt(rx * rx + (ry - MOUTH_CY) * (ry - MOUTH_CY));
+          double mouthR = MOUTH_R;
+          if (squig > 0) {
+            final double th = Math.atan2(rx, ry - MOUTH_CY);
+            mouthR += squig * 0.11
+              * Math.sin(th * 9 + this.squigPhase);
+          }
+          final boolean inMouth = ry > MOUTH_MIN_Y
+            && Math.abs(rm - mouthR) < MOUTH_W;
+
+          if (inX) {
+            if (eyesHot) { // Wow: the X eyes burn red
+              addPix(o, x, y, redX, edge);
+            }
+            continue; // otherwise cut dark into the glow
+          }
+          if (inMouth) {
+            continue; // the smile stays dark
+          }
+
+          // the disc: Ex Machina-style radial shimmer bands
+          final double wave = 0.5 + 0.5
+            * Math.cos((r * bandF - this.shimmer) * 2 * Math.PI);
+          final double bb = (0.55 + 0.45 * Math.pow(wave, 1.6))
+            * (0.92 + 0.08 * hashd(x * 131 + y * 7 + tq))
+            * (1 + this.kick * 0.20);
+          addPix(o, x, y, (r > 0.92) ? rimC : face, Math.min(1, bb * edge));
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/SpaceBoundSpecies.java
+++ b/src/main/java/apotheneum/piemonte/SpaceBoundSpecies.java
@@ -22,17 +22,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class SpaceBoundSpecies extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double TAU = Math.PI * 2;
   private static final int MAX_STARS = 256;
@@ -48,10 +41,6 @@ public class SpaceBoundSpecies extends ParameterPattern {
   public final CompoundParameter twinkle =
     new CompoundParameter("Twinkle", 0.5, 0, 1)
     .setDescription("How much the stars flicker (strongest at low speed)");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -84,7 +73,7 @@ public class SpaceBoundSpecies extends ParameterPattern {
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("density", this.density);
     addParameter("twinkle", this.twinkle);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -141,7 +130,7 @@ public class SpaceBoundSpecies extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/SpaceBoundSpecies.java
+++ b/src/main/java/apotheneum/piemonte/SpaceBoundSpecies.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * SpaceBoundSpecies — a flight through a field of stars. Each face of the
+ * sculpture is a window into space with its vanishing point at the center. Speed
+ * is a continuum: at rest the field drifts and twinkles, the brightest stars
+ * flashing four-point diffraction spikes; wind it up and the stars stream
+ * outward into hyperspace warp streaks. Wow bathes the field in a slow fBm
+ * nebula in a complementary hue. A pure-Java Apotheneum take on the
+ * LXStudio-TE Starfield shader.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class SpaceBoundSpecies extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double TAU = Math.PI * 2;
+  private static final int MAX_STARS = 256;
+  private static final double MIN_VEL = 0.05;   // constant outward drift (no center clump)
+  private static final double WARP_K = 3.0;     // perspective acceleration at speed 1
+  private static final double STRETCH = 6.0;    // extra streak length at speed 1
+  private static final double GOLDEN = 2.399963; // golden angle: per-panel rotation offset
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 128, 8, MAX_STARS)
+    .setDescription("Number of stars in flight");
+
+  public final CompoundParameter twinkle =
+    new CompoundParameter("Twinkle", 0.5, 0, 1)
+    .setDescription("How much the stars flicker (strongest at low speed)");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final double cx, cy, halfDiag, rot;
+    Panel(int[][] idx, int w, int h, double rot) {
+      this.idx = idx; this.w = w; this.h = h;
+      this.cx = w * 0.5; this.cy = h * 0.5;
+      this.halfDiag = 0.5 * Math.hypot(w, h);
+      this.rot = rot;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  // shared normalized-space star pool (unit disk)
+  private final double[] ang = new double[MAX_STARS];
+  private final double[] rad = new double[MAX_STARS];
+  private final double[] radPrev = new double[MAX_STARS];
+  private final double[] twPhase = new double[MAX_STARS];
+  private final double[] twRate = new double[MAX_STARS];
+  private final double[] baseBright = new double[MAX_STARS];
+  private final boolean[] tinted = new boolean[MAX_STARS];
+  private boolean inited = false;
+  private double timeMs = 0;
+
+  public SpaceBoundSpecies(LX lx) {
+    // Base registers color (star tint), speed (drift->warp), size (bloom/streak), wow (nebula).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("twinkle", this.twinkle);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    int pi = 0;
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, pi++ * GOLDEN));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h, pi++ * GOLDEN));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private void recycle(int i) {
+    this.rad[i] = 0.02 + Math.random() * 0.12;
+    this.radPrev[i] = this.rad[i];
+    this.ang[i] = Math.random() * TAU;
+    this.twPhase[i] = Math.random() * TAU;
+    this.twRate[i] = 6 + Math.random() * 8;
+    this.baseBright[i] = 0.4 + 0.6 * Math.random();
+    this.tinted[i] = Math.random() < 0.25;
+  }
+
+  private static double smoothstep(double e0, double e1, double x) {
+    double t = (x - e0) / (e1 - e0);
+    t = t < 0 ? 0 : (t > 1 ? 1 : t);
+    return t * t * (3 - 2 * t);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+    if (!this.inited) {
+      for (int i = 0; i < MAX_STARS; ++i) {
+        recycle(i);
+        this.rad[i] = Math.random() * 1.1; // spread the initial field
+        this.radPrev[i] = this.rad[i];
+      }
+      this.inited = true;
+    }
+
+    this.timeMs += deltaMs;
+    final double ts = this.timeMs * 0.001;
+    final double speed01 = getSpeed();
+    final double dt = deltaMs * 0.001;
+    final double warp = WARP_K * speed01;
+    final int count = this.density.getValuei();
+    final double sizeF = getSize();
+    final double twAmt = this.twinkle.getValue();
+    final double wow = getWow();
+    final int base = getColor();
+    final float tintHue = LXColor.h(base);
+    final boolean nebula = wow > 0.01;
+    final int nebColor = LXColor.hsb((float) ((tintHue + 150) % 360), 75, 100);
+
+    // advance the field once, in normalized space
+    for (int i = 0; i < count; ++i) {
+      this.radPrev[i] = this.rad[i];
+      this.rad[i] += (MIN_VEL + warp * this.rad[i]) * dt;
+      if (this.rad[i] > 1.2) {
+        recycle(i);
+      }
+    }
+
+    for (Panel p : this.panels) {
+      // slow nebula wash (only when Wow is up)
+      if (nebula) {
+        final float drift = (float) (ts * 0.03);
+        for (int y = 0; y < p.h; ++y) {
+          double uvy = (y - p.cy) / p.halfDiag;
+          for (int x = 0; x < p.w; ++x) {
+            double uvx = (x - p.cx) / p.halfDiag;
+            float n = Noise.stb_perlin_fbm_noise3(
+              (float) (uvx * 1.5 + drift + p.rot), (float) (uvy * 1.5), (float) (ts * 0.05),
+              2.0f, 0.5f, 2);
+            double nb = (n * 0.5 + 0.5);
+            nb = nb * nb * nb;
+            if (nb > 0.05) {
+              int idx = p.idx[x][y];
+              this.colors[idx] = LXColor.lightest(this.colors[idx],
+                LXColor.scaleBrightness(nebColor, (float) (nb * wow * 0.4)));
+            }
+          }
+        }
+      }
+
+      // stars
+      for (int i = 0; i < count; ++i) {
+        final double a = this.ang[i] + p.rot;
+        final double ca = Math.cos(a), sa = Math.sin(a);
+        final double r = this.rad[i];
+        final double sx = p.cx + ca * r * p.halfDiag;
+        final double sy = p.cy + sa * r * p.halfDiag;
+
+        double tw = 1.0 - twAmt * (1.0 - 0.7 * speed01) * 0.5
+          * (1.0 + Math.sin(ts * this.twRate[i] + this.twPhase[i]));
+        double b = this.baseBright[i] * (0.3 + 0.7 * smoothstep(0, 1, r)) * tw;
+        if (b <= 0.01) continue;
+        double bloomR = (0.6 + sizeF * 3.0) * (0.4 + r);
+        int col = this.tinted[i] ? LXColor.hsb(tintHue, 45, 100) : LXColor.WHITE;
+
+        if (speed01 < 0.08) {
+          splat(p, sx, sy, bloomR, b, col);
+          // diffraction spikes on the hero stars
+          if (this.baseBright[i] > 0.85) {
+            double sp = 0.45 * b * (0.5 + 0.5 * Math.sin(ts * 2 + this.twPhase[i]));
+            double so = bloomR + 1;
+            splat(p, sx - so, sy, 0.6, sp, col);
+            splat(p, sx + so, sy, 0.6, sp, col);
+            splat(p, sx, sy - so, 0.6, sp, col);
+            splat(p, sx, sy + so, 0.6, sp, col);
+          }
+        } else {
+          double sxp = p.cx + ca * this.radPrev[i] * p.halfDiag;
+          double syp = p.cy + sa * this.radPrev[i] * p.halfDiag;
+          double ex = sx + (sx - sxp) * speed01 * STRETCH;
+          double ey = sy + (sy - syp) * speed01 * STRETCH;
+          edge(p, sxp, syp, ex, ey, col, b, bloomR);
+        }
+      }
+
+      // Wow: orange particles materialize among the stars, glitching and
+      // flickering — more of them the higher the dial
+      if (wow > 0.05) {
+        final int nGlitch = (int) Math.round(wow * 26);
+        final int gq = (int) (this.timeMs / 60); // fast flicker quantum
+        final int orange = LXColor.hsb(28, 95, 100);
+        final int orangeHot = LXColor.lerp(orange, LXColor.WHITE, 0.5f);
+        for (int gi = 0; gi < nGlitch; ++gi) {
+          // ~55% duty flicker, re-rolled per quantum -> hard glitch blink
+          final double gate = hashd(gi * 977 + gq * 131);
+          if (gate > 0.55) continue;
+          final double gx = hashd(gi * 31 + 7) * p.w
+            + (hashd(gi * 61 + gq * 17) - 0.5) * 2.5; // positional jitter
+          final double gy = hashd(gi * 53 + 11) * p.h
+            + (hashd(gi * 43 + gq * 23) - 0.5) * 2.0;
+          final double gb = (0.4 + 0.6 * hashd(gi * 97 + gq * 7)) * wow;
+          splat(p, gx, gy, 0.9 + wow * 0.6, gb,
+            (gate < 0.12) ? orangeHot : orange);
+        }
+      }
+    }
+
+    copyExterior();
+  }
+
+  private void edge(Panel p, double x0, double y0, double x1, double y1,
+      int color, double bright, double r) {
+    double dx = x1 - x0, dy = y1 - y0;
+    int steps = (int) Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)));
+    if (steps < 1) steps = 1;
+    for (int k = 0; k <= steps; ++k) {
+      double t = (double) k / steps;
+      splat(p, x0 + dx * t, y0 + dy * t, r, bright, color);
+    }
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  private void splat(Panel p, double x, double y, double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(p.h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.max(0, Math.floor(x - r));
+    int x1 = (int) Math.min(p.w - 1, Math.ceil(x + r));
+    for (int yy = y0; yy <= y1; ++yy) {
+      double ddy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double ddx = xx - x;
+        double dd = Math.sqrt(ddx * ddx + ddy * ddy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        u = u * u * (3 - 2 * u);
+        double f = u * u * bright;
+        if (f <= 0) continue;
+        int idx = p.idx[xx][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/SpecialKube.java
+++ b/src/main/java/apotheneum/piemonte/SpecialKube.java
@@ -21,16 +21,9 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 
 @LXCategory("Apotheneum/piemonte")
 public class SpecialKube extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_CUBES = 48;
   private static final int CYAN = LXColor.rgb(0, 255, 255);
@@ -57,10 +50,6 @@ public class SpecialKube extends ParameterPattern {
   public final CompoundParameter thick =
     new CompoundParameter("Thick", 0.5, 0, 1)
     .setDescription("Wireframe line thickness");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -95,7 +84,7 @@ public class SpecialKube extends ParameterPattern {
     addParameter("spin", this.spin);
     addParameter("special", this.special);
     addParameter("thick", this.thick);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -153,7 +142,7 @@ public class SpecialKube extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
       this.inited = false;

--- a/src/main/java/apotheneum/piemonte/SpecialKube.java
+++ b/src/main/java/apotheneum/piemonte/SpecialKube.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * SpecialKube — a rain of spinning wireframe 3D cubes falling downward, each
+ * confined to a single flat panel of the sculpture (a cube face, or a cylinder
+ * quadrant) so the wireframes stay crisp and don't bend around the corners. The
+ * lines are thick, and a fraction of the cubes are "special" — they run a heavy
+ * glitch: flickering, jittering, flashing white and shifting toward cyan,
+ * echoing the LXStudio-TE SpecialKube shader's glitch strobe.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+
+@LXCategory("Apotheneum/piemonte")
+public class SpecialKube extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_CUBES = 48;
+  private static final int CYAN = LXColor.rgb(0, 255, 255);
+  private static final int STROBE_COLOR = LXColor.lerp(LXColor.WHITE, CYAN, 0.30f);
+  private static final double FALL = 0.00016;
+  private static final double SPIN_RATE = 0.0011;
+  private static final double SIZE_CELLS = 6.0;
+  private static final int[][] EDGES = {
+    {0,1},{0,2},{1,3},{2,3}, {4,5},{4,6},{5,7},{6,7}, {0,4},{1,5},{2,6},{3,7}
+  };
+
+  public final DiscreteParameter quantity =
+    new DiscreteParameter("Quantity", 14, 1, MAX_CUBES)
+    .setDescription("Number of cubes in flight");
+
+  public final CompoundParameter spin =
+    new CompoundParameter("Spin", 0.5, 0, 2)
+    .setDescription("Rotation speed");
+
+  public final CompoundParameter special =
+    new CompoundParameter("Special", 0.35, 0, 1)
+    .setDescription("Fraction of cubes that glitch");
+
+  public final CompoundParameter thick =
+    new CompoundParameter("Thick", 0.5, 0, 1)
+    .setDescription("Wireframe line thickness");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    Panel(int[][] idx, int w, int h) { this.idx = idx; this.w = w; this.h = h; }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  private final int[] panel = new int[MAX_CUBES];
+  private final double[] nx = new double[MAX_CUBES];
+  private final double[] ny = new double[MAX_CUBES];
+  private final double[] sz = new double[MAX_CUBES];
+  private final double[] ax = new double[MAX_CUBES];
+  private final double[] ay = new double[MAX_CUBES];
+  private final double[] az = new double[MAX_CUBES];
+  private final double[] rax = new double[MAX_CUBES];
+  private final double[] ray = new double[MAX_CUBES];
+  private final double[] raz = new double[MAX_CUBES];
+  private final double[] seed = new double[MAX_CUBES];
+  private boolean inited = false;
+  private double timeMs = 0;
+
+  private final double[] sx = new double[8];
+  private final double[] sy = new double[8];
+  private final double[] sp = new double[8];
+
+  public SpecialKube(LX lx) {
+    super(lx, 0.4, 0, 2, 0.5, 0, 1);
+    addParameter("quantity", this.quantity);
+    addParameter("spin", this.spin);
+    addParameter("special", this.special);
+    addParameter("thick", this.thick);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private void respawn(int i, boolean atTop) {
+    this.panel[i] = (int) (Math.random() * this.panels.length);
+    this.nx[i] = Math.random();
+    this.ny[i] = atTop ? -0.25 : Math.random() * 1.2 - 0.1;
+    this.sz[i] = 0.6 + 0.8 * Math.random();
+    this.ax[i] = Math.random() * Math.PI * 2;
+    this.ay[i] = Math.random() * Math.PI * 2;
+    this.az[i] = Math.random() * Math.PI * 2;
+    this.rax[i] = (0.3 + Math.random()) * (Math.random() < 0.5 ? -1 : 1);
+    this.ray[i] = (0.3 + Math.random()) * (Math.random() < 0.5 ? -1 : 1);
+    this.raz[i] = (0.3 + Math.random()) * (Math.random() < 0.5 ? -1 : 1);
+    this.seed[i] = Math.random();
+  }
+
+  private static double frac(double x) {
+    return x - Math.floor(x);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+      this.inited = false;
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+    if (!this.inited) {
+      for (int i = 0; i < MAX_CUBES; ++i) {
+        respawn(i, false);
+      }
+      this.inited = true;
+    }
+
+    this.timeMs += deltaMs;
+    final double speed = getSpeed();
+    final double dSpin = this.spin.getValue() * SPIN_RATE * deltaMs;
+    final int count = this.quantity.getValuei();
+    final double fall = speed * FALL * deltaMs;
+    final int base = getColor();
+    final double sizeBase = SIZE_CELLS * (0.4 + getSize() * 1.6);
+    final double wow = getWow();
+    // Wow drags more cubes into the glitch and pushes it harder.
+    final double specialFrac = this.special.getValue() + wow * (1.0 - this.special.getValue());
+    final double lineR = 0.8 + this.thick.getValue() * 2.0; // thicker wireframe
+    final double gt = this.timeMs * (0.02 + wow * 0.04);
+    // crisp global strobe: all special cubes flash together on a short duty cycle
+    final double strobeHz = 6.0 + speed * 2.0 + wow * 2.0;      // ~6..12 flashes/s
+    final boolean strobeOn = frac(this.timeMs * 0.001 * strobeHz) < (0.12 + wow * 0.10);
+
+    for (int i = 0; i < count; ++i) {
+      this.ny[i] += fall;
+      if (this.ny[i] > 1.25) {
+        respawn(i, true);
+      }
+      this.ax[i] += this.rax[i] * dSpin;
+      this.ay[i] += this.ray[i] * dSpin;
+      this.az[i] += this.raz[i] * dSpin;
+
+      final Panel p = this.panels[this.panel[i]];
+      final double s = sizeBase * this.sz[i];
+      double cx = this.nx[i] * p.w;
+      double cy = this.ny[i] * p.h;
+
+      int col = base;
+      double bright = 1.0;
+      if (this.seed[i] < specialFrac) {
+        // heavy glitch "wow" texture between flashes
+        double sd = this.seed[i];
+        double glitch = (frac(gt + sd * 10) > 0.5 && frac(gt * 3.7 + sd * 5) > 0.7) ? 1 : 0;
+        bright = 1.6 + glitch * 2.4;
+        col = LXColor.lerp(base, CYAN, (float) (glitch * 0.5));
+        if (glitch > 0) {
+          double j = 1.0 + wow * 2.0;
+          cx += (Math.random() - 0.5) * 4 * j; // digital jitter
+          cy += (Math.random() - 0.5) * 3 * j;
+        }
+        // crisp rhythmic strobe: all special cubes flash cyan-white in sync + shudder
+        if (strobeOn) {
+          col = STROBE_COLOR;
+          bright = 3.5 * (1.0 + wow * 1.5);
+          double sj = 3.0 * (1.0 + wow * 2.0);
+          cx += (Math.random() - 0.5) * sj;
+          cy += (Math.random() - 0.5) * sj;
+        }
+      }
+
+      projectCube(i, s, cx, cy);
+      for (int[] e : EDGES) {
+        // depth cue: nearer edges (larger perspective factor) render brighter
+        double eb = bright * (0.55 + 0.45 * 0.5 * (this.sp[e[0]] + this.sp[e[1]]));
+        edge(p, this.sx[e[0]], this.sy[e[0]], this.sx[e[1]], this.sy[e[1]], col, eb, lineR);
+      }
+    }
+
+    copyExterior();
+  }
+
+  private void projectCube(int i, double s, double cx, double cy) {
+    final double cax = Math.cos(this.ax[i]), san = Math.sin(this.ax[i]);
+    final double cay = Math.cos(this.ay[i]), say = Math.sin(this.ay[i]);
+    final double caz = Math.cos(this.az[i]), saz = Math.sin(this.az[i]);
+    final double focal = 2.2 * s;
+    for (int v = 0; v < 8; ++v) {
+      double x = ((v & 1) != 0) ? s : -s;
+      double y = ((v & 2) != 0) ? s : -s;
+      double z = ((v & 4) != 0) ? s : -s;
+      double y1 = y * cax - z * san, z1 = y * san + z * cax;
+      double x2 = x * cay + z1 * say, z2 = -x * say + z1 * cay;
+      double x3 = x2 * caz - y1 * saz, y3 = x2 * saz + y1 * caz;
+      double persp = focal / (focal + z2);
+      this.sx[v] = cx + x3 * persp;
+      this.sy[v] = cy + y3 * persp;
+      this.sp[v] = persp;
+    }
+  }
+
+  private void edge(Panel p, double x0, double y0, double x1, double y1,
+      int color, double bright, double r) {
+    double dx = x1 - x0, dy = y1 - y0;
+    int steps = (int) Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)));
+    if (steps < 1) steps = 1;
+    for (int k = 0; k <= steps; ++k) {
+      double t = (double) k / steps;
+      splat(p, x0 + dx * t, y0 + dy * t, r, bright, color);
+    }
+  }
+
+  private void splat(Panel p, double x, double y, double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(p.h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.max(0, Math.floor(x - r));
+    int x1 = (int) Math.min(p.w - 1, Math.ceil(x + r));
+    for (int yy = y0; yy <= y1; ++yy) {
+      double ddy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double ddx = xx - x;
+        double dd = Math.sqrt(ddx * ddx + ddy * ddy);
+        if (dd > r) continue;
+        double u = 1.0 - dd / r;
+        double f = Math.pow(u, 1.6) * bright;
+        if (f <= 0) continue;
+        int idx = p.idx[xx][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * StrandPattern — shared engine for the "hanging light-strand curtain" family of
+ * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
+ * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
+ * vertical strands of light with a top-lit drip gradient, glowing floor pools,
+ * comet rain, and heavy audio reactivity. Subclasses implement one "program"
+ * each; this base provides the column/drip/pool math, a comet renderer,
+ * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
+ * attack/release envelope, coarse FFT bins).
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+public abstract class StrandPattern extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  // --- audio state, computed once per frame ---
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  /** True on the frame a bass onset fires. */
+  protected boolean beat;
+  /** Normalized bass onset strength 0..1 for the current frame. */
+  protected double beatLevel;
+  /** Broadband level envelope: 25ms attack / 220ms release. */
+  protected double levelEnv;
+  protected double timeMs = 0;
+
+  protected StrandPattern(LX lx,
+      double speedDef, double speedMin, double speedMax,
+      double sizeDef, double sizeMin, double sizeMax) {
+    super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
+  }
+
+  /** Subclasses call this LAST in their constructor to keep Target at the end. */
+  protected void addTargetParameter() {
+    addParameter("target", this.target);
+  }
+
+  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
+  protected double beatThreshold() {
+    return 1.4;
+  }
+
+  private void stepAudio(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    this.beat = (bass > this.bassAvg * beatThreshold())
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 130)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (this.beat) {
+      this.sinceBeatMs = 0;
+    }
+    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+  }
+
+  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
+  protected double band(int i, int n) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    int lo = i * nb / n;
+    int hi = Math.max(lo + 1, (i + 1) * nb / n);
+    return m.getAveragef(lo, hi - lo);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+    stepAudio(deltaMs);
+    advance(deltaMs);
+
+    final Target t = this.target.getEnum();
+    if (t != Target.CYLINDER) {
+      renderStrands(Apotheneum.cube.exterior, deltaMs, true);
+    }
+    if (t != Target.CUBE) {
+      renderStrands(Apotheneum.cylinder.exterior, deltaMs, false);
+    }
+    copyExterior();
+  }
+
+  /** Per-frame global state update before surfaces render. */
+  protected void advance(double deltaMs) {}
+
+  /** Draw one surface's strand program. Called for cube and/or cylinder exterior. */
+  protected abstract void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube);
+
+  // ------------------------------------------------------------------
+  // strand look utilities
+
+  /** Top-lit drip gradient: strands are brightest at the hang point. */
+  protected static double drip(int y, int h) {
+    return 1.0 - 0.35 * (double) y / Math.max(1, h - 1);
+  }
+
+  /** Additive floor-pool boost for the bottom rows (strand puddles glowing). */
+  protected static double pool(int y, int h) {
+    int fromBottom = (h - 1) - y;
+    if (fromBottom >= 4) return 0;
+    return 0.35 * (1.0 - fromBottom / 4.0);
+  }
+
+  /**
+   * Mirror the rows above the floor line into the bottom rows at reduced gain —
+   * the reflective-floor signature. Call AFTER drawing surface content.
+   */
+  protected void mirrorFloor(Apotheneum.Orientation o, int rows, float gain) {
+    final int w = o.width();
+    final int h = o.height();
+    final int axis = h - rows;
+    for (int x = 0; x < w; ++x) {
+      for (int y = axis; y < h; ++y) {
+        int src = 2 * axis - 1 - y;
+        if (src < 0) continue;
+        int c = this.colors[o.point(x, src).index];
+        int idx = o.point(x, y).index;
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, gain));
+      }
+    }
+  }
+
+  /** Additive pixel write with wrapped x; y outside the surface is dropped. */
+  protected void addPix(Apotheneum.Orientation o, int x, int y, int color, double b) {
+    if (b <= 0.004) return;
+    final int h = o.height();
+    if (y < 0 || y >= h) return;
+    final int w = o.width();
+    final int xi = ((x % w) + w) % w;
+    final int idx = o.point(xi, y).index;
+    this.colors[idx] = LXColor.lightest(this.colors[idx],
+      LXColor.scaleBrightness(color, (float) LXUtils.clamp(b, 0, 1)));
+  }
+
+  /**
+   * Falling comet: sub-pixel head at (x, y) with an exponential tail rising
+   * above it. White-hot head when hot is true.
+   */
+  protected void comet(Apotheneum.Orientation o, double x, double y, double tail,
+      int color, double bright, boolean hot) {
+    final int xi = (int) Math.round(x);
+    final int head = (int) Math.floor(y);
+    final double hf = y - head;
+    final int n = Math.max(1, (int) tail);
+    final int headColor = hot ? LXColor.lerp(color, LXColor.WHITE, 0.55f) : color;
+    for (int k = 0; k <= n; ++k) {
+      double b = bright * Math.exp(-2.2 * k / tail);
+      addPix(o, xi, head - k, (k == 0) ? headColor : color, (k == 0) ? b * (0.4 + 0.6 * hf) : b);
+    }
+    addPix(o, xi, head + 1, headColor, bright * hf * 0.5);
+  }
+}

--- a/src/main/java/apotheneum/piemonte/StrandPattern.java
+++ b/src/main/java/apotheneum/piemonte/StrandPattern.java
@@ -7,10 +7,10 @@
  * patterns (Overflow, Whiteout, Mainframe, Pressure, Biorhythm, HolyWater,
  * Motherboard, Hexed, Heartthrob), modeled on the holotrigger installation:
  * vertical strands of light with a top-lit drip gradient, glowing floor pools,
- * comet rain, and heavy audio reactivity. Subclasses implement one "program"
- * each; this base provides the column/drip/pool math, a comet renderer,
- * wrapped-x pixel writes, and Cope-style audio detection (beat gate, broadband
- * attack/release envelope, coarse FFT bins).
+ * comet rain, and audio reactivity driven by the external Level/Pulse inputs
+ * on ParameterPattern. Subclasses implement one "program" each; this base
+ * provides the column/drip/pool math, a comet renderer, and wrapped-x pixel
+ * writes.
  */
 
 package apotheneum.piemonte;
@@ -18,30 +18,9 @@ package apotheneum.piemonte;
 import apotheneum.Apotheneum;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 public abstract class StrandPattern extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
-
-  // --- audio state, computed once per frame ---
-  private double bassAvg, prevBass, sinceBeatMs = 1e9;
-  /** True on the frame a bass onset fires. */
-  protected boolean beat;
-  /** Normalized bass onset strength 0..1 for the current frame. */
-  protected double beatLevel;
-  /** Broadband level envelope: 25ms attack / 220ms release. */
-  protected double levelEnv;
-  protected double timeMs = 0;
 
   protected StrandPattern(LX lx,
       double speedDef, double speedMin, double speedMax,
@@ -49,56 +28,13 @@ public abstract class StrandPattern extends ParameterPattern {
     super(lx, speedDef, speedMin, speedMax, sizeDef, sizeMin, sizeMax);
   }
 
-  /** Subclasses call this LAST in their constructor to keep Target at the end. */
-  protected void addTargetParameter() {
-    addParameter("target", this.target);
-  }
-
-  /** Beat threshold multiplier; override to wire a Sens param (Cope idiom). */
-  protected double beatThreshold() {
-    return 1.4;
-  }
-
-  private void stepAudio(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
-    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
-    this.sinceBeatMs += deltaMs;
-    this.beat = (bass > this.bassAvg * beatThreshold())
-      && (bass > this.prevBass)
-      && (this.sinceBeatMs >= 130)
-      && (bass > 0.01);
-    this.prevBass = bass;
-    if (this.beat) {
-      this.sinceBeatMs = 0;
-    }
-    this.beatLevel = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
-
-    double level = m.getAveragef(0, nb);
-    double alpha = (level > this.levelEnv)
-      ? 1 - Math.exp(-deltaMs / 25.0)
-      : 1 - Math.exp(-deltaMs / 220.0);
-    this.levelEnv += (level - this.levelEnv) * alpha;
-  }
-
-  /** Coarse FFT: average magnitude of bin i of n across the meter's bands. */
-  protected double band(int i, int n) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    int lo = i * nb / n;
-    int hi = Math.max(lo + 1, (i + 1) * nb / n);
-    return m.getAveragef(lo, hi - lo);
-  }
-
   @Override
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
-    this.timeMs += deltaMs;
     stepAudio(deltaMs);
     advance(deltaMs);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (t != Target.CYLINDER) {
       renderStrands(Apotheneum.cube.exterior, deltaMs, true);
     }

--- a/src/main/java/apotheneum/piemonte/Sunrise.java
+++ b/src/main/java/apotheneum/piemonte/Sunrise.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Sunrise — a sun literally rises from the bottom of each facade. The disc
+ * climbs from below the horizon — huge, molten, all orange and yellow —
+ * radiating thick yellow and orange beams outward at angled directions. The higher the sun climbs, the more beams break out, each one
+ * flaring in from nothing and swaying gently as it burns. At the peak the
+ * day turns and the sun eases back down, beams folding away, before dawn
+ * breaks again. Beats flare the beams; Wow speeds the sway and sharpens the
+ * flare.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Sunrise extends StrandPattern {
+
+  private static final int MAX_BEAMS = 24;
+  private static final double CYCLE_MS = 52000;  // full rise-and-set at speed 0.5
+  private static final double Y_LOW = 1.14;      // start below the horizon
+  private static final double Y_HIGH = 0.28;     // peak height (0 = top)
+
+  public final DiscreteParameter beams =
+    new DiscreteParameter("Beams", 16, 6, MAX_BEAMS)
+    .setDescription("Beams radiating at full rise");
+
+  // per-frame beam table (no per-pixel trig re-derivation)
+  private final double[] beamAng = new double[MAX_BEAMS];
+  private final double[] beamHw = new double[MAX_BEAMS];
+  private final double[] beamVis = new double[MAX_BEAMS];
+  private final boolean[] beamWhite = new boolean[MAX_BEAMS];
+
+  private double phase = 0; // 0..1 around the rise-and-set cycle
+  private double flare = 0; // beat flare envelope
+
+  public Sunrise(LX lx) {
+    // Base registers color (sun hue anchor), speed (day pace), size (sun radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("beams", this.beams);
+    addTargetParameter();
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** How far the sun has risen, 0..1, easing at both horizon and peak. */
+  private double riseAmount() {
+    final double tri = 1.0 - Math.abs(1.0 - 2.0 * this.phase); // rise then set
+    return tri * tri * (3 - 2 * tri);
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    this.phase += deltaMs * speed * 2 / CYCLE_MS;
+    this.phase -= Math.floor(this.phase);
+
+    if (this.beat) {
+      this.flare = 1;
+    }
+    this.flare *= Math.exp(-deltaMs / 300.0);
+
+    // beam table: angles fan the sky, swaying gently; more break out with rise
+    final double rise = riseAmount();
+    final double wow = getWow();
+    final int n = this.beams.getValuei();
+    final double sway = this.timeMs * 0.001 * (0.25 + wow * 1.1);
+    for (int i = 0; i < n; ++i) {
+      // spread over the full circle; low-threshold beams appear first
+      this.beamAng[i] = (double) i / n * 2 * Math.PI
+        + hashd(i * 77 + 5) * 0.5
+        + Math.sin(sway + hashd(i * 31) * 6.28) * (0.05 + wow * 0.10);
+      this.beamHw[i] = Math.toRadians(5 + 7 * hashd(i * 131 + 9)); // thick
+      final double thr = hashd(i * 53 + 3) * 0.8;
+      this.beamVis[i] = LXUtils.clamp((rise - thr) / 0.12, 0, 1);
+      this.beamWhite[i] = (i % 3) == 2; // every third beam burns orange
+    }
+  }
+
+  private static double angDiff(double a, double b) {
+    double d = a - b;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    return d;
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final int w = o.width();
+    final int h = o.height();
+    final double rise = riseAmount();
+    final double wow = getWow();
+    final int n = this.beams.getValuei();
+    final int tq = (int) (this.timeMs / 90);
+
+    final float hue = (LXColor.h(getColor()) + 46) % 360; // Hue 0 = classic yellow sun
+    final int core = LXColor.hsb(hue, 42, 100);            // molten yellow center
+    final int body = LXColor.hsb(hue, 88, 100);            // yellow
+    final int rim = LXColor.hsb((hue + 22) % 360, 95, 96); // orange edge/halo
+    final int beamY = LXColor.hsb(hue, 80, 100);
+    final int beamW = LXColor.hsb((hue + 24) % 360, 92, 100); // orange beams
+
+    final double R = (0.20 + getSize() * 0.35) * h; // sun radius in rows
+    final double yc = LXUtils.lerp(Y_LOW, Y_HIGH, rise);
+    final double sunY = yc * (h - 1);
+    final double beamGain = (0.75 + 0.25 * this.levelEnv + this.flare * 0.5)
+      * LXUtils.clamp(rise * 3, 0, 1);
+
+    final int nSuns = isCube ? 4 : 2; // one per cube face, two on the cylinder
+    final int half = w / (2 * nSuns);
+
+    for (int s = 0; s < nSuns; ++s) {
+      final int cx = (int) ((s + 0.5) * w / (double) nSuns);
+      for (int dx = -half; dx < half; ++dx) {
+        final int x = ((cx + dx) % w + w) % w;
+        for (int y = 0; y < h; ++y) {
+          final double ddy = sunY - y; // positive above the sun
+          final double r = Math.sqrt(dx * dx + ddy * ddy);
+
+          if (r <= R + 1.5) { // the disc: white core to yellow to orange rim
+            final double u = r / R;
+            final double edge = LXUtils.clamp(R + 1.0 - r, 0, 1);
+            final int c = (u < 0.45) ? core
+              : (u < 0.85) ? LXColor.lerp(body, core,
+                  (float) ((0.85 - u) / 0.40) * 0.5f)
+              : LXColor.lerp(rim, body, (float) LXUtils.clamp((1.0 - u) / 0.15, 0, 1));
+            final double boil = 0.92 + 0.08 * hashd(x * 131 + y * 7 + tq);
+            addPix(o, x, y, c, edge * boil);
+            continue;
+          }
+
+          // warm halo hugging the disc
+          final double halo = Math.exp(-(r - R) / (R * 0.55)) * 0.45;
+          if (halo > 0.02) {
+            addPix(o, x, y, rim, halo);
+          }
+
+          // the beams: thick angled rays, more of them the higher the sun
+          final double ang = Math.atan2(-ddy, dx); // -π/2 = straight up... flip below
+          double bb = 0;
+          boolean white = false;
+          for (int i = 0; i < n; ++i) {
+            if (this.beamVis[i] <= 0) continue;
+            final double d = Math.abs(angDiff(ang, this.beamAng[i]));
+            if (d >= this.beamHw[i]) continue;
+            final double aFall = 1.0 - (d / this.beamHw[i]) * (d / this.beamHw[i]);
+            final double rFall = Math.exp(-1.5 * (r - R) / h);
+            final double v = this.beamVis[i] * aFall * rFall;
+            if (v > bb) {
+              bb = v;
+              white = this.beamWhite[i];
+            }
+          }
+          if (bb > 0.02) {
+            final double tw = 0.85 + 0.15 * hashd(x * 977 + y * 53 + tq * 7);
+            addPix(o, x, y, white ? beamW : beamY,
+              Math.min(1, bb * beamGain * tw * (1 + wow * 0.3)));
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/Superbloom.java
+++ b/src/main/java/apotheneum/piemonte/Superbloom.java
@@ -21,17 +21,10 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class Superbloom extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_FLOWERS = 12;
   private static final double BUD_MS = 900;
@@ -53,10 +46,6 @@ public class Superbloom extends ParameterPattern {
   public final DiscreteParameter flowers =
     new DiscreteParameter("Flowers", 6, 1, MAX_FLOWERS)
     .setDescription("How many flowers live in the garden at once");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -92,7 +81,7 @@ public class Superbloom extends ParameterPattern {
     // Base registers color (garden hue anchor), speed (tempo), size (bloom radius).
     super(lx, 0.5, 0, 1, 0.5, 0, 1);
     addParameter("flowers", this.flowers);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -177,12 +166,10 @@ public class Superbloom extends ParameterPattern {
   }
 
   private boolean detectBeat(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
-    boolean beat = (bass > this.bassAvg * 1.3)
+    boolean beat = pulseHit() || (bass > this.bassAvg * 1.3)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= MIN_BEAT_MS)
       && (bass > 0.01);
@@ -191,7 +178,7 @@ public class Superbloom extends ParameterPattern {
       this.sinceBeatMs = 0;
     }
     // broadband level envelope: snappy attack, easy release
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0)
       : 1 - Math.exp(-deltaMs / 220.0);
@@ -208,7 +195,7 @@ public class Superbloom extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
       this.inited = false;

--- a/src/main/java/apotheneum/piemonte/Superbloom.java
+++ b/src/main/java/apotheneum/piemonte/Superbloom.java
@@ -1,0 +1,431 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * Superbloom — rare rains hit the desert and the whole canvas erupts. Giant
+ * green pixel-chunk buds appear scattered across the surface, swell, then
+ * blossom open into top-down flowers in wild multi-colors all their own: six
+ * species, each with two or three petal colors alternating around the bloom. The open flowers turn with the music — spinning
+ * up as the level swells, pulsing on beats — and after a lifetime each bloom
+ * folds away, its place taken by a fresh bud somewhere new. Wow pushes the
+ * garden into overdrive: harder beat-pulses, shimmering petals, faster unfurl.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class Superbloom extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_FLOWERS = 12;
+  private static final double BUD_MS = 900;
+  private static final double UNFURL_MS = 1500;
+  private static final double WILT_MS = 950;
+  private static final double MIN_BEAT_MS = 150;
+  private static final double TAU = Math.PI * 2;
+
+  // --- the six species: petals, petal sharpness, connected-core size, inner
+  // layer (scale, angular offset; 0 = none), palette hue offsets, center size ---
+  private static final int[]      F_PETALS = {  8,    6,   12,    5,   10,    5  };
+  private static final double[]   F_SHARP  = { 1.8,  3.0,  4.0,  1.2,  2.2,  1.6 };
+  private static final double[]   F_CMIN   = { 0.10, 0.12, 0.08, 0.18, 0.10, 0.15 };
+  private static final double[]   F_INNER  = {  0,   0.55,  0,    0,   0.60, 0.50 };
+  private static final double[][] F_HUES   = { {0, 40}, {0, 150, 210}, {0, 25},
+                                               {0, 180}, {0, 90, 320}, {0, 60} };
+  private static final double[]   F_CENTER = { 0.14, 0.12, 0.22, 0.13, 0.12, 0.16 };
+
+  public final DiscreteParameter flowers =
+    new DiscreteParameter("Flowers", 6, 1, MAX_FLOWERS)
+    .setDescription("How many flowers live in the garden at once");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final boolean wrap;
+    Panel(int[][] idx, int w, int h, boolean wrap) {
+      this.idx = idx; this.w = w; this.h = h; this.wrap = wrap;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  private final int[] fpanel = new int[MAX_FLOWERS];
+  private final int[] ftype = new int[MAX_FLOWERS];
+  private final double[] fx = new double[MAX_FLOWERS];
+  private final double[] fy = new double[MAX_FLOWERS];
+  private final double[] fr = new double[MAX_FLOWERS];    // full-bloom radius
+  private final double[] fage = new double[MAX_FLOWERS];
+  private final double[] flife = new double[MAX_FLOWERS]; // bloom hold duration
+  private final double[] frot = new double[MAX_FLOWERS];
+  private final double[] fdir = new double[MAX_FLOWERS];
+  private final double[] fhue = new double[MAX_FLOWERS]; // each flower's own hue
+  private final double[] fpulse = new double[MAX_FLOWERS];
+  private final boolean[] falive = new boolean[MAX_FLOWERS];
+  private boolean inited = false;
+
+  // audio: level envelope spins the garden, beats make it pulse
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+
+  public Superbloom(LX lx) {
+    // Base registers color (garden hue anchor), speed (tempo), size (bloom radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("flowers", this.flowers);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, false));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int w = o.width();
+      int h = o.height();
+      int[][] g = new int[w][h];
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          g[x][y] = o.point(x, y).index;
+        }
+      }
+      list.add(new Panel(g, w, h, true));
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private void spawn(int i, boolean scatterAge) {
+    // panel weighted by width
+    int total = 0;
+    for (Panel p : this.panels) total += p.w;
+    final double radius = (6 + getSize() * 14) * (0.8 + 0.4 * Math.random());
+
+    // a few placement attempts to avoid piling on a living neighbor
+    int bestPanel = 0;
+    double bestX = 0, bestY = 0, bestScore = -1;
+    for (int attempt = 0; attempt < 8; ++attempt) {
+      int pick = (int) (Math.random() * total);
+      int pi = 0;
+      for (int k = 0; k < this.panels.length; ++k) {
+        pick -= this.panels[k].w;
+        if (pick < 0) { pi = k; break; }
+      }
+      final Panel p = this.panels[pi];
+      final double cx = p.wrap ? Math.random() * p.w
+        : radius * 0.5 + Math.random() * (p.w - radius);
+      final double cy = p.h * (0.22 + Math.random() * 0.56);
+      double nearest = 1e9;
+      for (int k = 0; k < MAX_FLOWERS; ++k) {
+        if (!this.falive[k] || k == i || this.fpanel[k] != pi) continue;
+        double dx = Math.abs(this.fx[k] - cx);
+        if (p.wrap) dx = Math.min(dx, p.w - dx);
+        final double dy = this.fy[k] - cy;
+        nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy) - this.fr[k]);
+      }
+      if (nearest > bestScore) {
+        bestScore = nearest;
+        bestPanel = pi;
+        bestX = cx;
+        bestY = cy;
+      }
+    }
+
+    this.fpanel[i] = bestPanel;
+    this.fx[i] = bestX;
+    this.fy[i] = bestY;
+    this.fr[i] = radius;
+    this.ftype[i] = (int) (Math.random() * F_PETALS.length);
+    this.fhue[i] = Math.random() * 360; // wild-type color, independent of the palette
+    this.flife[i] = 7000 + Math.random() * 7000;
+    this.fage[i] = scatterAge ? Math.random() * (BUD_MS + UNFURL_MS + this.flife[i]) : 0;
+    this.frot[i] = Math.random() * TAU;
+    this.fdir[i] = (Math.random() < 0.5) ? 1 : -1;
+    this.fpulse[i] = 0;
+    this.falive[i] = true;
+  }
+
+  private boolean detectBeat(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    boolean beat = (bass > this.bassAvg * 1.3)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= MIN_BEAT_MS)
+      && (bass > 0.01);
+    this.prevBass = bass;
+    if (beat) {
+      this.sinceBeatMs = 0;
+    }
+    // broadband level envelope: snappy attack, easy release
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+    return beat;
+  }
+
+  private static double smooth(double u) {
+    u = LXUtils.clamp(u, 0, 1);
+    return u * u * (3 - 2 * u);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+      this.inited = false;
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+    if (!this.inited) {
+      for (int i = 0; i < MAX_FLOWERS; ++i) {
+        this.falive[i] = false;
+      }
+      final int n0 = this.flowers.getValuei();
+      for (int i = 0; i < n0; ++i) {
+        spawn(i, true); // staggered ages so the garden isn't synchronized
+      }
+      this.inited = true;
+    }
+
+    final boolean beat = detectBeat(deltaMs);
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    final double dt = deltaMs * (0.4 + speed * 1.6);
+    final int want = this.flowers.getValuei();
+    // rotation: gentle drift, spun up hard by the music
+    final double spin = deltaMs * speed * 0.00055 * (1.0 + this.levelEnv * 3.0 + wow * 0.5);
+
+    int alive = 0;
+    for (int i = 0; i < MAX_FLOWERS; ++i) {
+      if (this.falive[i]) ++alive;
+    }
+
+    for (int i = 0; i < MAX_FLOWERS; ++i) {
+      if (!this.falive[i]) {
+        if (alive < want) {
+          spawn(i, false);
+          ++alive;
+        } else {
+          continue;
+        }
+      } else if (alive > want && this.fage[i] < BUD_MS) {
+        // thin unopened buds when the Flowers knob comes down
+        this.falive[i] = false;
+        --alive;
+        continue;
+      }
+
+      this.fage[i] += dt;
+      this.frot[i] += spin * this.fdir[i];
+      if (beat) {
+        this.fpulse[i] = 1;
+      }
+      this.fpulse[i] *= Math.exp(-deltaMs / 180.0);
+
+      final double totalLife = BUD_MS + UNFURL_MS + this.flife[i] + WILT_MS;
+      if (this.fage[i] >= totalLife) {
+        this.falive[i] = false;
+        spawn(i, false); // a new bud opens somewhere else
+      }
+
+      draw(i, wow);
+    }
+
+    copyExterior();
+  }
+
+  private void draw(int i, double wow) {
+    final Panel p = this.panels[this.fpanel[i]];
+    final int type = this.ftype[i];
+    final double age = this.fage[i];
+    final double pulse = this.fpulse[i] * (0.5 + wow);
+
+    // lifecycle scales
+    double open;   // 0 = closed bud, 1 = fully open
+    double scale;  // overall size envelope
+    if (age < BUD_MS) {
+      open = 0;
+      scale = smooth(age / BUD_MS);
+    } else if (age < BUD_MS + UNFURL_MS) {
+      open = smooth((age - BUD_MS) / (UNFURL_MS / (1.0 + wow * 0.6)));
+      scale = 1;
+    } else if (age < BUD_MS + UNFURL_MS + this.flife[i]) {
+      open = 1;
+      scale = 1;
+    } else {
+      open = 1;
+      final double wt = (age - BUD_MS - UNFURL_MS - this.flife[i]) / WILT_MS;
+      scale = 1 - smooth(wt);
+    }
+    if (scale <= 0.01) return;
+
+    final double R = this.fr[i] * scale * (1.0 + pulse * 0.07);
+    final int petals = F_PETALS[type];
+    final double sharp = F_SHARP[type];
+    final double cmin = F_CMIN[type];
+    final double inner = F_INNER[type];
+    final double[] hues = F_HUES[type];
+    final double centerR = F_CENTER[type] * R;
+
+    // petal palette: this flower's own wild hue plus its species offsets
+    final float flowerHue = (float) this.fhue[i];
+    final int nc = hues.length;
+    final double rot = this.frot[i];
+    final double petalLen = R * (0.25 + 0.75 * open);
+    final double pulseBright = 1.0 + pulse * 0.45;
+    final int centerCol = LXColor.hsb(48, 70, 100); // golden stamen
+
+    // Wow: continued blooming — once open, an extra ring of large petals keeps
+    // growing outward through the bloom hold, reaching further the higher the dial
+    final double holdT = LXUtils.clamp(
+      (age - BUD_MS - UNFURL_MS) / Math.max(1.0, this.flife[i]), 0, 1);
+    final double expand = (wow > 0.05 && open >= 1)
+      ? smooth(LXUtils.clamp(holdT * (1.2 + wow * 1.4), 0, 1)) * wow : 0;
+    final double Rx = R * (1.0 + 0.85 * expand); // expanded reach
+    final double petalLen2 = Rx;
+
+    final int y0 = (int) Math.max(0, Math.floor(this.fy[i] - Rx - 1));
+    final int y1 = (int) Math.min(p.h - 1, Math.ceil(this.fy[i] + Rx + 1));
+    final int x0 = (int) Math.floor(this.fx[i] - Rx - 1);
+    final int x1 = (int) Math.ceil(this.fx[i] + Rx + 1);
+
+    for (int yy = y0; yy <= y1; ++yy) {
+      final double dy = yy - this.fy[i];
+      for (int xx = x0; xx <= x1; ++xx) {
+        final double dx = xx - this.fx[i];
+
+        int c = 0;
+        double b = 0;
+
+        if (open <= 0) {
+          // --- bud: a giant chunky pixel, quantized into blocks ---
+          final double q = Math.max(2, R * 0.16);
+          final double bxq = Math.floor(dx / q) * q + q * 0.5;
+          final double byq = Math.floor(dy / q) * q + q * 0.5;
+          final double budR = R * 0.30;
+          if (Math.max(Math.abs(bxq), Math.abs(byq)) < budR) {
+            final int bi = (int) Math.floor(dx / q) * 7 + (int) Math.floor(dy / q) * 131;
+            final double v = 0.55 + 0.45 * hashd(bi + i * 977);
+            // young buds are green, in blocky shades like unripe growth
+            c = LXColor.hsb((float) (100 + 32 * hashd(bi * 13 + i * 331)),
+              (float) (78 + 17 * hashd(bi * 29 + 5)), 100);
+            b = scale * v * (0.75 + 0.25 * Math.sin(age * 0.006)); // breathing
+          }
+        } else {
+          final double d = Math.sqrt(dx * dx + dy * dy);
+          if (d <= Rx + 1) {
+            final double theta = Math.atan2(dy, dx) - rot;
+            // continued-bloom ring: large petals growing outward past the flower
+            if (expand > 0.02 && d > R * 0.82) {
+              final double aX = (theta + Math.PI / petals) * petals * 0.5;
+              final double prX = Math.pow(Math.abs(Math.cos(aX)), sharp * 0.7);
+              final double edgeX = petalLen2 * (cmin + (1 - cmin) * prX);
+              if (d < edgeX) {
+                final int pidxX = (int) Math.floor((theta + Math.PI / petals) / (TAU / petals) + 0.5);
+                final int ciX = (((pidxX + 2) % nc) + nc) % nc;
+                final double uX = 1 - (d - R * 0.82) / Math.max(1e-3, edgeX - R * 0.82);
+                c = LXColor.hsb((flowerHue + (float) hues[ciX]) % 360,
+                  (float) (78 - 18 * uX), 100);
+                b = (0.30 + 0.55 * smooth(uX)) * pulseBright * expand;
+              }
+            }
+            // outer petal ring
+            double a = theta * petals * 0.5;
+            final double pr = Math.pow(Math.abs(Math.cos(a)), sharp);
+            final double edge = petalLen * (cmin + (1 - cmin) * pr);
+            if (d < edge) {
+              final int pidx = (int) Math.floor(theta / (TAU / petals) + 0.5);
+              final int ci = ((pidx % nc) + nc) % nc;
+              final double u = 1 - d / Math.max(1e-3, edge);
+              c = LXColor.hsb((flowerHue + (float) hues[ci]) % 360, (float) (88 - 20 * u), 100);
+              b = (0.40 + 0.60 * smooth(u * 1.4)) * pulseBright;
+              // vein highlight down the middle of each petal
+              b *= 1.0 + 0.35 * Math.pow(pr, 6);
+            }
+            // inner petal ring, offset half a petal, layered on top
+            if (inner > 0) {
+              final double thetaI = theta + Math.PI / petals;
+              final double ai = thetaI * petals * 0.5;
+              final double pri = Math.pow(Math.abs(Math.cos(ai)), sharp);
+              final double edgeI = petalLen * inner * (cmin + (1 - cmin) * pri);
+              if (d < edgeI) {
+                final int pidx = (int) Math.floor(thetaI / (TAU / petals) + 0.5);
+                final int ci = ((pidx + 1) % nc + nc) % nc;
+                final double u = 1 - d / Math.max(1e-3, edgeI);
+                c = LXColor.hsb((flowerHue + (float) hues[ci]) % 360, (float) (80 - 25 * u), 100);
+                b = (0.55 + 0.45 * smooth(u)) * pulseBright;
+              }
+            }
+            // stamen: warm bright center disc
+            if (d < centerR * (0.4 + 0.6 * open)) {
+              final double u = 1 - d / Math.max(1e-3, centerR);
+              c = LXColor.lerp(centerCol, LXColor.WHITE, (float) (u * 0.5));
+              b = (0.8 + 0.2 * u) * pulseBright;
+            }
+            // petal shimmer at high wow
+            if (b > 0 && wow > 0.3) {
+              b *= 1.0 + (wow - 0.3) * 0.5 * hashd(xx * 131 + yy * 7 + (int) (age * 0.02));
+            }
+          }
+        }
+
+        if (b <= 0.004) continue;
+        int xi = xx;
+        if (xi < 0 || xi >= p.w) {
+          if (!p.wrap) continue;
+          xi = ((xi % p.w) + p.w) % p.w;
+        }
+        final int idx = p.idx[xi][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1)));
+      }
+    }
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+}

--- a/src/main/java/apotheneum/piemonte/TheHumanRace.java
+++ b/src/main/java/apotheneum/piemonte/TheHumanRace.java
@@ -20,18 +20,11 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class TheHumanRace extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int NUM = 2600;         // figure pool
   private static final int CLUSTERS = 44;
@@ -60,10 +53,6 @@ public class TheHumanRace extends ParameterPattern {
   public final CompoundParameter horizon =
     new CompoundParameter("Horizon", 0.14, 0.02, 0.45)
     .setDescription("Where the horizon sits (lower = more landscape, less sky)");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -96,7 +85,7 @@ public class TheHumanRace extends ParameterPattern {
     addParameter("terrain", this.terrain);
     addParameter("specks", this.specks);
     addParameter("horizon", this.horizon);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildCrowd() {
@@ -170,7 +159,7 @@ public class TheHumanRace extends ParameterPattern {
     if (!this.crowdBuilt) {
       buildCrowd();
     }
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
     }

--- a/src/main/java/apotheneum/piemonte/TheHumanRace.java
+++ b/src/main/java/apotheneum/piemonte/TheHumanRace.java
@@ -1,0 +1,301 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * TheHumanRace — a vast landscape scattered with little glowing stick figures,
+ * gathered in loose bunches and stretching to a horizon. A slow camera drifts
+ * and pans across them, and because each face of the sculpture looks out in its
+ * own direction the crowd wraps around you in a 360 degree panorama. Most figures
+ * glow pale blue-white; a few are vivid specks. They sway as if walking.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class TheHumanRace extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int NUM = 2600;         // figure pool
+  private static final int CLUSTERS = 44;
+  private static final double AREA = 70;       // half-size of the field (world units)
+  private static final double PERIOD = 2 * AREA; // toroidal wrap so the camera glides forever
+  private static final double NEAR = 1.0;
+  private static final double H_EYE = 2.6;     // camera height above the ground
+  private static final double GLIDE = 0.005;   // world units / ms at speed 1
+  private static final double FAR = 46;        // distance where the crowd fogs out
+  private static final double TERR_FREQ = 0.055; // terrain feature scale
+  private static final double TERR_MAXH = 4.5;   // max hill/mountain height (world units)
+  private static final float PALE_SAT = 22;
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 2200, 200, NUM)
+    .setDescription("How many figures are drawn");
+
+  public final CompoundParameter terrain =
+    new CompoundParameter("Terrain", 0.6, 0, 1)
+    .setDescription("Height of the hills and mountains");
+
+  public final CompoundParameter specks =
+    new CompoundParameter("Specks", 0.15, 0, 1)
+    .setDescription("Fraction of figures that are vivid colored specks");
+
+  public final CompoundParameter horizon =
+    new CompoundParameter("Horizon", 0.14, 0.02, 0.45)
+    .setDescription("Where the horizon sits (lower = more landscape, less sky)");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final double facing; // world yaw this panel looks toward
+    Panel(int[][] idx, int w, int h, double facing) {
+      this.idx = idx; this.w = w; this.h = h; this.facing = facing;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  // crowd (built once)
+  private final double[] fx = new double[NUM];
+  private final double[] fz = new double[NUM];
+  private final double[] speckHue = new double[NUM];
+  private final double[] speckRand = new double[NUM];
+  private final double[] wphase = new double[NUM];
+  private final double[] wspeed = new double[NUM];
+  private final double[] fh = new double[NUM]; // terrain height under each figure
+  private boolean crowdBuilt = false;
+
+  private double camX = 0, camZ = 0, timeMs = 0;
+
+  public TheHumanRace(LX lx) {
+    // Base registers color (crowd tint), speed (camera + walk), size (figure size).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("terrain", this.terrain);
+    addParameter("specks", this.specks);
+    addParameter("horizon", this.horizon);
+    addParameter("target", this.target);
+  }
+
+  private void buildCrowd() {
+    double[] cxs = new double[CLUSTERS];
+    double[] czs = new double[CLUSTERS];
+    for (int c = 0; c < CLUSTERS; ++c) {
+      cxs[c] = (Math.random() * 2 - 1) * AREA;
+      czs[c] = (Math.random() * 2 - 1) * AREA;
+    }
+    for (int i = 0; i < NUM; ++i) {
+      if (Math.random() < 0.8) {
+        int c = (int) (Math.random() * CLUSTERS);
+        double sigma = 4 + Math.random() * 8;
+        this.fx[i] = cxs[c] + (Math.random() - Math.random()) * sigma;
+        this.fz[i] = czs[c] + (Math.random() - Math.random()) * sigma;
+      } else {
+        this.fx[i] = (Math.random() * 2 - 1) * AREA;
+        this.fz[i] = (Math.random() * 2 - 1) * AREA;
+      }
+      this.fh[i] = Noise.stb_perlin_fbm_noise3(
+        (float) (this.fx[i] * TERR_FREQ), (float) (this.fz[i] * TERR_FREQ), 0f, 2f, 0.5f, 4);
+      this.speckHue[i] = Math.random();
+      this.speckRand[i] = Math.random();
+      this.wphase[i] = Math.random() * Math.PI * 2;
+      this.wspeed[i] = 0.002 + Math.random() * 0.004;
+    }
+    this.crowdBuilt = true;
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      Apotheneum.Cube.Face[] faces = Apotheneum.cube.exterior.faces;
+      for (int f = 0; f < faces.length; ++f) {
+        int w = faces[f].columns.length;
+        int h = faces[f].columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = faces[f].columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, f * Math.PI / 2));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int q = o.width() / 4;
+      int h = o.height();
+      for (int seg = 0; seg < 4; ++seg) {
+        int[][] g = new int[q][h];
+        for (int x = 0; x < q; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = o.point(seg * q + x, y).index;
+          }
+        }
+        list.add(new Panel(g, q, h, seg * Math.PI / 2));
+      }
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private static double wrap(double d) {
+    return d - PERIOD * Math.rint(d / PERIOD);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    if (!this.crowdBuilt) {
+      buildCrowd();
+    }
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+
+    final double speed = Math.max(0.02, getSpeed());
+    // Wow = festival: the crowd dances harder, more vivid figures light up,
+    // and the camera sweeps faster through them
+    final double wow = getWow();
+    final double dtS = speed * deltaMs * (1 + wow * 0.6);
+    this.timeMs += deltaMs;
+    this.camZ += GLIDE * dtS * (1 + wow);           // glide forward
+    this.camX = 18 * Math.sin(this.timeMs * 0.00005 * (1 + wow)); // side drift
+    final double baseYaw = 0.35 * Math.sin(this.timeMs * 0.00008); // gentle pan
+
+    // advance the walk cycle
+    final int count = this.density.getValuei();
+    for (int i = 0; i < count; ++i) {
+      this.wphase[i] += this.wspeed[i] * dtS;
+    }
+
+    final double baseHue = LXColor.h(getColor());
+    final double specksFrac = Math.min(1, this.specks.getValue() * (1 + wow * 3));
+    final double sizeF = 0.5 + getSize() * 1.5;
+    final double terrScale = this.terrain.getValue() * TERR_MAXH;
+
+    for (Panel p : this.panels) {
+      final double yaw = p.facing + baseYaw;
+      final double cyaw = Math.cos(yaw), syaw = Math.sin(yaw);
+      final double horizon = p.h * this.horizon.getValue();
+      final double focV = p.h * 0.6;
+      // dim cool glow line along the horizon (figures draw over it)
+      int hy = (int) horizon;
+      for (int gy = Math.max(0, hy - 2); gy <= Math.min(p.h - 1, hy + 2); ++gy) {
+        double gg = Math.exp(-((gy - horizon) * (gy - horizon)) / (2 * 1.2 * 1.2));
+        int gc = LXColor.hsb(225, 30, (float) (16 * gg));
+        for (int gx = 0; gx < p.w; ++gx) {
+          this.colors[p.idx[gx][gy]] = LXColor.lightest(this.colors[p.idx[gx][gy]], gc);
+        }
+      }
+      for (int i = 0; i < count; ++i) {
+        double dx = wrap(this.fx[i] - this.camX);
+        double dz = wrap(this.fz[i] - this.camZ);
+        double fwd = dx * syaw + dz * cyaw;
+        if (fwd <= NEAR || fwd > FAR) continue; // fog cull the far crowd
+        double rightRatio = (dx * cyaw - dz * syaw) / fwd;
+        if (rightRatio < -1.05 || rightRatio > 1.05) continue;
+
+        double px = (0.5 + 0.5 * rightRatio) * p.w;
+        // figures stand on terrain: hills lift them toward/over the horizon, valleys drop them
+        double pyBase = horizon + ((H_EYE - this.fh[i] * terrScale) / fwd) * focV;
+        double figH = (1.7 / fwd) * focV * sizeF;
+        if (pyBase - figH > p.h - 1 || pyBase < -figH) continue; // off panel
+        // distance fog: near figures full, fading out toward FAR (no bright horizon bunch)
+        double fogT = LXUtils.clamp((FAR - fwd) / (FAR - NEAR) * 1.3, 0, 1);
+        double bright = Math.pow(fogT, 1.8) * (0.75 + 0.5 * this.speckRand[i]);
+
+        boolean speck = this.speckRand[i] < specksFrac;
+        int color;
+        if (speck) {
+          color = LXColor.hsb((float) (this.speckHue[i] * 360), 85, 100);
+        } else {
+          color = LXColor.hsb((float) baseHue, PALE_SAT, 100);
+          // cool-grade the distant crowd toward a hazy blue
+          double far = 1.0 - fogT;
+          color = LXColor.lerp(color, LXColor.hsb(225, 40, 70), (float) (0.6 * far));
+        }
+
+        drawFigure(p, px, pyBase, figH, bright, color, this.wphase[i]);
+      }
+    }
+
+    copyExterior();
+  }
+
+  private void drawFigure(Panel p, double px, double py, double h,
+      double bright, int color, double wphase) {
+    if (h < 2.5) {
+      splat(p, px, py - 0.4, 0.55 + h * 0.22, bright, color);
+      return;
+    }
+    final double r = Math.max(0.55, h * 0.05);
+    final double headR = h * 0.16;
+    final double headCy = py - h * 0.86;
+    final double hipY = py - h * 0.40;
+    final double shoulderY = headCy + headR + h * 0.06;
+    final double sway = Math.sin(wphase) * h * (0.13 + getWow() * 0.14); // dancing at high Wow
+
+    splat(p, px, headCy, headR, bright, color);                       // head
+    line(p, px, headCy + headR, px, hipY, r, bright, color);          // torso
+    line(p, px, hipY, px - h * 0.14 + sway, py, r, bright, color);    // left leg
+    line(p, px, hipY, px + h * 0.14 - sway, py, r, bright, color);    // right leg
+    line(p, px, shoulderY, px - h * 0.20 - sway, shoulderY + h * 0.16, r, bright, color); // left arm
+    line(p, px, shoulderY, px + h * 0.20 + sway, shoulderY + h * 0.16, r, bright, color); // right arm
+  }
+
+  private void line(Panel p, double x0, double y0, double x1, double y1,
+      double r, double bright, int color) {
+    double dx = x1 - x0, dy = y1 - y0;
+    int steps = (int) Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)));
+    if (steps < 1) steps = 1;
+    for (int k = 0; k <= steps; ++k) {
+      double t = (double) k / steps;
+      splat(p, x0 + dx * t, y0 + dy * t, r, bright, color);
+    }
+  }
+
+  private void splat(Panel p, double x, double y, double r, double bright, int color) {
+    int y0 = (int) Math.max(0, Math.floor(y - r));
+    int y1 = (int) Math.min(p.h - 1, Math.ceil(y + r));
+    int x0 = (int) Math.max(0, Math.floor(x - r));
+    int x1 = (int) Math.min(p.w - 1, Math.ceil(x + r));
+    for (int yy = y0; yy <= y1; ++yy) {
+      double ddy = yy - y;
+      for (int xx = x0; xx <= x1; ++xx) {
+        double ddx = xx - x;
+        double dd = Math.sqrt(ddx * ddx + ddy * ddy);
+        if (dd > r) continue;
+        double f = (1.0 - dd / r) * bright;
+        if (f <= 0) continue;
+        int idx = p.idx[xx][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx], LXColor.scaleBrightness(color, (float) f));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/TunnelVision.java
+++ b/src/main/java/apotheneum/piemonte/TunnelVision.java
@@ -23,17 +23,10 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 
 @LXCategory("Apotheneum/piemonte")
 public class TunnelVision extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final int MAX_CHAINS = 64;
   private static final int MAX_RINGS = 18;
@@ -56,10 +49,6 @@ public class TunnelVision extends ParameterPattern {
   public final CompoundParameter sensitivity =
     new CompoundParameter("Sens", 0.5, 0, 1)
     .setDescription("How readily the music opens new tunnels");
-
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
 
   private static final class Panel {
     final int[][] idx;
@@ -93,14 +82,12 @@ public class TunnelVision extends ParameterPattern {
 
   /** Returns onset strength 0..1, or -1 if no beat this frame. */
   private double detect(double deltaMs) {
-    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
-    int nb = Math.max(1, m.numBands);
-    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    double bass = this.level.getValue();
     this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
     this.sinceBeatMs += deltaMs;
     double sens = this.sensitivity.getValue();
     double threshold = 1.05 + (1 - sens) * 0.7;
-    boolean beat = (bass > this.bassAvg * threshold)
+    boolean beat = pulseHit() || (bass > this.bassAvg * threshold)
       && (bass > this.prevBass)
       && (this.sinceBeatMs >= 140)
       && (bass > 0.01);
@@ -115,7 +102,7 @@ public class TunnelVision extends ParameterPattern {
       // no music: relax back to the reference cadence
       this.beatPeriodMs += (REF_BEAT_MS - this.beatPeriodMs) * (1 - Math.exp(-deltaMs / 2000.0));
     }
-    double level = m.getAveragef(0, nb);
+    double level = this.level.getValue();
     double alpha = (level > this.levelEnv)
       ? 1 - Math.exp(-deltaMs / 25.0)
       : 1 - Math.exp(-deltaMs / 220.0);
@@ -129,7 +116,7 @@ public class TunnelVision extends ParameterPattern {
     addParameter("chains", this.chains);
     addParameter("rings", this.rings);
     addParameter("sensitivity", this.sensitivity);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   private void buildPanels(Target t) {
@@ -212,7 +199,7 @@ public class TunnelVision extends ParameterPattern {
   protected void render(double deltaMs) {
     setColors(LXColor.BLACK);
 
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
     if (this.panels == null || this.builtTarget != t) {
       buildPanels(t);
       this.inited = false;

--- a/src/main/java/apotheneum/piemonte/TunnelVision.java
+++ b/src/main/java/apotheneum/piemonte/TunnelVision.java
@@ -1,0 +1,370 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * TunnelVision — vertical tunnels of glowing hoops climb the surfaces. Each
+ * chain draws upward ring by ring from its base — every ring smaller and
+ * closer than the last, a tunnel receding into the sky — hangs complete for a
+ * beat, then collapses in the same order. The music runs the show: bass
+ * onsets punch new tunnels open (hard hits open several at once) and the
+ * louder it gets the more tunnels climb at once. A soft glint sweeps around
+ * each hoop; Wow opens more tunnels, drives the cadence, and sharpens the
+ * shine. In silence a few tunnels keep drawing on their own.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class TunnelVision extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final int MAX_CHAINS = 64;
+  private static final int MAX_RINGS = 18;
+  private static final double PERSP = 0.91;     // per-ring shrink into the tunnel
+  private static final double STAGGER_MS = 90;  // per-ring delay along the chain
+  private static final double GROW_MS = 150;    // ring pop-in
+  private static final double HOLD_MS = 550;    // complete chain hangs here
+  private static final double SHRINK_MS = 240;  // ring collapse
+  private static final double REF_BEAT_MS = 550; // lifecycle reference tempo (~109 BPM)
+  private static final double TAU = Math.PI * 2;
+
+  public final DiscreteParameter chains =
+    new DiscreteParameter("Chains", 36, 4, MAX_CHAINS)
+    .setDescription("How many hoop chains are alive at once");
+
+  public final DiscreteParameter rings =
+    new DiscreteParameter("Rings", 12, 4, MAX_RINGS)
+    .setDescription("Hoops per chain");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("How readily the music opens new tunnels");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private static final class Panel {
+    final int[][] idx;
+    final int w, h;
+    final boolean wrap;
+    Panel(int[][] idx, int w, int h, boolean wrap) {
+      this.idx = idx; this.w = w; this.h = h; this.wrap = wrap;
+    }
+  }
+
+  private Panel[] panels;
+  private Target builtTarget;
+
+  private final int[] cpanel = new int[MAX_CHAINS];
+  private final double[] cx0 = new double[MAX_CHAINS];
+  private final double[] cy0 = new double[MAX_CHAINS];
+  private final double[] cdir = new double[MAX_CHAINS];
+  private final double[] cslope = new double[MAX_CHAINS];
+  private final double[] cspace = new double[MAX_CHAINS];
+  private final double[] cage = new double[MAX_CHAINS];
+  private final double[] cwait = new double[MAX_CHAINS]; // respawn delay
+  private final int[] cn = new int[MAX_CHAINS];
+  private final boolean[] calive = new boolean[MAX_CHAINS];
+  private boolean inited = false;
+  private double timeMs = 0;
+
+  // audio: tunnels open on bass onsets, population swells with the level
+  private double bassAvg, prevBass, sinceBeatMs = 1e9;
+  private double levelEnv = 0;
+  private double beatPeriodMs = REF_BEAT_MS; // tracked tempo: EMA of onset spacing
+
+  /** Returns onset strength 0..1, or -1 if no beat this frame. */
+  private double detect(double deltaMs) {
+    heronarts.lx.audio.GraphicMeter m = this.lx.engine.audio.meter;
+    int nb = Math.max(1, m.numBands);
+    double bass = m.getAveragef(0, Math.max(1, nb / 4));
+    this.bassAvg += (bass - this.bassAvg) * (1 - Math.exp(-deltaMs / 400.0));
+    this.sinceBeatMs += deltaMs;
+    double sens = this.sensitivity.getValue();
+    double threshold = 1.05 + (1 - sens) * 0.7;
+    boolean beat = (bass > this.bassAvg * threshold)
+      && (bass > this.prevBass)
+      && (this.sinceBeatMs >= 140)
+      && (bass > 0.01);
+    double ratio = LXUtils.clamp((bass / Math.max(1e-4, this.bassAvg) - 1.0) / 1.5, 0, 1);
+    this.prevBass = bass;
+    if (beat) {
+      // track the tempo: smooth the spacing between onsets (clamped to sane BPM)
+      double interval = LXUtils.clamp(this.sinceBeatMs, 240, 1500);
+      this.beatPeriodMs += (interval - this.beatPeriodMs) * 0.25;
+      this.sinceBeatMs = 0;
+    } else if (this.sinceBeatMs > 4000) {
+      // no music: relax back to the reference cadence
+      this.beatPeriodMs += (REF_BEAT_MS - this.beatPeriodMs) * (1 - Math.exp(-deltaMs / 2000.0));
+    }
+    double level = m.getAveragef(0, nb);
+    double alpha = (level > this.levelEnv)
+      ? 1 - Math.exp(-deltaMs / 25.0)
+      : 1 - Math.exp(-deltaMs / 220.0);
+    this.levelEnv += (level - this.levelEnv) * alpha;
+    return beat ? ratio : -1;
+  }
+
+  public TunnelVision(LX lx) {
+    // Base registers color (hoop tint), speed (sequence tempo), size (hoop radius).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("chains", this.chains);
+    addParameter("rings", this.rings);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("target", this.target);
+  }
+
+  private void buildPanels(Target t) {
+    java.util.List<Panel> list = new java.util.ArrayList<>();
+    if (t != Target.CYLINDER) {
+      for (Apotheneum.Cube.Face face : Apotheneum.cube.exterior.faces) {
+        int w = face.columns.length;
+        int h = face.columns[0].points.length;
+        int[][] g = new int[w][h];
+        for (int x = 0; x < w; ++x) {
+          for (int y = 0; y < h; ++y) {
+            g[x][y] = face.columns[x].points[y].index;
+          }
+        }
+        list.add(new Panel(g, w, h, false));
+      }
+    }
+    if (t != Target.CUBE) {
+      Apotheneum.Orientation o = Apotheneum.cylinder.exterior;
+      int w = o.width();
+      int h = o.height();
+      int[][] g = new int[w][h];
+      for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+          g[x][y] = o.point(x, y).index;
+        }
+      }
+      list.add(new Panel(g, w, h, true)); // seamless around the cylinder
+    }
+    this.panels = list.toArray(new Panel[0]);
+    this.builtTarget = t;
+  }
+
+  private void spawn(int i) {
+    // pick a panel weighted by width so the cylinder gets its share
+    int total = 0;
+    for (Panel p : this.panels) total += p.w;
+    int pick = (int) (Math.random() * total);
+    int pi = 0;
+    for (int k = 0; k < this.panels.length; ++k) {
+      pick -= this.panels[k].w;
+      if (pick < 0) { pi = k; break; }
+    }
+    final Panel p = this.panels[pi];
+    final int n = this.rings.getValuei();
+    final double baseR = ringRadius(p);
+    // wider spacing relative to the small hoops stretches the tunnel tall
+    final double space = baseR * (1.1 + Math.random() * 0.5);
+
+    this.cpanel[i] = pi;
+    // vertical tunnels: rings stack upward with a slight lateral lean
+    this.cdir[i] = (Math.random() < 0.5) ? 1 : -1;
+    this.cslope[i] = (Math.random() - 0.5) * 0.22; // lateral drift per step
+    this.cspace[i] = space;
+    this.cn[i] = n;
+    if (p.wrap) {
+      this.cx0[i] = Math.random() * p.w;
+    } else {
+      double margin = baseR + 1;
+      this.cx0[i] = (p.w > 2 * margin)
+        ? margin + Math.random() * (p.w - 2 * margin) : p.w * 0.5;
+    }
+    // base ring near the floor; the chain draws upward from here
+    this.cy0[i] = p.h * (0.72 + Math.random() * 0.20);
+    this.cage[i] = 0;
+    this.calive[i] = true;
+  }
+
+  private double ringRadius(Panel p) {
+    // small hoops so many tunnels fit per face
+    return (0.035 + getSize() * 0.075) * Math.min(p.w, p.h) + 1;
+  }
+
+  private static double smooth(double u) {
+    u = LXUtils.clamp(u, 0, 1);
+    return u * u * (3 - 2 * u);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+
+    final Target t = this.target.getEnum();
+    if (this.panels == null || this.builtTarget != t) {
+      buildPanels(t);
+      this.inited = false;
+    }
+    if (this.panels.length == 0) {
+      return;
+    }
+    if (!this.inited) {
+      for (int i = 0; i < MAX_CHAINS; ++i) {
+        this.calive[i] = false;
+        this.cwait[i] = Math.random() * 800;
+      }
+      this.inited = true;
+    }
+
+    this.timeMs += deltaMs;
+    final double speed = Math.max(0.02, getSpeed());
+    final double wow = getWow();
+    // lifecycle clock follows the music's tempo: faster track, faster tunnels
+    final double tempoScale = REF_BEAT_MS / this.beatPeriodMs;
+    final double dt = deltaMs * (0.4 + speed * 1.6) * (1.0 + wow * 0.6) * tempoScale;
+    final int base = getColor();
+    final int hoop = LXColor.lerp(base, LXColor.WHITE, 0.35f);
+    final int hot = LXColor.lerp(base, LXColor.WHITE, 0.85f);
+    final double onset = detect(deltaMs);
+    final boolean quiet = this.levelEnv < 0.04;
+    // the music sets the population: level raises the ceiling, Wow raises it more
+    final int want = Math.min(MAX_CHAINS, this.chains.getValuei()
+      + (int) Math.round(this.levelEnv * 14 + wow * 10));
+    final double glintAmt = 0.35 + wow * 0.65;
+    final double ga = this.timeMs * 0.0012; // glint sweep angle
+
+    int active = 0;
+    for (int i = 0; i < MAX_CHAINS; ++i) {
+      if (this.calive[i]) ++active;
+    }
+
+    // bass onsets punch new tunnels open, harder hits open several at once
+    if (onset >= 0) {
+      int burst = 2 + (int) Math.round(onset * 5 + wow * 3);
+      for (int i = 0; i < MAX_CHAINS && burst > 0 && active < want; ++i) {
+        if (!this.calive[i]) {
+          spawn(i);
+          ++active;
+          --burst;
+        }
+      }
+    }
+
+    for (int i = 0; i < MAX_CHAINS; ++i) {
+      if (!this.calive[i]) {
+        // in silence, a gentle timer keeps a few tunnels drawing
+        if (quiet && active < this.chains.getValuei()) {
+          this.cwait[i] -= dt;
+          if (this.cwait[i] <= 0) {
+            spawn(i);
+            ++active;
+          }
+        }
+        continue;
+      }
+
+      this.cage[i] += dt;
+      final int n = this.cn[i];
+      final double collapseStart = n * STAGGER_MS + GROW_MS + HOLD_MS;
+      final double deathAt = collapseStart + n * STAGGER_MS + SHRINK_MS;
+      if (this.cage[i] >= deathAt) {
+        this.calive[i] = false;
+        this.cwait[i] = 300 + Math.random() * 900;
+        --active;
+        continue;
+      }
+
+      final Panel p = this.panels[this.cpanel[i]];
+      final double baseR = ringRadius(p);
+      double cx = this.cx0[i];
+      double cy = this.cy0[i];
+      double r = baseR;
+      double space = this.cspace[i];
+
+      for (int k = 0; k < n; ++k) {
+        final double tb = this.cage[i] - k * STAGGER_MS;
+        double sc = 0;
+        double flash = 0;
+        if (tb > 0) {
+          sc = smooth(tb / GROW_MS);
+          flash = Math.exp(-tb / 140.0); // birth pop
+          final double tc = this.cage[i] - collapseStart - k * STAGGER_MS;
+          if (tc > 0) {
+            final double c = 1.0 - tc / SHRINK_MS;
+            if (c <= 0) {
+              sc = 0;
+            } else {
+              sc *= smooth(c);
+              flash = Math.max(flash, 0.7 * (1.0 - c)); // brighten as it collapses
+            }
+          }
+        }
+        if (sc > 0.02) {
+          final double rr = r * sc;
+          final int col = (flash > 0.25) ? hot : hoop;
+          final double bright = LXUtils.clamp(0.85 + flash * 0.9, 0, 1.75);
+          ring(p, cx, cy, rr, 1.15, bright, col, ga + k * 0.9, glintAmt);
+          if (rr > 4.5) {
+            // inner rim doubles the hoop, like an LED ring inside its frame
+            ring(p, cx, cy, rr * 0.80, 0.9, bright * 0.45, hoop, ga + k * 0.9 + Math.PI, glintAmt * 0.6);
+          }
+        }
+        // step up the tunnel: rings stack vertically with a slight lean
+        cx += this.cslope[i] * space;
+        cy -= space;
+        r *= PERSP;
+        space *= PERSP;
+      }
+    }
+
+    copyExterior();
+  }
+
+  /** Draw a hoop outline with a rotating glint highlight. */
+  private void ring(Panel p, double cx, double cy, double r, double th,
+      double bright, int color, double glintAngle, double glintAmt) {
+    final int y0 = (int) Math.max(0, Math.floor(cy - r - th));
+    final int y1 = (int) Math.min(p.h - 1, Math.ceil(cy + r + th));
+    final int x0 = (int) Math.floor(cx - r - th);
+    final int x1 = (int) Math.ceil(cx + r + th);
+    final double gc = Math.cos(glintAngle), gs = Math.sin(glintAngle);
+    for (int yy = y0; yy <= y1; ++yy) {
+      final double dy = yy - cy;
+      for (int xx = x0; xx <= x1; ++xx) {
+        final double dx = xx - cx;
+        final double d = Math.sqrt(dx * dx + dy * dy);
+        final double band = 1.0 - Math.abs(d - r) / th;
+        if (band <= 0) continue;
+        double f = Math.pow(band, 1.6) * bright;
+        // specular glint sweeping around the hoop
+        if (d > 1e-3) {
+          final double ca = (dx * gc + dy * gs) / d;
+          if (ca > 0) {
+            f *= 1.0 + glintAmt * ca * ca * ca * ca;
+          }
+        }
+        if (f <= 0.004) continue;
+        int xi = xx;
+        if (xi < 0 || xi >= p.w) {
+          if (!p.wrap) continue;
+          xi = ((xi % p.w) + p.w) % p.w;
+        }
+        final int idx = p.idx[xi][yy];
+        this.colors[idx] = LXColor.lightest(this.colors[idx],
+          LXColor.scaleBrightness(color, (float) LXUtils.clamp(f, 0, 1)));
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -209,6 +209,9 @@ public class UFOAbduction extends StrandPattern {
         this.collapseT = -1;
         this.cube.reset();
         this.cylinder.reset();
+        // drop queued staggered spawns too, so a wave launched just before
+        // the collapse can't fire into the clean relaunch
+        java.util.Arrays.fill(this.pendAlive, false);
         this.relaunchQueued = true;
       }
     } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
@@ -226,8 +229,15 @@ public class UFOAbduction extends StrandPattern {
       final double strength = this.relaunchQueued ? 1.0
         : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
       final int n = this.lanes.getValuei();
-      launchWave(this.cube, true, n, strength, this.relaunchQueued);
-      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      // only feed the surfaces actually being rendered — a hidden target
+      // would otherwise pile up frozen heads at their spawn points
+      final Target t = getTarget();
+      if (t != Target.CYLINDER) {
+        launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      }
+      if (t != Target.CUBE) {
+        launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      }
       this.relaunchQueued = false;
     }
     this.launchFlash *= Math.exp(-deltaMs / 160.0);

--- a/src/main/java/apotheneum/piemonte/UFOAbduction.java
+++ b/src/main/java/apotheneum/piemonte/UFOAbduction.java
@@ -1,0 +1,373 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * UFOAbduction — beat-locked counter-propagating waves on strand lanes. On every
+ * beat, green blocks launch upward from the floor at full speed, decelerate
+ * as they pass through the center — slowing to a crawl but never stopping,
+ * fattening into chunky bright slabs — then accelerate back to launch speed
+ * as they exit the top, like waves passing through a dense medium. Red
+ * streaks run the other way, top to floor, threading through the risers.
+ * Tails stretch with speed: long streamers at the edges, short stubs through
+ * the slow center; white-hot cores at speed. Lanes fire in synchronized
+ * clusters, the palette snaps between green-dominant, red-dominant, and
+ * mixed sections, and a big drop collapses the field to black before
+ * slamming a fresh wave up every lane. Modeled on the wave.mov reference.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Apotheneum/piemonte")
+public class UFOAbduction extends StrandPattern {
+
+  private static final int MAX_HEADS = 96;
+  private static final double GREEN_HUE = 120;
+  private static final double RED_HUE = 10;
+  // calibrated from wave.mov: 800ms transit = 165ms entry + 565ms center stall
+  // + 65ms exit burst; stall:exit velocity ratio ~1:36; 900ms launch cadence
+  private static final double V_ENTRY = 0.00135;  // heights/ms, bottom leg
+  private static final double V_STALL = 0.00024;  // crawl through the center
+  private static final double V_EXIT = 0.0075;    // explosive top exit
+  private static final double V_RED = 0.0011;     // ~0.9s full-height descent
+  private static final double STALL_LO = 0.60;    // stall band (y, 0 = top)
+  private static final double STALL_HI = 0.44;
+  private static final double EXIT_AT = 0.30;     // full burst above here
+  private static final double IDLE_WAVE_MS = 900; // measured launch cadence
+  private static final double SECTION_MS = 4500;  // palette section length
+  private static final double COLLAPSE_MS = 450;
+
+  public final DiscreteParameter lanes =
+    new DiscreteParameter("Lanes", 14, 6, 24)
+    .setDescription("Strand lanes around the surface");
+
+  public final CompoundParameter sensitivity =
+    new CompoundParameter("Sens", 0.5, 0, 1)
+    .setDescription("Audio sensitivity of launches and drops");
+
+  public final CompoundParameter glow =
+    new CompoundParameter("Glow", 0.6, 0, 1)
+    .setDescription("How far the blocks radiate light");
+
+  public final CompoundParameter trail =
+    new CompoundParameter("Trail", 0.5, 0, 1)
+    .setDescription("How long the gradient tails stream behind");
+
+  private final class Surface {
+    boolean inited;
+    final int[] lane = new int[MAX_HEADS];
+    final double[] y = new double[MAX_HEADS];     // normalized 0..1, 0 = top
+    final double[] v = new double[MAX_HEADS];     // heights/ms, +down -up
+    final boolean[] isRed = new boolean[MAX_HEADS];
+    final boolean[] thin = new boolean[MAX_HEADS]; // single-line red beams
+    final boolean[] waveR = new boolean[MAX_HEADS]; // reds riding the stall profile
+    final boolean[] alive = new boolean[MAX_HEADS];
+    void reset() {
+      for (int i = 0; i < MAX_HEADS; ++i) this.alive[i] = false;
+      this.inited = true;
+    }
+    void spawn(int lane, boolean red) {
+      for (int i = 0; i < MAX_HEADS; ++i) {
+        if (this.alive[i]) continue;
+        this.lane[i] = lane;
+        this.isRed[i] = red;
+        this.thin[i] = red && Math.random() < 0.5;
+        // half the single lines mirror the risers' stall trajectory downward;
+        // the rest plummet straight to the floor
+        this.waveR[i] = red && this.thin[i] && Math.random() < 0.5;
+        if (red) {
+          this.y[i] = -0.02 - Math.random() * 0.08;
+          this.v[i] = this.waveR[i]
+            ? (0.9 + Math.random() * 0.2) // variance factor for the profile
+            : V_RED * (0.9 + Math.random() * 0.25) * (this.thin[i] ? 1.25 : 1.0);
+        } else {
+          this.y[i] = 1.02 + Math.random() * 0.10;
+          this.v[i] = -(0.75 + Math.random() * 0.5); // wide variance staggers the field
+        }
+        this.alive[i] = true;
+        return;
+      }
+    }
+  }
+
+  private final Surface cube = new Surface();
+  private final Surface cylinder = new Surface();
+  private double waveTimer = 0;
+  private double launchFlash = 0;
+  private double collapseT = -1;
+  private boolean relaunchQueued = false;
+  private int section = 0;
+
+  public UFOAbduction(LX lx) {
+    // Base registers color (hue shift), speed (cadence + velocity), size (block thickness).
+    super(lx, 0.5, 0, 1, 0.5, 0, 1);
+    addParameter("lanes", this.lanes);
+    addParameter("sensitivity", this.sensitivity);
+    addParameter("glow", this.glow);
+    addParameter("trail", this.trail);
+    addTargetParameter();
+  }
+
+  @Override
+  protected double beatThreshold() {
+    return 1.05 + (1 - this.sensitivity.getValue()) * 0.7;
+  }
+
+  /** Measured rise profile: brisk entry, long center stall, explosive exit. */
+  private static double riseProfile(double y) {
+    if (y > STALL_LO) {
+      final double u = LXUtils.clamp((y - STALL_LO) / 0.10, 0, 1);
+      return LXUtils.lerp(V_STALL, V_ENTRY, u * u * (3 - 2 * u));
+    } else if (y > STALL_HI) {
+      return V_STALL;
+    }
+    final double u = LXUtils.clamp((STALL_HI - y) / (STALL_HI - EXIT_AT), 0, 1);
+    return LXUtils.lerp(V_STALL, V_EXIT, u * u * (3 - 2 * u));
+  }
+
+  private static double hashd(int n) {
+    int h = n * 374761393;
+    h = (h ^ (h >>> 13)) * 1103515245;
+    h ^= (h >>> 16);
+    return (h & 0x7fffffff) / (double) 0x7fffffff;
+  }
+
+  /** Section palette mode: 0 = green-dominant, 1 = red-dominant, 2 = mixed. */
+  private int sectionMode() {
+    final double r = hashd(this.section * 613 + 29);
+    return (r < 0.42) ? 0 : (r < 0.68 ? 1 : 2);
+  }
+
+  // pending staggered spawns for launch wipes (lane, color, delay)
+  private final int[] pendLane = new int[MAX_HEADS];
+  private final boolean[] pendRed = new boolean[MAX_HEADS];
+  private final double[] pendMs = new double[MAX_HEADS];
+  private final boolean[] pendCube = new boolean[MAX_HEADS];
+  private final boolean[] pendAlive = new boolean[MAX_HEADS];
+
+  private void launchWave(Surface s, boolean isCube, int nLanes, double strength, boolean forceAll) {
+    final int mode = sectionMode();
+    final double redFrac = (mode == 0) ? 0.20 : (mode == 1 ? 0.75 : 0.5);
+    // per-event wipe: 0 = global, 1 = left->right, 2 = right->left, 3 = edges->center
+    final int wipe = (int) (hashd((int) (this.timeMs * 7) + 31) * 4);
+    for (int l = 0; l < nLanes; ++l) {
+      final int cluster = l / 3;
+      final double on = hashd(this.section * 977 + cluster * 131 + (int) (this.timeMs / 400));
+      if (!forceAll && on > 0.40 + strength * 0.55) continue;
+      final boolean red = hashd(this.section * 313 + cluster * 53) < redFrac;
+      double delay = 0;
+      final double u = (double) l / Math.max(1, nLanes - 1);
+      if (wipe == 1) delay = u * 370;
+      else if (wipe == 2) delay = (1 - u) * 370;
+      else if (wipe == 3) delay = (1.0 - Math.abs(u - 0.5) * 2) * 200; // edges first
+      // per-lane scatter on every wave so blocks never march in one big group
+      delay += hashd(l * 641 + (int) (this.timeMs * 3)) * 280;
+      queueSpawn(s, isCube, l, red, delay);
+      if (mode == 2 && hashd(l * 97 + (int) this.timeMs) < 0.3) {
+        queueSpawn(s, isCube, l, !red, delay + 60);
+      }
+    }
+  }
+
+  private void queueSpawn(Surface s, boolean isCube, int lane, boolean red, double delay) {
+    if (delay <= 0) {
+      s.spawn(lane, red);
+      return;
+    }
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) {
+        this.pendLane[i] = lane;
+        this.pendRed[i] = red;
+        this.pendMs[i] = delay;
+        this.pendCube[i] = isCube;
+        this.pendAlive[i] = true;
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void advance(double deltaMs) {
+    final double speed = Math.max(0.05, getSpeed());
+    final double wow = getWow();
+    this.section = (int) (this.timeMs / SECTION_MS);
+
+    // collapse-to-black then hard re-drop on big hits
+    if (this.collapseT >= 0) {
+      this.collapseT += deltaMs;
+      if (this.collapseT >= COLLAPSE_MS) {
+        this.collapseT = -1;
+        this.cube.reset();
+        this.cylinder.reset();
+        this.relaunchQueued = true;
+      }
+    } else if (this.beat && this.beatLevel > 0.80 - wow * 0.15) {
+      this.collapseT = 0;
+    }
+
+    // beat-locked launches, with an idle subdivision cadence as fallback
+    this.waveTimer += deltaMs * speed * 2;
+    final boolean waveDue = this.waveTimer >= IDLE_WAVE_MS;
+    final boolean launch = this.relaunchQueued
+      || (this.collapseT < 0 && ((this.beat && this.beatLevel > 0.15) || waveDue));
+    if (launch) {
+      this.waveTimer = 0;
+      this.launchFlash = 1;
+      final double strength = this.relaunchQueued ? 1.0
+        : LXUtils.clamp(this.levelEnv * 1.6 + this.beatLevel * 0.4 + wow * 0.3, 0.15, 1);
+      final int n = this.lanes.getValuei();
+      launchWave(this.cube, true, n, strength, this.relaunchQueued);
+      launchWave(this.cylinder, false, n, strength, this.relaunchQueued);
+      this.relaunchQueued = false;
+    }
+    this.launchFlash *= Math.exp(-deltaMs / 160.0);
+
+    // fire staggered wipe spawns as their delays elapse
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!this.pendAlive[i]) continue;
+      this.pendMs[i] -= deltaMs;
+      if (this.pendMs[i] <= 0) {
+        (this.pendCube[i] ? this.cube : this.cylinder).spawn(this.pendLane[i], this.pendRed[i]);
+        this.pendAlive[i] = false;
+      }
+    }
+  }
+
+  @Override
+  protected void renderStrands(Apotheneum.Orientation o, double deltaMs, boolean isCube) {
+    final Surface s = isCube ? this.cube : this.cylinder;
+    if (!s.inited) s.reset();
+    final int w = o.width();
+    final int h = o.height();
+    final double wow = getWow();
+    final double speed = Math.max(0.05, getSpeed());
+    final double hueShift = LXColor.h(getColor());
+    final int green = LXColor.hsb((float) (((GREEN_HUE + hueShift) % 360)), 96, 100);
+    final int red = LXColor.hsb((float) (((RED_HUE + hueShift) % 360)), 98, 100);
+    final int nLanes = this.lanes.getValuei();
+    final double laneW = (double) w / nLanes;
+    // collapse envelope dims everything toward black before the re-drop
+    final double collapse = (this.collapseT >= 0)
+      ? 1.0 - this.collapseT / COLLAPSE_MS : 1.0;
+
+    for (int i = 0; i < MAX_HEADS; ++i) {
+      if (!s.alive[i]) continue;
+
+      // --- velocity field: green decelerates through the center and accelerates
+      // back out — waves passing through a dense medium, never stopping ---
+      final double vScale = speed * 2; // default Speed 0.5 == measured reference speed
+      if (s.isRed[i]) {
+        if (s.waveR[i]) {
+          // mirrored riser trajectory: zoom in from the top, slow-motion crawl
+          // through the center, burst out the floor
+          s.y[i] += s.v[i] * riseProfile(1.0 - s.y[i]) * vScale * deltaMs;
+        } else {
+          s.y[i] += s.v[i] * vScale * deltaMs; // straight plummet
+        }
+        if (s.y[i] >= 1.05) { s.alive[i] = false; continue; }
+      } else {
+        s.y[i] += s.v[i] * riseProfile(s.y[i]) * vScale * deltaMs;
+        if (s.y[i] <= -0.08) { s.alive[i] = false; continue; } // bursts out the top
+      }
+
+      // --- geometry: thick through the slow center, thin at speed; tail follows ---
+      double vNorm;
+      if (s.isRed[i] && !s.waveR[i]) {
+        vNorm = LXUtils.clamp(Math.abs(s.v[i]) / V_ENTRY, 0, 1.2);
+      } else {
+        final double yp = s.isRed[i] ? 1.0 - s.y[i] : s.y[i];
+        vNorm = LXUtils.clamp(riseProfile(yp) / V_ENTRY, 0, 1.2);
+      }
+      final double thickN = LXUtils.lerp(0.11 * (0.6 + getSize() * 0.9), 0.045, Math.min(1, vNorm));
+      final int thick = Math.max(2, (int) Math.round(thickN * h));
+      // Trail dial: 0.5 == 2x the original length; up to ~4x at full
+      final double trailK = 0.7 + this.trail.getValue() * 2.6;
+      final double tailN = LXUtils.clamp(vNorm * 0.85 * trailK, 0.16 * trailK, 1.9);
+      final int tail = (int) Math.round(tailN * h);
+      double bright = collapse;
+      if (bright <= 0.01) continue;
+
+      final int base = s.isRed[i] ? red : green;
+      // white-hot core at launch speed and on the beat flash
+      final double hot = LXUtils.clamp(vNorm * 0.7 + this.launchFlash * 0.4, 0, 0.85);
+      final int headC = LXColor.lerp(base, LXColor.WHITE, (float) hot);
+
+      int x0 = (int) (s.lane[i] * laneW);
+      int x1 = Math.min(w - 1, (int) ((s.lane[i] + 1) * laneW) - 2); // 1-col dark seam
+      if (s.isRed[i]) {
+        // red runs thin down the lane: some 2-wide strands, some single lines
+        final int cxr = (x0 + x1) / 2;
+        x0 = cxr;
+        x1 = s.thin[i] ? cxr : Math.min(w - 1, cxr + 1);
+      }
+      // strictly monotonic travel: the slow-motion crawl through the center is
+      // pure velocity — no positional oscillation (it read as shaking at LED scale)
+      final double ycF = LXUtils.clamp(s.y[i], -0.1, 1.1) * (h - 1);
+      final int yc = (int) Math.round(ycF);
+      final int dir = s.isRed[i] ? 1 : -1; // travel direction (+down)
+      // red pulses as it descends: a throb riding the moving packet
+      final double throb = s.isRed[i]
+        ? 0.55 + 0.45 * Math.sin(2 * Math.PI * this.timeMs / 1000.0 + i * 0.4) : 1.0;
+
+      final int headThick = s.isRed[i] ? Math.max(2, thick / 2) : thick; // compact red pulse
+
+      // radiant aura: soft gradient bloom bleeding off the block (ComeUp-style),
+      // strongest around the slow heavy slabs; the Glow dial sets reach + intensity
+      final double glowV = this.glow.getValue();
+      final int auraR = (s.isRed[i] ? 1 : 2) + (int) Math.round(glowV * 4);
+      final double auraB = bright * throb * (s.isRed[i] ? 0.5 : 1.0)
+        * (0.08 + glowV * 0.50) * (1.0 - 0.4 * Math.min(1, vNorm));
+      if (auraB > 0.02) {
+        final int byTop = Math.min(yc, yc - dir * (headThick - 1));
+        final int byBot = Math.max(yc, yc - dir * (headThick - 1));
+        for (int x = x0 - auraR; x <= x1 + auraR; ++x) {
+          final int dxo = (x < x0) ? (x0 - x) : ((x > x1) ? (x - x1) : 0);
+          for (int yy = byTop - auraR; yy <= byBot + auraR; ++yy) {
+            if (yy < 0 || yy >= h) continue;
+            final int dyo = (yy < byTop) ? (byTop - yy) : ((yy > byBot) ? (yy - byBot) : 0);
+            final int dout = dxo + dyo;
+            if (dout == 0) continue; // inside the block
+            addPix(o, x, yy, base, auraB * Math.exp(-dout * (1.4 - glowV * 0.7)));
+          }
+        }
+      }
+
+      // continuous block span with sub-pixel feathered edges — glides, no snapping
+      final double leadF = ycF;
+      final double trailF = ycF - dir * (headThick - 1);
+      final double topF = Math.min(leadF, trailF);
+      final double botF = Math.max(leadF, trailF);
+      for (int x = x0; x <= x1; ++x) {
+        for (int yy = (int) Math.floor(topF) - 1; yy <= (int) Math.ceil(botF) + 1; ++yy) {
+          if (yy < 0 || yy >= h) continue;
+          final double dOut = (yy < topF) ? (topF - yy) : ((yy > botF) ? (yy - botF) : 0);
+          final double cov = LXUtils.clamp(1.0 - dOut, 0, 1); // edge feather
+          if (cov <= 0.02) continue;
+          final double u = LXUtils.clamp(1.0 - Math.abs(leadF - yy) / headThick, 0, 1);
+          addPix(o, x, yy, (u > 0.5) ? headC : base, bright * throb * (0.55 + 0.45 * u) * cov);
+        }
+        // tail streams behind, sub-pixel anchored to the trailing edge
+        for (int k = 1; k <= tail; ++k) {
+          final double yyF = trailF - dir * k;
+          final double fFall = Math.exp(-1.8 * k / tail);
+          if (fFall < 0.02) break;
+          final int yy0 = (int) Math.floor(yyF);
+          final double frac = yyF - yy0;
+          final double tb = bright * throb * fFall * 0.8;
+          if (yy0 >= 0 && yy0 < h) addPix(o, x, yy0, base, tb * (1 - frac));
+          if (yy0 + 1 >= 0 && yy0 + 1 < h) addPix(o, x, yy0 + 1, base, tb * frac);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/apotheneum/piemonte/WYD.java
+++ b/src/main/java/apotheneum/piemonte/WYD.java
@@ -21,18 +21,11 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.Noise;
 
 @LXCategory("Apotheneum/piemonte")
 public class WYD extends ParameterPattern {
-
-  public enum Target {
-    BOTH,
-    CUBE,
-    CYLINDER
-  }
 
   private static final double TAU = Math.PI * 2;
   private static final float FX = 2.2f;    // horizontal noise frequency (flow warp)
@@ -47,10 +40,6 @@ public class WYD extends ParameterPattern {
     new CompoundParameter("Depth", 0.6, 0, 1)
     .setDescription("Strength of the light/shadow that gives the waves depth");
 
-  public final EnumParameter<Target> target =
-    new EnumParameter<Target>("Target", Target.BOTH)
-    .setDescription("Which structures to render to");
-
   private double timeMs = 0;
 
   public WYD(LX lx) {
@@ -58,7 +47,7 @@ public class WYD extends ParameterPattern {
     super(lx, 0.4, 0, 1, 0.5, 0, 1);
     addParameter("density", this.density);
     addParameter("depth", this.depth);
-    addParameter("target", this.target);
+    addTargetParameter();
   }
 
   @Override
@@ -79,7 +68,7 @@ public class WYD extends ParameterPattern {
     final int shadow = LXColor.hsb(
       (float) ((LXColor.h(base) + 320) % 360),
       (float) Math.min(100, LXColor.s(base) + 10), 100);
-    final Target t = this.target.getEnum();
+    final Target t = getTarget();
 
     if (t != Target.CYLINDER) {
       draw(Apotheneum.cube.exterior, drift, tEvolve, dens, sharp, depthAmt, base, shadow);

--- a/src/main/java/apotheneum/piemonte/WYD.java
+++ b/src/main/java/apotheneum/piemonte/WYD.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026- Patrick Piemonte
+ *
+ * Created by patrick piemonte
+ *
+ * WYD — a field of fine flowing waveform lines that ripple and drift like silk
+ * or wind-blown hair. The streamlines are warped by multi-octave noise and lit by
+ * a slow second noise field so crests glow bright while the hollows fall into
+ * complementary-tinted shadow, giving the waves real depth. The whole field
+ * flows seamlessly around the sculpture in 3D.
+ *
+ * WARNING: Flashing imagery, best viewed in deep playa
+ */
+
+package apotheneum.piemonte;
+
+import apotheneum.Apotheneum;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.utils.LXUtils;
+import heronarts.lx.utils.Noise;
+
+@LXCategory("Apotheneum/piemonte")
+public class WYD extends ParameterPattern {
+
+  public enum Target {
+    BOTH,
+    CUBE,
+    CYLINDER
+  }
+
+  private static final double TAU = Math.PI * 2;
+  private static final float FX = 2.2f;    // horizontal noise frequency (flow warp)
+  private static final float LX_F = 1.3f;  // lighting-field frequency
+  private static final double WARP = 1.35; // how strongly the flow bends the lines
+
+  public final DiscreteParameter density =
+    new DiscreteParameter("Density", 16, 4, 44)
+    .setDescription("Number of flowing wave lines");
+
+  public final CompoundParameter depth =
+    new CompoundParameter("Depth", 0.6, 0, 1)
+    .setDescription("Strength of the light/shadow that gives the waves depth");
+
+  public final EnumParameter<Target> target =
+    new EnumParameter<Target>("Target", Target.BOTH)
+    .setDescription("Which structures to render to");
+
+  private double timeMs = 0;
+
+  public WYD(LX lx) {
+    // Base registers color (wave tint), speed (flow drift), size (line thickness).
+    super(lx, 0.4, 0, 1, 0.5, 0, 1);
+    addParameter("density", this.density);
+    addParameter("depth", this.depth);
+    addParameter("target", this.target);
+  }
+
+  @Override
+  protected void render(double deltaMs) {
+    setColors(LXColor.BLACK);
+    this.timeMs += deltaMs;
+
+    final double speed = getSpeed();
+    final double wow = getWow();
+    // Wow = wind gust: the silk whips harder, flows faster, crests blaze
+    final double drift = this.timeMs * 0.00035 * speed * (1 + wow * 1.2); // horizontal flow
+    final float tEvolve = (float) (this.timeMs * 0.0002 * (0.4 + speed));
+    final double dens = this.density.getValuei();
+    final double sharp = 3.0 + (1.0 - getSize()) * 34.0;    // thinner lines when Size is low
+    final double depthAmt = this.depth.getValue();
+    final int base = getColor();
+    // hollows fall toward a complementary shadow tint instead of flat darkness
+    final int shadow = LXColor.hsb(
+      (float) ((LXColor.h(base) + 320) % 360),
+      (float) Math.min(100, LXColor.s(base) + 10), 100);
+    final Target t = this.target.getEnum();
+
+    if (t != Target.CYLINDER) {
+      draw(Apotheneum.cube.exterior, drift, tEvolve, dens, sharp, depthAmt, base, shadow);
+    }
+    if (t != Target.CUBE) {
+      draw(Apotheneum.cylinder.exterior, drift, tEvolve, dens, sharp, depthAmt, base, shadow);
+    }
+    copyExterior();
+  }
+
+  private void draw(Apotheneum.Orientation o, double drift, float tEvolve,
+      double dens, double sharp, double depthAmt, int base, int shadow) {
+    // fade the fine secondary layer out as density approaches Nyquist
+    final double v2w = 0.35 * smoothstep(20.0, 12.0, dens);
+    for (Apotheneum.Column column : o.columns()) {
+      for (LXPoint p : column.points) {
+        // warp field bends the horizontal streamlines (seamless in 3D world space)
+        float warp = Noise.stb_perlin_fbm_noise3(
+          (float) (p.xn * FX + drift), p.zn * FX, tEvolve, 2.0f, 0.5f, 3);
+        double phase = (p.yn * dens - warp * WARP * (1 + getWow() * 1.4)) * TAU;
+        double v = 0.5 + 0.5 * Math.cos(phase);
+        double line = Math.pow(v, sharp);
+        // a finer secondary layer for silky detail
+        if (v2w > 0.01) {
+          double v2 = 0.5 + 0.5 * Math.cos((p.yn * dens * 2.3 - warp * WARP) * TAU);
+          line = Math.max(line, v2w * Math.pow(v2, sharp * 1.6));
+        }
+
+        // slow lighting field -> crests glow, hollows fall dark (depth)
+        float lf = Noise.stb_perlin_fbm_noise3(
+          (float) (p.xn * LX_F + drift * 0.5), p.zn * LX_F,
+          (float) (p.yn * 0.8 + tEvolve * 0.6), 2.0f, 0.5f, 2);
+        double light = LXUtils.lerp(1.0, LXUtils.clamp(0.5 + 0.75 * lf, 0.08, 1.0), depthAmt);
+
+        double b = line * light;
+        if (b <= 0.01) continue;
+        int c0 = LXColor.lerp(shadow, base, (float) light);
+        float ll = (float) (line * light);
+        int c = LXColor.lerp(c0, LXColor.WHITE, ll * ll * 0.85f);
+        this.colors[p.index] = LXColor.scaleBrightness(c, (float) LXUtils.clamp(b, 0, 1));
+      }
+    }
+  }
+
+  private static double smoothstep(double e0, double e1, double x) {
+    double t = (x - e0) / (e1 - e0);
+    t = t < 0 ? 0 : (t > 1 ? 1 : t);
+    return t * t * (3 - 2 * t);
+  }
+}

--- a/src/main/resources/projects/Apotheneum-piemonte.lxp
+++ b/src/main/resources/projects/Apotheneum-piemonte.lxp
@@ -1,0 +1,7044 @@
+{
+  "version": "1.1.1-SNAPSHOT",
+  "timestamp": 1750854907820,
+  "model": {
+    "id": 2,
+    "class": "heronarts.lx.structure.LXStructure",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true,
+      "modulationsExpanded": true,
+      "showNormalizationBounds": false,
+      "showFixtureLabels": false,
+      "fixtureLabelHorizontalAlignment": 1,
+      "fixtureLabelHorizontalAlignment/name": "CENTER",
+      "fixtureLabelVerticalAlignment": 1,
+      "fixtureLabelVerticalAlignment/name": "MIDDLE",
+      "fixtureLabelPositionX": 0,
+      "fixtureLabelPositionX/name": "POSITION",
+      "fixtureLabelPositionY": 0,
+      "fixtureLabelPositionY/name": "POSITION",
+      "fixtureLabelPositionZ": 0,
+      "fixtureLabelPositionZ/name": "POSITION",
+      "fixtureLabelOffsetX": 0.0,
+      "fixtureLabelOffsetY": 0.0,
+      "fixtureLabelOffsetZ": 0.0
+    },
+    "parameters": {
+      "label": "LX",
+      "syncModelFile": true,
+      "allWhite": false,
+      "mute": false,
+      "normalizationMode": 0,
+      "normalizationMode/name": "AUTOMATIC",
+      "normalizationX": 0.0,
+      "normalizationY": 0.0,
+      "normalizationZ": 0.0,
+      "normalizationWidth": 1000.0,
+      "normalizationHeight": 1000.0,
+      "normalizationDepth": 1000.0
+    },
+    "children": {
+      "views": {
+        "id": 3,
+        "class": "heronarts.lx.structure.view.LXViewEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX"
+        },
+        "children": {},
+        "views": [
+          {
+            "id": 2692,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cube",
+              "enabled": true,
+              "selector": "cube",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9839998,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 1,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cube Interior",
+              "enabled": true,
+              "selector": "cube & interior",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9839999,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 2,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cube Exterior",
+              "enabled": true,
+              "selector": "cube & exterior",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 37644,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 8,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Faces",
+              "enabled": true,
+              "selector": "cubeFace*",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 1,
+              "orientation/name": "GROUP",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9840001,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 8,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Faces Interior",
+              "enabled": true,
+              "selector": "interior & cubeFace*",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 1,
+              "orientation/name": "GROUP",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9840020,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 8,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Faces Exterior",
+              "enabled": true,
+              "selector": "exterior & cubeFace*",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 1,
+              "orientation/name": "GROUP",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 10020,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 1,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Left",
+              "enabled": true,
+              "selector": "left",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 10021,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 9,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Right",
+              "enabled": true,
+              "selector": "right",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 10022,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 8,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Front",
+              "enabled": true,
+              "selector": "front",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 10023,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 7,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Back",
+              "enabled": true,
+              "selector": "back",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 2665,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 5,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cylinder",
+              "enabled": true,
+              "selector": "cylinder",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9839978,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 4,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cylinder Interior",
+              "enabled": true,
+              "selector": "cylinder & interior",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9839979,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 3,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cylinder Exterior",
+              "enabled": true,
+              "selector": "cylinder & exterior",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 32540,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 6,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Interior",
+              "enabled": true,
+              "selector": "interior",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 33411,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 7,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Exterior",
+              "enabled": true,
+              "selector": "exterior",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9840039,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 16,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Lights",
+              "enabled": true,
+              "selector": "cube, cylinder",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 9822437,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 9,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Haptics",
+              "enabled": true,
+              "selector": "haptics",
+              "normalization": 0,
+              "normalization/name": "RELATIVE",
+              "orientation": 0,
+              "orientation/name": "GLOBAL",
+              "priority": true,
+              "cueActive": false
+            },
+            "children": {}
+          }
+        ]
+      }
+    },
+    "output": {
+      "id": 4,
+      "class": "heronarts.lx.structure.LXStructureOutput",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Output",
+        "enabled": true,
+        "brightness": 1.0,
+        "fps": 0.0,
+        "gamma": 1.0,
+        "gammaMode": 1,
+        "gammaMode/name": "DIRECT",
+        "whitePointRed": 255,
+        "whitePointGreen": 255,
+        "whitePointBlue": 255,
+        "whitePointWhite": 255
+      },
+      "children": {}
+    },
+    "fixtures": [
+      {
+        "jsonFixtureType": "Apotheneum/Apotheneum",
+        "jsonParameters": {
+          "interiorEnabled": true,
+          "nodeSpacing": 9.375,
+          "nodeInset": 15.8125,
+          "cubeTop": 444.0,
+          "cubeSide": 491.0,
+          "cylinderRadius": 180.0,
+          "meshEnabled": true,
+          "meshInset": 1.0,
+          "meshWidth": 1.0,
+          "meshNodeSize": 3.0,
+          "trussWidth": 12.0,
+          "trussTop": 480.0,
+          "sandEnabled": true,
+          "sandScale": 80.0,
+          "haloEnabled": true,
+          "haloScale": 3200.0,
+          "starsEnabled": true,
+          "peopleEnabled": true
+        },
+        "id": 14078,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Apotheneum",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "hasCustomPointSize": false,
+          "pointSize": 5.0,
+          "selected": true,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Apotheneum/Apotheneum"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Apotheneum/Apotheneum-Haptics",
+        "jsonParameters": {},
+        "id": 9818696,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Haptics",
+          "x": 245.5,
+          "y": 30.0,
+          "z": 245.5,
+          "yaw": 0.0,
+          "pitch": 90.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "hasCustomPointSize": false,
+          "pointSize": 5.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Apotheneum/Apotheneum-Haptics"
+        },
+        "children": {}
+      }
+    ],
+    "file": "Apotheneum/Apotheneum.lxm"
+  },
+  "engine": {
+    "id": 1,
+    "class": "heronarts.lx.LXEngine",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true,
+      "modulationsExpanded": true
+    },
+    "parameters": {
+      "label": "Engine",
+      "compositorMultithreaded": false,
+      "networkMultithreaded": false,
+      "framesPerSecond": 60.0,
+      "speed": 1.0,
+      "performanceMode": false,
+      "camera-1": false,
+      "camera-2": false,
+      "camera-3": false,
+      "camera-4": false,
+      "camera-5": false,
+      "camera-6": false
+    },
+    "children": {
+      "palette": {
+        "id": 6,
+        "class": "heronarts.lx.color.LXPalette",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Color Palette",
+          "transitionEnabled": true,
+          "transitionTimeSecs": 5.0,
+          "transitionMode": 0,
+          "transitionMode/name": "RGB",
+          "autoCycleEnabled": true,
+          "autoCycleMode": 0,
+          "autoCycleMode/name": "NEXT",
+          "autoCycleTimeSecs": 45.0,
+          "autoCycleCursor": 1,
+          "triggerSwatchCycle": false,
+          "expandedPerformance": true,
+          "label1": "1",
+          "label2": "2",
+          "label3": "3",
+          "label4": "4",
+          "label5": "5"
+        },
+        "children": {
+          "swatch": {
+            "id": 7,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Deep",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 8,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 11.529411315917969,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 2591,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 9.882352828979492,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 2593,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 60.0,
+                  "primary/saturation": 83.6601333618164,
+                  "primary/hue": 314.53125,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        },
+        "swatches": [
+          {
+            "id": 11820,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Deep",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 11821,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11823,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 25.242189407348633,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11825,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 237.0703125,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 11888,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Hot",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 11889,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 19.44140625,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11891,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11893,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 86.28580474853516,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 11827,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Cool",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 11828,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 175.96875,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11830,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 107.015625,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11832,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 229.921875,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 12043,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Amber",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 12044,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 36.201171875,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 12046,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 46.50716018676758,
+                  "primary/hue": 19.078125,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 12048,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 56.32161331176758,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842603,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Miami",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842604,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 320.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842605,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 180.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842606,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 275.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842607,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 200.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842608,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 80.0,
+                  "primary/hue": 45.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842609,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Sunset",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842610,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 15.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842611,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 340.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842612,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 280.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842613,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 30.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842614,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 55.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842615,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "UV",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842616,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 270.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842617,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 220.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842618,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 130.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842619,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 80.0,
+                  "primary/hue": 290.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842620,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 180.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842621,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Fire",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842622,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842623,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 20.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842624,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 40.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842625,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 55.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842626,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 330.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842627,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Ocean",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842628,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842629,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 220.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842630,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 165.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842631,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 80.0,
+                  "primary/hue": 240.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842632,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 185.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842633,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Candy",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842634,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 330.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842635,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 160.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842636,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 65.0,
+                  "primary/hue": 55.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842637,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 285.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842638,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 200.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842639,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Acid",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842640,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 100.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842641,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 65.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842642,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 305.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842643,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 145.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842644,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 55.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842645,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Twilight",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842646,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 260.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842647,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 230.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842648,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 320.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842649,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 280.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842650,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 50.0,
+                  "primary/hue": 205.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842651,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Lava",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842652,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842653,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 15.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842654,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 35.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842655,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 350.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842656,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 25.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842657,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Aurora",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842658,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 150.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842659,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 175.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842660,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 200.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842661,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 280.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842662,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 130.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842663,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "NeonNoir",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842664,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 315.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842665,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842666,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 255.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842667,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 340.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842668,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 210.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842669,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "DesertRose",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842670,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 345.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842671,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 20.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842672,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 30.0,
+                  "primary/hue": 90.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842673,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 45.0,
+                  "primary/hue": 330.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842674,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 40.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842675,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Jungle",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842676,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 120.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842677,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 90.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842678,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 80.0,
+                  "primary/hue": 150.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842679,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 70.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842680,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 60.0,
+                  "primary/hue": 170.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842681,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Grape",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842682,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 280.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842683,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 80.0,
+                  "primary/hue": 300.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842684,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 260.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842685,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 320.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842686,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 240.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842687,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Tropicana",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842688,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 35.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842689,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 90.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842690,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 320.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842691,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 55.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842692,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 180.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842693,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Ice",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842694,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 40.0,
+                  "primary/hue": 200.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842695,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 25.0,
+                  "primary/hue": 220.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842696,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 185.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842697,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 30.0,
+                  "primary/hue": 240.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842698,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 15.0,
+                  "primary/hue": 210.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842699,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Ember",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842700,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 90.0,
+                  "primary/hue": 10.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842701,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 85.0,
+                  "primary/hue": 30.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842702,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 45.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842703,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842704,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 20.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 9842705,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Prism",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 9842706,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842707,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 72.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842708,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 144.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842709,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 216.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 9842710,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "mode/name": "FIXED",
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 288.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        ]
+      },
+      "tempo": {
+        "id": 10,
+        "class": "heronarts.lx.Tempo",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Tempo",
+          "clockSource": 0,
+          "clockSource/name": "INTERNAL",
+          "period": 500.0,
+          "bpm": 120.0,
+          "tap": false,
+          "nudgeUp": false,
+          "nudgeDown": false,
+          "beatsPerBar": 4,
+          "trigger": false,
+          "enabled": false,
+          "launchQuantization": 0,
+          "follow": false
+        },
+        "children": {
+          "nudge": {
+            "id": 11,
+            "class": "heronarts.lx.modulator.LinearEnvelope",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LENV",
+              "running": false,
+              "trigger": false,
+              "reset": false,
+              "midiSource/index": 0,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "loop": false,
+              "tempoSync": false,
+              "tempoMultiplier": 4,
+              "tempoMultiplier/name": "QUARTER",
+              "tempoLock": true
+            },
+            "children": {},
+            "basis": 0.0
+          }
+        }
+      },
+      "clips": {
+        "id": 12,
+        "class": "heronarts.lx.clip.LXClipEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Clips",
+          "focusedClip": 0.0,
+          "numScenes": 8,
+          "snapshotTransitionEnabled": false,
+          "snapshotTransitionTimeSecs": 5.0,
+          "stopClips": false,
+          "launchPatternCycle": false,
+          "triggerPatternCycle": false,
+          "timeBaseDefault": 1,
+          "timeBaseDefault/name": "TEMPO",
+          "clipSnapshotDefault": false,
+          "gridMode": 0,
+          "gridMode/name": "PATTERNS",
+          "gridViewOffset": 0,
+          "gridPatternOffset": 0,
+          "gridViewExpanded": false,
+          "clipInspectorExpanded": false,
+          "scene-1": false,
+          "pattern-1": false,
+          "scene-2": false,
+          "pattern-2": false,
+          "scene-3": false,
+          "pattern-3": false,
+          "scene-4": false,
+          "pattern-4": false,
+          "scene-5": false,
+          "pattern-5": false,
+          "scene-6": false,
+          "pattern-6": false,
+          "scene-7": false,
+          "pattern-7": false,
+          "scene-8": false,
+          "pattern-8": false,
+          "scene-9": false,
+          "pattern-9": false,
+          "scene-10": false,
+          "pattern-10": false,
+          "scene-11": false,
+          "pattern-11": false,
+          "scene-12": false,
+          "pattern-12": false,
+          "scene-13": false,
+          "pattern-13": false,
+          "scene-14": false,
+          "pattern-14": false,
+          "scene-15": false,
+          "pattern-15": false,
+          "scene-16": false,
+          "pattern-16": false,
+          "scene-17": false,
+          "pattern-17": false,
+          "scene-18": false,
+          "pattern-18": false,
+          "scene-19": false,
+          "pattern-19": false,
+          "scene-20": false,
+          "pattern-20": false,
+          "scene-21": false,
+          "pattern-21": false,
+          "scene-22": false,
+          "pattern-22": false,
+          "scene-23": false,
+          "pattern-23": false,
+          "scene-24": false,
+          "pattern-24": false,
+          "scene-25": false,
+          "pattern-25": false,
+          "scene-26": false,
+          "pattern-26": false,
+          "scene-27": false,
+          "pattern-27": false,
+          "scene-28": false,
+          "pattern-28": false,
+          "scene-29": false,
+          "pattern-29": false,
+          "scene-30": false,
+          "pattern-30": false,
+          "scene-31": false,
+          "pattern-31": false,
+          "scene-32": false,
+          "pattern-32": false,
+          "scene-33": false,
+          "pattern-33": false,
+          "scene-34": false,
+          "pattern-34": false,
+          "scene-35": false,
+          "pattern-35": false,
+          "scene-36": false,
+          "pattern-36": false,
+          "scene-37": false,
+          "pattern-37": false,
+          "scene-38": false,
+          "pattern-38": false,
+          "scene-39": false,
+          "pattern-39": false,
+          "scene-40": false,
+          "pattern-40": false,
+          "scene-41": false,
+          "pattern-41": false,
+          "scene-42": false,
+          "pattern-42": false,
+          "scene-43": false,
+          "pattern-43": false,
+          "scene-44": false,
+          "pattern-44": false,
+          "scene-45": false,
+          "pattern-45": false,
+          "scene-46": false,
+          "pattern-46": false,
+          "scene-47": false,
+          "pattern-47": false,
+          "scene-48": false,
+          "pattern-48": false,
+          "scene-49": false,
+          "pattern-49": false,
+          "scene-50": false,
+          "pattern-50": false,
+          "scene-51": false,
+          "pattern-51": false,
+          "scene-52": false,
+          "pattern-52": false,
+          "scene-53": false,
+          "pattern-53": false,
+          "scene-54": false,
+          "pattern-54": false,
+          "scene-55": false,
+          "pattern-55": false,
+          "scene-56": false,
+          "pattern-56": false,
+          "scene-57": false,
+          "pattern-57": false,
+          "scene-58": false,
+          "pattern-58": false,
+          "scene-59": false,
+          "pattern-59": false,
+          "scene-60": false,
+          "pattern-60": false,
+          "scene-61": false,
+          "pattern-61": false,
+          "scene-62": false,
+          "pattern-62": false,
+          "scene-63": false,
+          "pattern-63": false,
+          "scene-64": false,
+          "pattern-64": false,
+          "scene-65": false,
+          "pattern-65": false,
+          "scene-66": false,
+          "pattern-66": false,
+          "scene-67": false,
+          "pattern-67": false,
+          "scene-68": false,
+          "pattern-68": false,
+          "scene-69": false,
+          "pattern-69": false,
+          "scene-70": false,
+          "pattern-70": false,
+          "scene-71": false,
+          "pattern-71": false,
+          "scene-72": false,
+          "pattern-72": false,
+          "scene-73": false,
+          "pattern-73": false,
+          "scene-74": false,
+          "pattern-74": false,
+          "scene-75": false,
+          "pattern-75": false,
+          "scene-76": false,
+          "pattern-76": false,
+          "scene-77": false,
+          "pattern-77": false,
+          "scene-78": false,
+          "pattern-78": false,
+          "scene-79": false,
+          "pattern-79": false,
+          "scene-80": false,
+          "pattern-80": false,
+          "scene-81": false,
+          "pattern-81": false,
+          "scene-82": false,
+          "pattern-82": false,
+          "scene-83": false,
+          "pattern-83": false,
+          "scene-84": false,
+          "pattern-84": false,
+          "scene-85": false,
+          "pattern-85": false,
+          "scene-86": false,
+          "pattern-86": false,
+          "scene-87": false,
+          "pattern-87": false,
+          "scene-88": false,
+          "pattern-88": false,
+          "scene-89": false,
+          "pattern-89": false,
+          "scene-90": false,
+          "pattern-90": false,
+          "scene-91": false,
+          "pattern-91": false,
+          "scene-92": false,
+          "pattern-92": false,
+          "scene-93": false,
+          "pattern-93": false,
+          "scene-94": false,
+          "pattern-94": false,
+          "scene-95": false,
+          "pattern-95": false,
+          "scene-96": false,
+          "pattern-96": false,
+          "scene-97": false,
+          "pattern-97": false,
+          "scene-98": false,
+          "pattern-98": false,
+          "scene-99": false,
+          "pattern-99": false,
+          "scene-100": false,
+          "pattern-100": false,
+          "scene-101": false,
+          "pattern-101": false,
+          "scene-102": false,
+          "pattern-102": false,
+          "scene-103": false,
+          "pattern-103": false,
+          "scene-104": false,
+          "pattern-104": false,
+          "scene-105": false,
+          "pattern-105": false,
+          "scene-106": false,
+          "pattern-106": false,
+          "scene-107": false,
+          "pattern-107": false,
+          "scene-108": false,
+          "pattern-108": false,
+          "scene-109": false,
+          "pattern-109": false,
+          "scene-110": false,
+          "pattern-110": false,
+          "scene-111": false,
+          "pattern-111": false,
+          "scene-112": false,
+          "pattern-112": false,
+          "scene-113": false,
+          "pattern-113": false,
+          "scene-114": false,
+          "pattern-114": false,
+          "scene-115": false,
+          "pattern-115": false,
+          "scene-116": false,
+          "pattern-116": false,
+          "scene-117": false,
+          "pattern-117": false,
+          "scene-118": false,
+          "pattern-118": false,
+          "scene-119": false,
+          "pattern-119": false,
+          "scene-120": false,
+          "pattern-120": false,
+          "scene-121": false,
+          "pattern-121": false,
+          "scene-122": false,
+          "pattern-122": false,
+          "scene-123": false,
+          "pattern-123": false,
+          "scene-124": false,
+          "pattern-124": false,
+          "scene-125": false,
+          "pattern-125": false,
+          "scene-126": false,
+          "pattern-126": false,
+          "scene-127": false,
+          "pattern-127": false,
+          "scene-128": false,
+          "pattern-128": false
+        },
+        "children": {
+          "grid": {
+            "id": 13,
+            "class": "heronarts.lx.clip.LXClipEngine$Grid",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Grid",
+              "snap": true,
+              "mode": 0,
+              "mode/name": "ADAPTIVE",
+              "adaptiveSpacing": 0,
+              "adaptiveSpacing/name": "NARROWEST",
+              "fixedSpacingAbsolute": 2,
+              "fixedSpacingAbsolute/name": "SECOND",
+              "fixedSpacingTempo": 0
+            },
+            "children": {}
+          }
+        }
+      },
+      "audio": {
+        "id": 14,
+        "class": "heronarts.lx.audio.LXAudioEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true,
+          "ioExpanded": false,
+          "numSoundObjects": 0.0
+        },
+        "parameters": {
+          "label": "Audio",
+          "enabled": true,
+          "mode": 0,
+          "mode/name": "INPUT",
+          "expandedPerformance": true
+        },
+        "children": {
+          "input": {
+            "id": 15,
+            "class": "heronarts.lx.audio.LXAudioInput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Input",
+              "device": 0
+            },
+            "children": {}
+          },
+          "output": {
+            "id": 16,
+            "class": "heronarts.lx.audio.LXAudioOutput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Output",
+              "file": "",
+              "trigger": false,
+              "looping": false,
+              "play": false
+            },
+            "children": {}
+          },
+          "soundStage": {
+            "id": 17,
+            "class": "heronarts.lx.audio.SoundStage",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SoundStage",
+              "mode": 0,
+              "mode/name": "DEFAULT",
+              "xAbsolute": 0.0,
+              "yAbsolute": 0.0,
+              "zAbsolute": 0.0,
+              "widthAbsolute": 100.0,
+              "heightAbsolute": 100.0,
+              "depthAbsolute": 100.0,
+              "azimuthAbsolute": 0.0,
+              "elevationAbsolute": 0.0,
+              "xRelative": 0.0,
+              "yRelative": 0.0,
+              "zRelative": 0.0,
+              "widthRelative": 1.0,
+              "heightRelative": 1.0,
+              "depthRelative": 1.0,
+              "azimuthRelative": 0.0,
+              "elevationRelative": 0.0,
+              "showSoundStage": false,
+              "showSoundObjects": true,
+              "soundObjectMeterMode": 0,
+              "soundObjectMeterMode/name": "NONE",
+              "soundObjectSize": 10.0,
+              "soundObjectLabels": true
+            },
+            "children": {}
+          },
+          "adm": {
+            "id": 18,
+            "class": "heronarts.lx.audio.ADM",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "ADM"
+            },
+            "children": {}
+          },
+          "envelop": {
+            "id": 83,
+            "class": "heronarts.lx.audio.Envelop",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "metersExpanded": false
+            },
+            "parameters": {
+              "label": "Envelop",
+              "running": false,
+              "trigger": false,
+              "reset": false
+            },
+            "children": {
+              "source": {
+                "id": 84,
+                "class": "heronarts.lx.audio.Envelop$Source",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Source",
+                  "running": true,
+                  "trigger": false,
+                  "reset": false,
+                  "gain": 0.0,
+                  "range": 24.0,
+                  "attack": 0.0,
+                  "release": 50.0,
+                  "source-1": 0.0,
+                  "source-2": 0.0,
+                  "source-3": 0.0,
+                  "source-4": 0.0,
+                  "source-5": 0.0,
+                  "source-6": 0.0,
+                  "source-7": 0.0,
+                  "source-8": 0.0,
+                  "source-9": 0.0,
+                  "source-10": 0.0,
+                  "source-11": 0.0,
+                  "source-12": 0.0,
+                  "source-13": 0.0,
+                  "source-14": 0.0,
+                  "source-15": 0.0,
+                  "source-16": 0.0,
+                  "source-17": 0.0,
+                  "source-18": 0.0,
+                  "source-19": 0.0,
+                  "source-20": 0.0,
+                  "source-21": 0.0,
+                  "source-22": 0.0,
+                  "source-23": 0.0,
+                  "source-24": 0.0,
+                  "source-25": 0.0,
+                  "source-26": 0.0,
+                  "source-27": 0.0,
+                  "source-28": 0.0,
+                  "source-29": 0.0,
+                  "source-30": 0.0,
+                  "source-31": 0.0,
+                  "source-32": 0.0
+                },
+                "children": {}
+              },
+              "decode": {
+                "id": 85,
+                "class": "heronarts.lx.audio.Envelop$Decode",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Decode",
+                  "running": true,
+                  "trigger": false,
+                  "reset": false,
+                  "gain": 0.0,
+                  "range": 24.0,
+                  "attack": 0.0,
+                  "release": 50.0,
+                  "decode-1": 0.0,
+                  "decode-2": 0.0,
+                  "decode-3": 0.0,
+                  "decode-4": 0.0,
+                  "decode-5": 0.0,
+                  "decode-6": 0.0,
+                  "decode-7": 0.0,
+                  "decode-8": 0.0
+                },
+                "children": {}
+              }
+            }
+          },
+          "reaper": {
+            "id": 86,
+            "class": "heronarts.lx.audio.Reaper",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "metersExpanded": false
+            },
+            "parameters": {
+              "label": "Reaper",
+              "running": false,
+              "trigger": false,
+              "reset": false,
+              "meterAttack": 0.0,
+              "meterRelease": 0.0,
+              "foldMode": 1,
+              "foldMode/name": "ACTIVE",
+              "master": 0.0,
+              "master-active": false,
+              "meter-1": 0.0,
+              "meter-1-active": false,
+              "meter-2": 0.0,
+              "meter-2-active": false,
+              "meter-3": 0.0,
+              "meter-3-active": false,
+              "meter-4": 0.0,
+              "meter-4-active": false,
+              "meter-5": 0.0,
+              "meter-5-active": false,
+              "meter-6": 0.0,
+              "meter-6-active": false,
+              "meter-7": 0.0,
+              "meter-7-active": false,
+              "meter-8": 0.0,
+              "meter-8-active": false,
+              "meter-9": 0.0,
+              "meter-9-active": false,
+              "meter-10": 0.0,
+              "meter-10-active": false,
+              "meter-11": 0.0,
+              "meter-11-active": false,
+              "meter-12": 0.0,
+              "meter-12-active": false,
+              "meter-13": 0.0,
+              "meter-13-active": false,
+              "meter-14": 0.0,
+              "meter-14-active": false,
+              "meter-15": 0.0,
+              "meter-15-active": false,
+              "meter-16": 0.0,
+              "meter-16-active": false,
+              "meter-17": 0.0,
+              "meter-17-active": false,
+              "meter-18": 0.0,
+              "meter-18-active": false,
+              "meter-19": 0.0,
+              "meter-19-active": false,
+              "meter-20": 0.0,
+              "meter-20-active": false,
+              "meter-21": 0.0,
+              "meter-21-active": false,
+              "meter-22": 0.0,
+              "meter-22-active": false,
+              "meter-23": 0.0,
+              "meter-23-active": false,
+              "meter-24": 0.0,
+              "meter-24-active": false,
+              "meter-25": 0.0,
+              "meter-25-active": false,
+              "meter-26": 0.0,
+              "meter-26-active": false,
+              "meter-27": 0.0,
+              "meter-27-active": false,
+              "meter-28": 0.0,
+              "meter-28-active": false,
+              "meter-29": 0.0,
+              "meter-29-active": false,
+              "meter-30": 0.0,
+              "meter-30-active": false,
+              "meter-31": 0.0,
+              "meter-31-active": false,
+              "meter-32": 0.0,
+              "meter-32-active": false
+            },
+            "children": {}
+          },
+          "meter": {
+            "id": 87,
+            "class": "heronarts.lx.audio.LXAudioEngine$Meter",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Meter",
+              "running": false,
+              "trigger": false,
+              "reset": false,
+              "midiSource/index": 0,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "gain": 0.0,
+              "range": 48.0,
+              "attack": 10.0,
+              "release": 100.0,
+              "slope": 4.5,
+              "band-1": 0.0,
+              "band-2": 0.0,
+              "band-3": 0.0,
+              "band-4": 0.0,
+              "band-5": 0.0,
+              "band-6": 0.0,
+              "band-7": 0.0,
+              "band-8": 0.0,
+              "band-9": 0.0,
+              "band-10": 0.0,
+              "band-11": 0.0,
+              "band-12": 0.0,
+              "band-13": 0.0,
+              "band-14": 0.0,
+              "band-15": 0.0,
+              "band-16": 0.0
+            },
+            "children": {}
+          }
+        }
+      },
+      "mixer": {
+        "id": 88,
+        "class": "heronarts.lx.mixer.LXMixerEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Mixer",
+          "crossfader": 0.5,
+          "crossfaderBlendMode": 0,
+          "focusedChannel": 0,
+          "focusedChannelAux": 0,
+          "cueA": false,
+          "cueB": false,
+          "auxA": false,
+          "auxB": false,
+          "autoMuteDefault": true,
+          "autoMutePatternDefault": false,
+          "viewCondensed": false,
+          "viewStacked": false,
+          "viewDeviceBin": true
+        },
+        "children": {
+          "master": {
+            "id": 96,
+            "class": "heronarts.lx.mixer.LXMasterBus",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false
+            },
+            "parameters": {
+              "label": "Master",
+              "fader": 1.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "previewMode": 0,
+              "previewMode/name": "PRE"
+            },
+            "children": {
+              "modulation": {
+                "id": 97,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [
+              {
+                "id": 191749,
+                "class": "apotheneum.core.ApotheneumDoors",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": false,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Doors",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "locked": true,
+                  "mute": true
+                },
+                "children": {
+                  "modulation": {
+                    "id": 191750,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              }
+            ],
+            "clips": []
+          }
+        },
+        "channels": [
+          {
+            "id": 9842358,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "EXT-A",
+              "fader": 1.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 15,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 1,
+              "autoCycleMode/name": "RANDOM",
+              "autoCycleTimeSecs": 45.0,
+              "transitionEnabled": true,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9842359,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 9842360,
+                "class": "apotheneum.piemonte.Afterglow"
+              },
+              {
+                "id": 9842361,
+                "class": "apotheneum.piemonte.CandyFlip"
+              },
+              {
+                "id": 9842362,
+                "class": "apotheneum.piemonte.ComeUp"
+              },
+              {
+                "id": 9842363,
+                "class": "apotheneum.piemonte.Cope"
+              },
+              {
+                "id": 9842364,
+                "class": "apotheneum.piemonte.Crush"
+              },
+              {
+                "id": 9842365,
+                "class": "apotheneum.piemonte.Destination"
+              },
+              {
+                "id": 9842366,
+                "class": "apotheneum.piemonte.UFOAbduction"
+              },
+              {
+                "id": 9842367,
+                "class": "apotheneum.piemonte.FeelSomething"
+              },
+              {
+                "id": 9842370,
+                "class": "apotheneum.piemonte.Digits"
+              },
+              {
+                "id": 9842371,
+                "class": "apotheneum.piemonte.Drip"
+              },
+              {
+                "id": 9842372,
+                "class": "apotheneum.piemonte.Liftoff"
+              },
+              {
+                "id": 9842373,
+                "class": "apotheneum.piemonte.Downlink"
+              },
+              {
+                "id": 9842374,
+                "class": "apotheneum.piemonte.Overclock"
+              },
+              {
+                "id": 9842375,
+                "class": "apotheneum.piemonte.Pressure"
+              },
+              {
+                "id": 9842376,
+                "class": "apotheneum.piemonte.Origami"
+              },
+              {
+                "id": 9842377,
+                "class": "apotheneum.piemonte.ParticleWave"
+              },
+              {
+                "id": 9842378,
+                "class": "apotheneum.piemonte.PlayaStrobe"
+              },
+              {
+                "id": 9842379,
+                "class": "apotheneum.piemonte.Overflow"
+              },
+              {
+                "id": 9842380,
+                "class": "apotheneum.piemonte.Bruh"
+              },
+              {
+                "id": 9842381,
+                "class": "apotheneum.piemonte.Replies"
+              },
+              {
+                "id": 9842382,
+                "class": "apotheneum.piemonte.ReUp"
+              },
+              {
+                "id": 9842383,
+                "class": "apotheneum.piemonte.Radiate"
+              },
+              {
+                "id": 9842384,
+                "class": "apotheneum.piemonte.SpaceBoundSpecies"
+              },
+              {
+                "id": 9842385,
+                "class": "apotheneum.piemonte.SpecialKube"
+              },
+              {
+                "id": 9842386,
+                "class": "apotheneum.piemonte.Superbloom"
+              },
+              {
+                "id": 9842387,
+                "class": "apotheneum.piemonte.TheHumanRace"
+              },
+              {
+                "id": 9842388,
+                "class": "apotheneum.piemonte.Cooked"
+              },
+              {
+                "id": 9842389,
+                "class": "apotheneum.piemonte.Diabolical"
+              },
+              {
+                "id": 9842390,
+                "class": "apotheneum.piemonte.TunnelVision"
+              },
+              {
+                "id": 9842391,
+                "class": "apotheneum.piemonte.WYD"
+              },
+              {
+                "id": 9843711,
+                "class": "apotheneum.piemonte.Likes"
+              },
+              {
+                "id": 9843712,
+                "class": "apotheneum.piemonte.Ghosted"
+              },
+              {
+                "id": 9845794,
+                "class": "apotheneum.piemonte.LockedIn"
+              },
+              {
+                "id": 9846800,
+                "class": "apotheneum.piemonte.Sunrise"
+              },
+              {
+                "id": 9847806,
+                "class": "apotheneum.piemonte.Nice"
+              },
+              {
+                "id": 9848812,
+                "class": "apotheneum.piemonte.CrashingOut"
+              },
+              {
+                "id": 9849818,
+                "class": "apotheneum.piemonte.SafteyThird"
+              }
+            ]
+          },
+          {
+            "id": 9842426,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "INT-A",
+              "fader": 1.0,
+              "arm": false,
+              "selected": true,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 14,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 1,
+              "autoCycleMode/name": "RANDOM",
+              "autoCycleTimeSecs": 45.0,
+              "transitionEnabled": true,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9842427,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 9842431,
+                "class": "apotheneum.piemonte.Afterglow"
+              },
+              {
+                "id": 9842432,
+                "class": "apotheneum.piemonte.CandyFlip"
+              },
+              {
+                "id": 9842433,
+                "class": "apotheneum.piemonte.ComeUp"
+              },
+              {
+                "id": 9842434,
+                "class": "apotheneum.piemonte.Cope"
+              },
+              {
+                "id": 9842435,
+                "class": "apotheneum.piemonte.Crush"
+              },
+              {
+                "id": 9842436,
+                "class": "apotheneum.piemonte.Destination"
+              },
+              {
+                "id": 9842437,
+                "class": "apotheneum.piemonte.UFOAbduction"
+              },
+              {
+                "id": 9842438,
+                "class": "apotheneum.piemonte.FeelSomething"
+              },
+              {
+                "id": 9842441,
+                "class": "apotheneum.piemonte.Digits"
+              },
+              {
+                "id": 9842442,
+                "class": "apotheneum.piemonte.Drip"
+              },
+              {
+                "id": 9842443,
+                "class": "apotheneum.piemonte.Liftoff"
+              },
+              {
+                "id": 9842444,
+                "class": "apotheneum.piemonte.Downlink"
+              },
+              {
+                "id": 9842445,
+                "class": "apotheneum.piemonte.Overclock"
+              },
+              {
+                "id": 9842446,
+                "class": "apotheneum.piemonte.Pressure"
+              },
+              {
+                "id": 9842447,
+                "class": "apotheneum.piemonte.Origami"
+              },
+              {
+                "id": 9842448,
+                "class": "apotheneum.piemonte.ParticleWave"
+              },
+              {
+                "id": 9842449,
+                "class": "apotheneum.piemonte.PlayaStrobe"
+              },
+              {
+                "id": 9842450,
+                "class": "apotheneum.piemonte.Overflow"
+              },
+              {
+                "id": 9842451,
+                "class": "apotheneum.piemonte.Bruh"
+              },
+              {
+                "id": 9842452,
+                "class": "apotheneum.piemonte.Replies"
+              },
+              {
+                "id": 9842453,
+                "class": "apotheneum.piemonte.ReUp"
+              },
+              {
+                "id": 9842454,
+                "class": "apotheneum.piemonte.Radiate"
+              },
+              {
+                "id": 9842455,
+                "class": "apotheneum.piemonte.SpaceBoundSpecies"
+              },
+              {
+                "id": 9842456,
+                "class": "apotheneum.piemonte.SpecialKube"
+              },
+              {
+                "id": 9842457,
+                "class": "apotheneum.piemonte.Superbloom"
+              },
+              {
+                "id": 9842458,
+                "class": "apotheneum.piemonte.TheHumanRace"
+              },
+              {
+                "id": 9842459,
+                "class": "apotheneum.piemonte.Cooked"
+              },
+              {
+                "id": 9842460,
+                "class": "apotheneum.piemonte.Diabolical"
+              },
+              {
+                "id": 9842461,
+                "class": "apotheneum.piemonte.TunnelVision"
+              },
+              {
+                "id": 9842462,
+                "class": "apotheneum.piemonte.WYD"
+              },
+              {
+                "id": 9843713,
+                "class": "apotheneum.piemonte.Likes"
+              },
+              {
+                "id": 9843714,
+                "class": "apotheneum.piemonte.Ghosted"
+              },
+              {
+                "id": 9845795,
+                "class": "apotheneum.piemonte.LockedIn"
+              },
+              {
+                "id": 9846801,
+                "class": "apotheneum.piemonte.Sunrise"
+              },
+              {
+                "id": 9847807,
+                "class": "apotheneum.piemonte.Nice"
+              },
+              {
+                "id": 9848813,
+                "class": "apotheneum.piemonte.CrashingOut"
+              },
+              {
+                "id": 9849819,
+                "class": "apotheneum.piemonte.SafteyThird"
+              }
+            ]
+          },
+          {
+            "id": 9842497,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "EXT-B",
+              "fader": 0.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 15,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 1,
+              "autoCycleMode/name": "RANDOM",
+              "autoCycleTimeSecs": 45.0,
+              "transitionEnabled": true,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 15,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9842498,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 15,
+            "patterns": [
+              {
+                "id": 9842499,
+                "class": "apotheneum.piemonte.Afterglow"
+              },
+              {
+                "id": 9842500,
+                "class": "apotheneum.piemonte.CandyFlip"
+              },
+              {
+                "id": 9842501,
+                "class": "apotheneum.piemonte.ComeUp"
+              },
+              {
+                "id": 9842502,
+                "class": "apotheneum.piemonte.Cope"
+              },
+              {
+                "id": 9842503,
+                "class": "apotheneum.piemonte.Crush"
+              },
+              {
+                "id": 9842504,
+                "class": "apotheneum.piemonte.Destination"
+              },
+              {
+                "id": 9842505,
+                "class": "apotheneum.piemonte.UFOAbduction"
+              },
+              {
+                "id": 9842506,
+                "class": "apotheneum.piemonte.FeelSomething"
+              },
+              {
+                "id": 9842509,
+                "class": "apotheneum.piemonte.Digits"
+              },
+              {
+                "id": 9842510,
+                "class": "apotheneum.piemonte.Drip"
+              },
+              {
+                "id": 9842511,
+                "class": "apotheneum.piemonte.Liftoff"
+              },
+              {
+                "id": 9842512,
+                "class": "apotheneum.piemonte.Downlink"
+              },
+              {
+                "id": 9842513,
+                "class": "apotheneum.piemonte.Overclock"
+              },
+              {
+                "id": 9842514,
+                "class": "apotheneum.piemonte.Pressure"
+              },
+              {
+                "id": 9842515,
+                "class": "apotheneum.piemonte.Origami"
+              },
+              {
+                "id": 9842516,
+                "class": "apotheneum.piemonte.ParticleWave"
+              },
+              {
+                "id": 9842517,
+                "class": "apotheneum.piemonte.PlayaStrobe"
+              },
+              {
+                "id": 9842518,
+                "class": "apotheneum.piemonte.Overflow"
+              },
+              {
+                "id": 9842519,
+                "class": "apotheneum.piemonte.Bruh"
+              },
+              {
+                "id": 9842520,
+                "class": "apotheneum.piemonte.Replies"
+              },
+              {
+                "id": 9842521,
+                "class": "apotheneum.piemonte.ReUp"
+              },
+              {
+                "id": 9842522,
+                "class": "apotheneum.piemonte.Radiate"
+              },
+              {
+                "id": 9842523,
+                "class": "apotheneum.piemonte.SpaceBoundSpecies"
+              },
+              {
+                "id": 9842524,
+                "class": "apotheneum.piemonte.SpecialKube"
+              },
+              {
+                "id": 9842525,
+                "class": "apotheneum.piemonte.Superbloom"
+              },
+              {
+                "id": 9842526,
+                "class": "apotheneum.piemonte.TheHumanRace"
+              },
+              {
+                "id": 9842527,
+                "class": "apotheneum.piemonte.Cooked"
+              },
+              {
+                "id": 9842528,
+                "class": "apotheneum.piemonte.Diabolical"
+              },
+              {
+                "id": 9842529,
+                "class": "apotheneum.piemonte.TunnelVision"
+              },
+              {
+                "id": 9842530,
+                "class": "apotheneum.piemonte.WYD"
+              },
+              {
+                "id": 9843715,
+                "class": "apotheneum.piemonte.Likes"
+              },
+              {
+                "id": 9843716,
+                "class": "apotheneum.piemonte.Ghosted"
+              },
+              {
+                "id": 9845796,
+                "class": "apotheneum.piemonte.LockedIn"
+              },
+              {
+                "id": 9846802,
+                "class": "apotheneum.piemonte.Sunrise"
+              },
+              {
+                "id": 9847808,
+                "class": "apotheneum.piemonte.Nice"
+              },
+              {
+                "id": 9848814,
+                "class": "apotheneum.piemonte.CrashingOut"
+              },
+              {
+                "id": 9849820,
+                "class": "apotheneum.piemonte.SafteyThird"
+              }
+            ]
+          },
+          {
+            "id": 9842565,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "INT-B",
+              "fader": 0.0,
+              "arm": false,
+              "selected": true,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 14,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 1,
+              "autoCycleMode/name": "RANDOM",
+              "autoCycleTimeSecs": 45.0,
+              "transitionEnabled": true,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 15,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9842566,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 15,
+            "patterns": [
+              {
+                "id": 9842570,
+                "class": "apotheneum.piemonte.Afterglow"
+              },
+              {
+                "id": 9842571,
+                "class": "apotheneum.piemonte.CandyFlip"
+              },
+              {
+                "id": 9842572,
+                "class": "apotheneum.piemonte.ComeUp"
+              },
+              {
+                "id": 9842573,
+                "class": "apotheneum.piemonte.Cope"
+              },
+              {
+                "id": 9842574,
+                "class": "apotheneum.piemonte.Crush"
+              },
+              {
+                "id": 9842575,
+                "class": "apotheneum.piemonte.Destination"
+              },
+              {
+                "id": 9842576,
+                "class": "apotheneum.piemonte.UFOAbduction"
+              },
+              {
+                "id": 9842577,
+                "class": "apotheneum.piemonte.FeelSomething"
+              },
+              {
+                "id": 9842580,
+                "class": "apotheneum.piemonte.Digits"
+              },
+              {
+                "id": 9842581,
+                "class": "apotheneum.piemonte.Drip"
+              },
+              {
+                "id": 9842582,
+                "class": "apotheneum.piemonte.Liftoff"
+              },
+              {
+                "id": 9842583,
+                "class": "apotheneum.piemonte.Downlink"
+              },
+              {
+                "id": 9842584,
+                "class": "apotheneum.piemonte.Overclock"
+              },
+              {
+                "id": 9842585,
+                "class": "apotheneum.piemonte.Pressure"
+              },
+              {
+                "id": 9842586,
+                "class": "apotheneum.piemonte.Origami"
+              },
+              {
+                "id": 9842587,
+                "class": "apotheneum.piemonte.ParticleWave"
+              },
+              {
+                "id": 9842588,
+                "class": "apotheneum.piemonte.PlayaStrobe"
+              },
+              {
+                "id": 9842589,
+                "class": "apotheneum.piemonte.Overflow"
+              },
+              {
+                "id": 9842590,
+                "class": "apotheneum.piemonte.Bruh"
+              },
+              {
+                "id": 9842591,
+                "class": "apotheneum.piemonte.Replies"
+              },
+              {
+                "id": 9842592,
+                "class": "apotheneum.piemonte.ReUp"
+              },
+              {
+                "id": 9842593,
+                "class": "apotheneum.piemonte.Radiate"
+              },
+              {
+                "id": 9842594,
+                "class": "apotheneum.piemonte.SpaceBoundSpecies"
+              },
+              {
+                "id": 9842595,
+                "class": "apotheneum.piemonte.SpecialKube"
+              },
+              {
+                "id": 9842596,
+                "class": "apotheneum.piemonte.Superbloom"
+              },
+              {
+                "id": 9842597,
+                "class": "apotheneum.piemonte.TheHumanRace"
+              },
+              {
+                "id": 9842598,
+                "class": "apotheneum.piemonte.Cooked"
+              },
+              {
+                "id": 9842599,
+                "class": "apotheneum.piemonte.Diabolical"
+              },
+              {
+                "id": 9842600,
+                "class": "apotheneum.piemonte.TunnelVision"
+              },
+              {
+                "id": 9842601,
+                "class": "apotheneum.piemonte.WYD"
+              },
+              {
+                "id": 9843717,
+                "class": "apotheneum.piemonte.Likes"
+              },
+              {
+                "id": 9843718,
+                "class": "apotheneum.piemonte.Ghosted"
+              },
+              {
+                "id": 9845797,
+                "class": "apotheneum.piemonte.LockedIn"
+              },
+              {
+                "id": 9846803,
+                "class": "apotheneum.piemonte.Sunrise"
+              },
+              {
+                "id": 9847809,
+                "class": "apotheneum.piemonte.Nice"
+              },
+              {
+                "id": 9848815,
+                "class": "apotheneum.piemonte.CrashingOut"
+              },
+              {
+                "id": 9849821,
+                "class": "apotheneum.piemonte.SafteyThird"
+              }
+            ]
+          },
+          {
+            "id": 9844719,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "EXT-C",
+              "fader": 0.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 15,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 1,
+              "autoCycleMode/name": "RANDOM",
+              "autoCycleTimeSecs": 45.0,
+              "transitionEnabled": true,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9844720,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 9844721,
+                "class": "apotheneum.piemonte.Afterglow"
+              },
+              {
+                "id": 9844722,
+                "class": "apotheneum.piemonte.CandyFlip"
+              },
+              {
+                "id": 9844723,
+                "class": "apotheneum.piemonte.ComeUp"
+              },
+              {
+                "id": 9844724,
+                "class": "apotheneum.piemonte.Cope"
+              },
+              {
+                "id": 9844725,
+                "class": "apotheneum.piemonte.Crush"
+              },
+              {
+                "id": 9844726,
+                "class": "apotheneum.piemonte.Destination"
+              },
+              {
+                "id": 9844727,
+                "class": "apotheneum.piemonte.UFOAbduction"
+              },
+              {
+                "id": 9844728,
+                "class": "apotheneum.piemonte.FeelSomething"
+              },
+              {
+                "id": 9844730,
+                "class": "apotheneum.piemonte.Digits"
+              },
+              {
+                "id": 9844731,
+                "class": "apotheneum.piemonte.Drip"
+              },
+              {
+                "id": 9844732,
+                "class": "apotheneum.piemonte.Liftoff"
+              },
+              {
+                "id": 9844733,
+                "class": "apotheneum.piemonte.Downlink"
+              },
+              {
+                "id": 9844734,
+                "class": "apotheneum.piemonte.Overclock"
+              },
+              {
+                "id": 9844735,
+                "class": "apotheneum.piemonte.Pressure"
+              },
+              {
+                "id": 9844736,
+                "class": "apotheneum.piemonte.Origami"
+              },
+              {
+                "id": 9844737,
+                "class": "apotheneum.piemonte.ParticleWave"
+              },
+              {
+                "id": 9844738,
+                "class": "apotheneum.piemonte.PlayaStrobe"
+              },
+              {
+                "id": 9844739,
+                "class": "apotheneum.piemonte.Overflow"
+              },
+              {
+                "id": 9844740,
+                "class": "apotheneum.piemonte.Bruh"
+              },
+              {
+                "id": 9844741,
+                "class": "apotheneum.piemonte.Replies"
+              },
+              {
+                "id": 9844742,
+                "class": "apotheneum.piemonte.ReUp"
+              },
+              {
+                "id": 9844743,
+                "class": "apotheneum.piemonte.Radiate"
+              },
+              {
+                "id": 9844744,
+                "class": "apotheneum.piemonte.SpaceBoundSpecies"
+              },
+              {
+                "id": 9844745,
+                "class": "apotheneum.piemonte.SpecialKube"
+              },
+              {
+                "id": 9844746,
+                "class": "apotheneum.piemonte.Superbloom"
+              },
+              {
+                "id": 9844747,
+                "class": "apotheneum.piemonte.TheHumanRace"
+              },
+              {
+                "id": 9844748,
+                "class": "apotheneum.piemonte.Cooked"
+              },
+              {
+                "id": 9844749,
+                "class": "apotheneum.piemonte.Diabolical"
+              },
+              {
+                "id": 9844750,
+                "class": "apotheneum.piemonte.TunnelVision"
+              },
+              {
+                "id": 9844751,
+                "class": "apotheneum.piemonte.WYD"
+              },
+              {
+                "id": 9844753,
+                "class": "apotheneum.piemonte.Likes"
+              },
+              {
+                "id": 9844754,
+                "class": "apotheneum.piemonte.Ghosted"
+              },
+              {
+                "id": 9845798,
+                "class": "apotheneum.piemonte.LockedIn"
+              },
+              {
+                "id": 9846804,
+                "class": "apotheneum.piemonte.Sunrise"
+              },
+              {
+                "id": 9847810,
+                "class": "apotheneum.piemonte.Nice"
+              },
+              {
+                "id": 9848816,
+                "class": "apotheneum.piemonte.CrashingOut"
+              },
+              {
+                "id": 9849822,
+                "class": "apotheneum.piemonte.SafteyThird"
+              }
+            ]
+          },
+          {
+            "id": 9844755,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "INT-C",
+              "fader": 0.0,
+              "arm": false,
+              "selected": true,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 14,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 1,
+              "autoCycleMode/name": "RANDOM",
+              "autoCycleTimeSecs": 45.0,
+              "transitionEnabled": true,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9844756,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 9844760,
+                "class": "apotheneum.piemonte.Afterglow"
+              },
+              {
+                "id": 9844761,
+                "class": "apotheneum.piemonte.CandyFlip"
+              },
+              {
+                "id": 9844762,
+                "class": "apotheneum.piemonte.ComeUp"
+              },
+              {
+                "id": 9844763,
+                "class": "apotheneum.piemonte.Cope"
+              },
+              {
+                "id": 9844764,
+                "class": "apotheneum.piemonte.Crush"
+              },
+              {
+                "id": 9844765,
+                "class": "apotheneum.piemonte.Destination"
+              },
+              {
+                "id": 9844766,
+                "class": "apotheneum.piemonte.UFOAbduction"
+              },
+              {
+                "id": 9844767,
+                "class": "apotheneum.piemonte.FeelSomething"
+              },
+              {
+                "id": 9844769,
+                "class": "apotheneum.piemonte.Digits"
+              },
+              {
+                "id": 9844770,
+                "class": "apotheneum.piemonte.Drip"
+              },
+              {
+                "id": 9844771,
+                "class": "apotheneum.piemonte.Liftoff"
+              },
+              {
+                "id": 9844772,
+                "class": "apotheneum.piemonte.Downlink"
+              },
+              {
+                "id": 9844773,
+                "class": "apotheneum.piemonte.Overclock"
+              },
+              {
+                "id": 9844774,
+                "class": "apotheneum.piemonte.Pressure"
+              },
+              {
+                "id": 9844775,
+                "class": "apotheneum.piemonte.Origami"
+              },
+              {
+                "id": 9844776,
+                "class": "apotheneum.piemonte.ParticleWave"
+              },
+              {
+                "id": 9844777,
+                "class": "apotheneum.piemonte.PlayaStrobe"
+              },
+              {
+                "id": 9844778,
+                "class": "apotheneum.piemonte.Overflow"
+              },
+              {
+                "id": 9844779,
+                "class": "apotheneum.piemonte.Bruh"
+              },
+              {
+                "id": 9844780,
+                "class": "apotheneum.piemonte.Replies"
+              },
+              {
+                "id": 9844781,
+                "class": "apotheneum.piemonte.ReUp"
+              },
+              {
+                "id": 9844782,
+                "class": "apotheneum.piemonte.Radiate"
+              },
+              {
+                "id": 9844783,
+                "class": "apotheneum.piemonte.SpaceBoundSpecies"
+              },
+              {
+                "id": 9844784,
+                "class": "apotheneum.piemonte.SpecialKube"
+              },
+              {
+                "id": 9844785,
+                "class": "apotheneum.piemonte.Superbloom"
+              },
+              {
+                "id": 9844786,
+                "class": "apotheneum.piemonte.TheHumanRace"
+              },
+              {
+                "id": 9844787,
+                "class": "apotheneum.piemonte.Cooked"
+              },
+              {
+                "id": 9844788,
+                "class": "apotheneum.piemonte.Diabolical"
+              },
+              {
+                "id": 9844789,
+                "class": "apotheneum.piemonte.TunnelVision"
+              },
+              {
+                "id": 9844790,
+                "class": "apotheneum.piemonte.WYD"
+              },
+              {
+                "id": 9844792,
+                "class": "apotheneum.piemonte.Likes"
+              },
+              {
+                "id": 9844793,
+                "class": "apotheneum.piemonte.Ghosted"
+              },
+              {
+                "id": 9845799,
+                "class": "apotheneum.piemonte.LockedIn"
+              },
+              {
+                "id": 9846805,
+                "class": "apotheneum.piemonte.Sunrise"
+              },
+              {
+                "id": 9847811,
+                "class": "apotheneum.piemonte.Nice"
+              },
+              {
+                "id": 9848817,
+                "class": "apotheneum.piemonte.CrashingOut"
+              },
+              {
+                "id": 9849823,
+                "class": "apotheneum.piemonte.SafteyThird"
+              }
+            ]
+          },
+          {
+            "id": 2559,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Color",
+              "fader": 0.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 1,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 0,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleMode/name": "NEXT",
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 2,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 2560,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 2,
+            "patterns": [
+              {
+                "id": 2578,
+                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Gradient",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "xAmount": 0.3786542327143252,
+                  "yAmount": -0.40146168984938413,
+                  "zAmount": 0.0,
+                  "xOffset": 0.0,
+                  "yOffset": 0.0,
+                  "zOffset": 0.0,
+                  "colorMode": 2,
+                  "colorMode/name": "PALETTE",
+                  "blendMode": 0,
+                  "blendMode/name": "RGB",
+                  "gradient": 0.0,
+                  "fixedColor/brightness": 100.0,
+                  "fixedColor/saturation": 100.0,
+                  "fixedColor/hue": 0.0,
+                  "xMode": 2,
+                  "xMode/name": "RADIAL",
+                  "yMode": 1,
+                  "yMode/name": "CENTER",
+                  "zMode": 2,
+                  "zMode/name": "RADIAL",
+                  "paletteIndex": 1,
+                  "paletteStops": 5,
+                  "gradientRange": 360.0,
+                  "saturationRange": 0.0,
+                  "brightnessRange": 0.0,
+                  "gradientClamp": 0,
+                  "gradientClamp/name": "CLAMP",
+                  "gradientPhase": 0.0,
+                  "gradientScale": 1.0,
+                  "gradientCompress": 1.0,
+                  "gradientInvert": true,
+                  "rotate": true,
+                  "yaw": 227.65781191934366,
+                  "pitch": 0.0,
+                  "roll": 0.0,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 2579,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [
+                      {
+                        "id": 2644,
+                        "class": "heronarts.lx.modulator.CycleModulator",
+                        "internal": {
+                          "modulationColor": 1,
+                          "modulationControlsExpanded": true,
+                          "modulationsExpanded": true
+                        },
+                        "parameters": {
+                          "label": "Cycle",
+                          "running": true,
+                          "trigger": false,
+                          "reset": false,
+                          "midiSource/index": 0,
+                          "midiFilter/enabled": true,
+                          "midiFilter/channel": 16,
+                          "midiFilter/channel/name": "OMNI",
+                          "midiFilter/minNote": 0,
+                          "midiFilter/noteRange": 128,
+                          "midiFilter/minVelocity": 1,
+                          "midiFilter/velocityRange": 127,
+                          "speedUnipolar": 0.34445312450407073,
+                          "speedBipolar": 1.0,
+                          "speedRangeHz": 0.1,
+                          "speedPolarity": 0,
+                          "speedPolarity/name": "UNIPOLAR"
+                        },
+                        "children": {}
+                      }
+                    ],
+                    "modulations": [
+                      {
+                        "source": {
+                          "id": 2644,
+                          "path": "/modulation/modulator/1"
+                        },
+                        "target": {
+                          "componentId": 2578,
+                          "parameterPath": "pitch",
+                          "path": "/pitch"
+                        },
+                        "id": 2645,
+                        "class": "heronarts.lx.modulation.LXCompoundModulation",
+                        "internal": {
+                          "modulationColor": 0,
+                          "modulationControlsExpanded": true,
+                          "modulationsExpanded": true
+                        },
+                        "parameters": {
+                          "label": "LX",
+                          "enabled": true,
+                          "polarity": 0,
+                          "polarity/name": "UNIPOLAR",
+                          "range": 1.0
+                        },
+                        "children": {}
+                      }
+                    ],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": []
+              },
+              {
+                "id": 11970,
+                "class": "heronarts.lx.pattern.form.ChevronPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": true
+                },
+                "parameters": {
+                  "label": "Chevron",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "x": 0.5,
+                  "y": 0.5,
+                  "z": 0.0,
+                  "xAmt": 1.0,
+                  "yAmt": 1.0,
+                  "zAmt": 0.0,
+                  "stripes": 0.8699795451325552,
+                  "sharp": 2.6845640966590416,
+                  "speedUnipolar": 100.0,
+                  "speedBipolar": 2.570311981253326,
+                  "speedIsBipolar": true,
+                  "speedRange": 1.0,
+                  "tempoSync": false,
+                  "tempoDivision": 4,
+                  "tempoDivision/name": "QUARTER",
+                  "reverse": false,
+                  "invert": 0.0,
+                  "level": 1.0,
+                  "rotate": true,
+                  "yaw": 0.0,
+                  "pitch": 0.0,
+                  "roll": 0.0,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 11971,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [
+                      {
+                        "id": 12005,
+                        "class": "heronarts.lx.modulator.CycleModulator",
+                        "internal": {
+                          "modulationColor": 4,
+                          "modulationControlsExpanded": true,
+                          "modulationsExpanded": true
+                        },
+                        "parameters": {
+                          "label": "Cycle",
+                          "running": true,
+                          "trigger": false,
+                          "reset": false,
+                          "midiSource/index": 0,
+                          "midiFilter/enabled": true,
+                          "midiFilter/channel": 16,
+                          "midiFilter/channel/name": "OMNI",
+                          "midiFilter/minNote": 0,
+                          "midiFilter/noteRange": 128,
+                          "midiFilter/minVelocity": 1,
+                          "midiFilter/velocityRange": 127,
+                          "speedUnipolar": 0.13945313007570803,
+                          "speedBipolar": 1.0,
+                          "speedRangeHz": 0.1,
+                          "speedPolarity": 0,
+                          "speedPolarity/name": "UNIPOLAR"
+                        },
+                        "children": {}
+                      }
+                    ],
+                    "modulations": [
+                      {
+                        "source": {
+                          "id": 12005,
+                          "path": "/modulation/modulator/1"
+                        },
+                        "target": {
+                          "componentId": 11970,
+                          "parameterPath": "yaw",
+                          "path": "/yaw"
+                        },
+                        "id": 12006,
+                        "class": "heronarts.lx.modulation.LXCompoundModulation",
+                        "internal": {
+                          "modulationColor": 0,
+                          "modulationControlsExpanded": true,
+                          "modulationsExpanded": true
+                        },
+                        "parameters": {
+                          "label": "LX",
+                          "enabled": true,
+                          "polarity": 0,
+                          "polarity/name": "UNIPOLAR",
+                          "range": 1.0
+                        },
+                        "children": {}
+                      }
+                    ],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": [
+                  {
+                    "id": 11983,
+                    "class": "heronarts.lx.effect.color.ColorizeEffect",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true,
+                      "expanded": true,
+                      "expandedCue": true,
+                      "expandedAux": true,
+                      "modulationExpanded": false
+                    },
+                    "parameters": {
+                      "label": "Colorize",
+                      "midiFilter/enabled": true,
+                      "midiFilter/channel": 16,
+                      "midiFilter/channel/name": "OMNI",
+                      "midiFilter/minNote": 0,
+                      "midiFilter/noteRange": 128,
+                      "midiFilter/minVelocity": 1,
+                      "midiFilter/velocityRange": 127,
+                      "view": 0,
+                      "viewPriority": 0,
+                      "enabled": true,
+                      "locked": false,
+                      "source": 2,
+                      "source/name": "RED",
+                      "gradientHue": 0.0,
+                      "gradientSaturation": 0.0,
+                      "gradientBrightness": 0.0,
+                      "colorMode": 3,
+                      "colorMode/name": "PALETTE",
+                      "blendMode": 0,
+                      "blendMode/name": "RGB",
+                      "color1/brightness": 0.0,
+                      "color1/saturation": 0.0,
+                      "color1/hue": 0.0,
+                      "color2/brightness": 100.0,
+                      "color2/saturation": 0.0,
+                      "color2/hue": 0.0,
+                      "paletteIndex": 1,
+                      "paletteStops": 3,
+                      "paletteInvert": false,
+                      "paletteDepth": 1.0,
+                      "primaryHue": 0.0,
+                      "primarySaturation": 0.0,
+                      "primaryBrightness": 0.0,
+                      "amount": 1.0,
+                      "filterThreshold": 0.0,
+                      "filterMode": 0,
+                      "filterMode/name": "LEAVE"
+                    },
+                    "children": {
+                      "modulation": {
+                        "id": 11984,
+                        "class": "heronarts.lx.modulation.LXModulationEngine",
+                        "internal": {
+                          "modulationColor": 0,
+                          "modulationControlsExpanded": true,
+                          "modulationsExpanded": true
+                        },
+                        "parameters": {
+                          "label": "Modulation"
+                        },
+                        "children": {},
+                        "modulators": [],
+                        "modulations": [],
+                        "triggers": []
+                      }
+                    },
+                    "deviceVersion": -1
+                  }
+                ]
+              },
+              {
+                "id": 12068,
+                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Noise",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "midpoint": 50.0,
+                  "contrast": 125.0325808340138,
+                  "minLevel": 0.0,
+                  "maxLevel": 100.0,
+                  "invert": 0.0,
+                  "xOffset": 0.0,
+                  "yOffset": 0.0,
+                  "zOffset": 0.0,
+                  "scale": 0.19570312683936208,
+                  "minScale": 1.0,
+                  "maxScale": 10.0,
+                  "xScale": 1.0,
+                  "yScale": 1.0,
+                  "zScale": 1.0,
+                  "motion": true,
+                  "motionSpeed": 0.20452535373624414,
+                  "motionSpeedRange": 72.88613173816702,
+                  "xMotion": 0.0,
+                  "yMotion": 0.9918155039194971,
+                  "zMotion": 0.0,
+                  "algorithm": 0,
+                  "algorithm/name": "PERLIN",
+                  "seed": 0,
+                  "octaves": 3,
+                  "lacunarity": 2.0,
+                  "gain": 0.5,
+                  "ridgeOffset": 0.9,
+                  "xMode": 0,
+                  "xMode/name": "NORMAL",
+                  "yMode": 0,
+                  "yMode/name": "NORMAL",
+                  "zMode": 0,
+                  "zMode/name": "NORMAL",
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 12069,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": [
+                  {
+                    "id": 12085,
+                    "class": "heronarts.lx.effect.color.ColorizeEffect",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true,
+                      "expanded": true,
+                      "expandedCue": true,
+                      "expandedAux": true,
+                      "modulationExpanded": false
+                    },
+                    "parameters": {
+                      "label": "Colorize",
+                      "midiFilter/enabled": true,
+                      "midiFilter/channel": 16,
+                      "midiFilter/channel/name": "OMNI",
+                      "midiFilter/minNote": 0,
+                      "midiFilter/noteRange": 128,
+                      "midiFilter/minVelocity": 1,
+                      "midiFilter/velocityRange": 127,
+                      "view": 0,
+                      "viewPriority": 0,
+                      "enabled": true,
+                      "locked": false,
+                      "source": 0,
+                      "source/name": "BRIGHTNESS",
+                      "gradientHue": 0.0,
+                      "gradientSaturation": 0.0,
+                      "gradientBrightness": 0.0,
+                      "colorMode": 3,
+                      "colorMode/name": "PALETTE",
+                      "blendMode": 0,
+                      "blendMode/name": "RGB",
+                      "color1/brightness": 0.0,
+                      "color1/saturation": 0.0,
+                      "color1/hue": 0.0,
+                      "color2/brightness": 100.0,
+                      "color2/saturation": 0.0,
+                      "color2/hue": 0.0,
+                      "paletteIndex": 1,
+                      "paletteStops": 3,
+                      "paletteInvert": false,
+                      "paletteDepth": 1.0,
+                      "primaryHue": 0.0,
+                      "primarySaturation": 0.0,
+                      "primaryBrightness": 0.0,
+                      "amount": 1.0,
+                      "filterThreshold": 0.0,
+                      "filterMode": 0,
+                      "filterMode/name": "LEAVE"
+                    },
+                    "children": {
+                      "modulation": {
+                        "id": 12086,
+                        "class": "heronarts.lx.modulation.LXModulationEngine",
+                        "internal": {
+                          "modulationColor": 0,
+                          "modulationControlsExpanded": true,
+                          "modulationsExpanded": true
+                        },
+                        "parameters": {
+                          "label": "Modulation"
+                        },
+                        "children": {},
+                        "modulators": [],
+                        "modulations": [],
+                        "triggers": []
+                      }
+                    },
+                    "deviceVersion": -1
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": 2595,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Sparkle",
+              "fader": 0.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 11,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleMode/name": "NEXT",
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 2596,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 2614,
+                "class": "heronarts.lx.pattern.texture.SparklePattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Sparkle",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "density": 7.562357394332107,
+                  "speed": 0.07626488094683737,
+                  "variation": 25.0,
+                  "duration": 100.0,
+                  "sharp": 0.0,
+                  "waveshape": 0,
+                  "minInterval": 0.2396232623387648,
+                  "maxInterval": 4.8896038884439585,
+                  "minLevel": 75.0,
+                  "maxLevel": 100.0,
+                  "baseLevel": 0.0,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 2615,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": []
+              }
+            ]
+          },
+          {
+            "id": 37663,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Faces",
+              "fader": 0.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 0,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 4,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleMode/name": "NEXT",
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 37664,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 37682,
+                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Gradient",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "xAmount": 1.0,
+                  "yAmount": 0.0,
+                  "zAmount": 0.0,
+                  "xOffset": 0.0,
+                  "yOffset": 0.0,
+                  "zOffset": 0.0,
+                  "colorMode": 1,
+                  "colorMode/name": "LINKED",
+                  "blendMode": 0,
+                  "blendMode/name": "RGB",
+                  "gradient": -1.0,
+                  "fixedColor/brightness": 100.0,
+                  "fixedColor/saturation": 100.0,
+                  "fixedColor/hue": 0.0,
+                  "xMode": 0,
+                  "xMode/name": "NORMAL",
+                  "yMode": 0,
+                  "yMode/name": "NORMAL",
+                  "zMode": 0,
+                  "zMode/name": "NORMAL",
+                  "paletteIndex": 1,
+                  "paletteStops": 5,
+                  "gradientRange": 360.0,
+                  "saturationRange": 0.0,
+                  "brightnessRange": 100.0,
+                  "gradientClamp": 0,
+                  "gradientClamp/name": "CLAMP",
+                  "gradientPhase": 0.0,
+                  "gradientScale": 1.0,
+                  "gradientCompress": 1.0,
+                  "gradientInvert": false,
+                  "rotate": false,
+                  "yaw": 0.0,
+                  "pitch": 0.0,
+                  "roll": 0.0,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 37683,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": []
+              }
+            ]
+          },
+          {
+            "id": 9822408,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Haptics",
+              "fader": 1.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "crossfadeGroup/name": "BYPASS",
+              "blendMode": 4,
+              "autoMute": true,
+              "midiSource/index": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/channel/name": "OMNI",
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 17,
+              "compositeMode": 0,
+              "compositeMode/name": "PLAYLIST",
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleMode/name": "NEXT",
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 2,
+              "triggerPatternCycle": false,
+              "launchPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 9822409,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 2,
+            "patterns": [
+              {
+                "id": 9822456,
+                "class": "heronarts.lx.pattern.color.SolidPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Solid",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "color/brightness": 100.0,
+                  "color/saturation": 100.0,
+                  "color/hue": 0.0,
+                  "color/mode": 0,
+                  "color/mode/name": "STATIC",
+                  "color/index": 1,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 9822457,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": []
+              },
+              {
+                "id": 9822469,
+                "class": "heronarts.lx.pattern.form.ChevronPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Chevron",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "x": 0.5,
+                  "y": 0.5,
+                  "z": 0.5,
+                  "xAmt": 1.0,
+                  "yAmt": 0.0,
+                  "zAmt": -1.0,
+                  "stripes": 0.9824487587954384,
+                  "sharp": 1.860681570730794,
+                  "speedUnipolar": 100.0,
+                  "speedBipolar": 20.109374907042366,
+                  "speedIsBipolar": true,
+                  "speedRange": 1.0,
+                  "tempoSync": false,
+                  "tempoDivision": 4,
+                  "tempoDivision/name": "QUARTER",
+                  "reverse": false,
+                  "invert": 0.0,
+                  "level": 1.0,
+                  "rotate": false,
+                  "yaw": 0.0,
+                  "pitch": 0.0,
+                  "roll": 0.0,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 9822470,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": []
+              },
+              {
+                "id": 9822498,
+                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Noise",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "midpoint": 46.08203116804361,
+                  "contrast": 164.0944072890909,
+                  "minLevel": 0.0,
+                  "maxLevel": 100.0,
+                  "invert": 0.0,
+                  "xOffset": 0.0,
+                  "yOffset": 0.0,
+                  "zOffset": 0.0,
+                  "scale": 0.1274609403917566,
+                  "minScale": 1.0,
+                  "maxScale": 10.0,
+                  "xScale": 1.0,
+                  "yScale": 1.0,
+                  "zScale": 1.0,
+                  "motion": true,
+                  "motionSpeed": 0.5057488232268952,
+                  "motionSpeedRange": 12.0,
+                  "xMotion": 0.0,
+                  "yMotion": 1.0,
+                  "zMotion": 0.0,
+                  "algorithm": 0,
+                  "algorithm/name": "PERLIN",
+                  "seed": 0,
+                  "octaves": 3,
+                  "lacunarity": 2.0,
+                  "gain": 0.5,
+                  "ridgeOffset": 0.9,
+                  "xMode": 0,
+                  "xMode/name": "NORMAL",
+                  "yMode": 0,
+                  "yMode/name": "NORMAL",
+                  "zMode": 0,
+                  "zMode/name": "NORMAL",
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 9822499,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": []
+              }
+            ]
+          }
+        ]
+      },
+      "modulation": {
+        "id": 98,
+        "class": "heronarts.lx.modulation.LXModulationEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Modulation"
+        },
+        "children": {},
+        "modulators": [],
+        "modulations": [],
+        "triggers": []
+      },
+      "output": {
+        "id": 99,
+        "class": "heronarts.lx.LXEngine$Output",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Output",
+          "enabled": false,
+          "brightness": 1.0,
+          "fps": 0.0,
+          "gamma": 1.0,
+          "gammaMode": 1,
+          "gammaMode/name": "DIRECT",
+          "whitePointRed": 255,
+          "whitePointGreen": 255,
+          "whitePointBlue": 255,
+          "whitePointWhite": 255
+        },
+        "children": {}
+      },
+      "snapshots": {
+        "id": 101,
+        "class": "heronarts.lx.snapshot.LXSnapshotEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Snapshots",
+          "recallMixer": true,
+          "recallModulation": true,
+          "recallPattern": true,
+          "recallEffect": true,
+          "recallMaster": true,
+          "recallOutput": false,
+          "channelMode": 1,
+          "channelMode/name": "FADE",
+          "missingChannelMode": 0,
+          "missingChannelMode/name": "IGNORE",
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleMode/name": "NEXT",
+          "autoCycleTimeSecs": 60.0,
+          "autoCycleCursor": -1,
+          "triggerSnapshotCycle": false
+        },
+        "children": {},
+        "snapshots": []
+      },
+      "dmx": {
+        "id": 102,
+        "class": "heronarts.lx.dmx.LXDmxEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "artNetReceiveHost": "0.0.0.0",
+          "artNetReceivePort": 6454,
+          "artNetReceiveActive": false,
+          "artNetLog": false
+        },
+        "children": {}
+      },
+      "midi": {
+        "id": 103,
+        "class": "heronarts.lx.midi.LXMidiEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "computerKeyboardEnabled": true,
+          "computerKeyboardOctave": 6,
+          "computerKeyboardVelocity": 2,
+          "computerKeyboardChannel": 0
+        },
+        "children": {},
+        "templates": [],
+        "mapping": []
+      },
+      "osc": {
+        "id": 104,
+        "class": "heronarts.lx.osc.LXOscEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "OSC",
+          "receiveHost": "0.0.0.0",
+          "receivePort": 3030,
+          "receiveActive": false,
+          "transmitHost": "localhost",
+          "transmitPort": 4040,
+          "transmitActive": true,
+          "logInput": false,
+          "logOutput": false
+        },
+        "children": {},
+        "inputs": [],
+        "outputs": []
+      }
+    }
+  },
+  "externals": {
+    "ui": {
+      "leftPaneActiveSection": 1,
+      "audioExpanded": true,
+      "envelopExpanded": true,
+      "reaperExpanded": true,
+      "paletteExpanded": true,
+      "cameraExpanded": true,
+      "mixerCentered": false,
+      "fixtureInspectorExpanded": true,
+      "viewsExpanded": true,
+      "soundStageExpanded": true,
+      "preview": {
+        "projection": 0,
+        "projection/name": "PERSPECTIVE",
+        "perspective": 60.0,
+        "depth": 2.0,
+        "animationTime": 2000.0,
+        "animationEase": 1.0,
+        "animationEaseShape": 1,
+        "animationEaseShape/name": "QUADRATIC",
+        "animationClampY": true,
+        "animationMinY": 40.0,
+        "animationMaxY": 1000.0,
+        "animation": true,
+        "camera": {
+          "active": true,
+          "radius": 994.3555026051904,
+          "theta": 342.67047444265336,
+          "phi": 17.06061791884713,
+          "x": 245.5,
+          "y": 237.0,
+          "z": 245.5
+        },
+        "cue": [
+          {
+            "active": true,
+            "radius": 994.3555026051904,
+            "theta": 342.67047444265336,
+            "phi": 17.06061791884713,
+            "x": 245.5,
+            "y": 237.0,
+            "z": 245.5
+          },
+          {
+            "active": true,
+            "radius": 202.6420865401347,
+            "theta": 359.9906089513097,
+            "phi": -88.745351113379,
+            "x": 245.5,
+            "y": 237.0,
+            "z": 245.5
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "autopilot": {
+          "enabled": false,
+          "radiusPeriod": 15.0,
+          "radiusMin": 120.0,
+          "radiusMax": 120.0,
+          "radiusContrast": 0.0,
+          "radiusMotion": 2,
+          "radiusMotion/name": "NOISE",
+          "thetaPeriod": 60.0,
+          "thetaMin": 0.0,
+          "thetaMax": 360.0,
+          "thetaContrast": 0.0,
+          "thetaMotion": 1,
+          "thetaMotion/name": "CYCLE",
+          "phiPeriod": 15.0,
+          "phiMin": 0.0,
+          "phiMax": 30.0,
+          "phiContrast": 0.0,
+          "phiMotion": 2,
+          "phiMotion/name": "NOISE"
+        },
+        "focus": 0,
+        "pointCloud": {
+          "ledStyle": 2,
+          "ledStyle/name": "LENS3",
+          "pointSize": 7.0,
+          "alphaRef": 0,
+          "feather": 0.7000000000000001,
+          "sparkle": 1.0,
+          "sparkleCurve": 2.0,
+          "sparkleRotate": 127.30781380087137,
+          "directional": 1,
+          "directional/name": "DIRECTED",
+          "directionalDispersion": 180.0,
+          "directionalContrast": 0.9,
+          "directionalShowNormals": false,
+          "directionalShowNormalsLength": 5.0,
+          "contrast": 1.0,
+          "depthTest": true,
+          "useCustomParams": false
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "size": 10,
+          "plane": 0,
+          "planes": 1,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "neg1": false,
+          "neg2": false
+        },
+        "axes": {
+          "visible": false
+        }
+      },
+      "previewAux": {
+        "projection": 0,
+        "projection/name": "PERSPECTIVE",
+        "perspective": 60.0,
+        "depth": 2.0,
+        "animationTime": 1000.0,
+        "animationEase": 0.0,
+        "animationEaseShape": 0,
+        "animationEaseShape/name": "SINUSOIDAL",
+        "animationClampY": false,
+        "animationMinY": 0.0,
+        "animationMaxY": 10000.0,
+        "animation": false,
+        "camera": {
+          "active": false,
+          "radius": 982.0,
+          "theta": 0.0,
+          "phi": 0.0,
+          "x": 245.5,
+          "y": 237.0,
+          "z": 245.5
+        },
+        "cue": [
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "autopilot": {
+          "enabled": false,
+          "radiusPeriod": 15.0,
+          "radiusMin": 120.0,
+          "radiusMax": 120.0,
+          "radiusContrast": 0.0,
+          "radiusMotion": 2,
+          "radiusMotion/name": "NOISE",
+          "thetaPeriod": 60.0,
+          "thetaMin": 0.0,
+          "thetaMax": 360.0,
+          "thetaContrast": 0.0,
+          "thetaMotion": 1,
+          "thetaMotion/name": "CYCLE",
+          "phiPeriod": 15.0,
+          "phiMin": 0.0,
+          "phiMax": 30.0,
+          "phiContrast": 0.0,
+          "phiMotion": 2,
+          "phiMotion/name": "NOISE"
+        },
+        "focus": 0,
+        "pointCloud": {
+          "ledStyle": 0,
+          "ledStyle/name": "LENS1",
+          "pointSize": 3.0,
+          "alphaRef": 8,
+          "feather": 0.5,
+          "sparkle": 1.0,
+          "sparkleCurve": 2.0,
+          "sparkleRotate": 45.0,
+          "directional": 0,
+          "directional/name": "OMNI",
+          "directionalDispersion": 180.0,
+          "directionalContrast": 0.0,
+          "directionalShowNormals": false,
+          "directionalShowNormalsLength": 5.0,
+          "contrast": 1.0,
+          "depthTest": true,
+          "useCustomParams": false
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "size": 10,
+          "plane": 0,
+          "planes": 1,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "neg1": false,
+          "neg2": false
+        },
+        "axes": {
+          "visible": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
adds the next batch of piemonte patterns. all files live flat in apotheneum/piemonte/.

patterns:
- replies: glowing dots glide along the cylinder's rings or columns, each trailing a soft afterglow. when two dots collide they burst — and the cube answers: the face looking toward the collision flickers in reply, the outer chamber echoing the inner one.
- reup: every vertical string is lit solid. on each bass hit, a random group of strings is knocked dark; they then fade — "re-up" — back to full, while new groups drop out on the next hits.
- tunnelvision: vertical tunnels of glowing hoops climb the surfaces. each chain draws upward ring by ring from its base — every ring smaller and closer than the last, a tunnel receding into the sky — hangs complete for a beat, then collapses in the same order.
- afterglow: joints of light scattered across the surfaces, each constantly pulsing white dots outward along its own rays — a handful of directions at arbitrary angles, like edges meeting at a vertex. the joints themselves stay dark; all you see is the endless soft...

also adds apotheneum-piemonte.lxp under resources/projects - a ready-to-load project with deck channels running these patterns.

depends on #49

will attach video