### PR TITLE
Add brightness-preserving colorize effect

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-# Compile check on every PR and every push to main, so breakage is caught here
+# Build and test on every PR and every push to main, so breakage is caught here
 # rather than the next time someone builds locally.
 #
 # `mvn package` compiles the package and runs the headless-LX component tests.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 # Compile check on every PR and every push to main, so breakage is caught here
 # rather than the next time someone builds locally.
 #
-# This is a compile check only — the project has no src/test yet. If tests are
-# added later, `mvn package` runs them with no change to this file.
+# `mvn package` compiles the package and runs the headless-LX component tests.
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ $ mvn -Pinstall install
 
 This builds the JAR file and copies it to `~/Chromatik/Packages` for automatic loading in Chromatik.
 
+Headless component tests can be run without installing the package:
+
+```bash
+$ mvn test
+```
+
 #### Releasing
 
 Releases are cut by pushing a calendar tag. CI builds the JAR and creates the GitHub

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <junit.version>5.11.3</junit.version>
+        <junit-platform-launcher.version>1.11.3</junit-platform-launcher.version>
         
     </properties>
     
@@ -39,6 +42,18 @@
             <artifactId>glxstudio</artifactId>
             <version>${lx.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit-platform-launcher.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
   	
@@ -79,6 +94,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java
+++ b/src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java
@@ -1,0 +1,350 @@
+package apotheneum.doved.effects;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.LXComponent;
+import heronarts.lx.color.ColorParameter;
+import heronarts.lx.color.GradientUtils.BlendFunction;
+import heronarts.lx.color.GradientUtils.BlendMode;
+import heronarts.lx.color.GradientUtils.ColorStops;
+import heronarts.lx.color.GradientUtils.GradientFunction;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LXDynamicColor;
+import heronarts.lx.color.LXPalette;
+import heronarts.lx.color.LXSwatch;
+import heronarts.lx.effect.LXEffect;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory(LXCategory.COLOR)
+@LXComponent.Description("Colorizes by brightness while preserving the source form")
+public class ColorizeMultiplyEffect extends LXEffect implements GradientFunction {
+
+  public interface SourceFunction {
+    float getLerpFactor(int argb);
+  }
+
+  public enum SourceMode {
+    BRIGHTNESS("Brightness", (argb) -> LXColor.b(argb) * .01f),
+    LUMINOSITY("Luminosity", (argb) -> LXColor.luminosity(argb) * .01f);
+
+    private final String label;
+    public final SourceFunction lerp;
+
+    SourceMode(String label, SourceFunction lerp) {
+      this.label = label;
+      this.lerp = lerp;
+    }
+
+    @Override
+    public String toString() {
+      return this.label;
+    }
+  }
+
+  public enum ColorMode {
+    FIXED("Fixed"),
+    RELATIVE("Relative"),
+    LINKED("Linked"),
+    PALETTE("Palette");
+
+    private final String label;
+
+    ColorMode(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return this.label;
+    }
+  }
+
+  public enum ThresholdMode {
+    LEAVE("Leave"),
+    BLACK("Black"),
+    CLEAR("Clear");
+
+    private final String label;
+
+    ThresholdMode(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return this.label;
+    }
+  }
+
+  public final CompoundParameter depth =
+    new CompoundParameter("Depth", 1)
+    .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+    .setDescription("How strongly source brightness scales the gradient color");
+
+  public final EnumParameter<SourceMode> source =
+    new EnumParameter<SourceMode>("Source", SourceMode.BRIGHTNESS)
+    .setDescription("Source value used to index and scale the gradient");
+
+  public final CompoundParameter threshold =
+    new CompoundParameter("Threshold", 0)
+    .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+    .setDescription("Source values below this level are gated without remapping the gradient");
+
+  public final EnumParameter<ThresholdMode> thresholdMode =
+    new EnumParameter<ThresholdMode>("Threshold Mode", ThresholdMode.LEAVE)
+    .setDescription("How to treat colors beneath the threshold");
+
+  public final EnumParameter<BlendMode> blendMode =
+    new EnumParameter<BlendMode>("Blend Mode", BlendMode.RGB)
+    .setDescription("How colors are interpolated between gradient stops");
+
+  public final EnumParameter<ColorMode> colorMode =
+    new EnumParameter<ColorMode>("Color Mode", ColorMode.FIXED)
+    .setDescription("Which source supplies the gradient colors");
+
+  public final ColorParameter color1 =
+    new ColorParameter("Color 1", 0xff000000)
+    .setDescription("The first fixed or relative gradient color");
+
+  public final ColorParameter color2 =
+    new ColorParameter("Color 2", 0xffffffff)
+    .setDescription("The second fixed gradient color");
+
+  public final CompoundParameter gradientHue =
+    new CompoundParameter("H-Offset", 0, -360, 360)
+    .setUnits(CompoundParameter.Units.DEGREES)
+    .setDescription("Hue offset of the relative or linked gradient")
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+  public final CompoundParameter gradientSaturation =
+    new CompoundParameter("S-Offset", 0, -100, 100)
+    .setUnits(CompoundParameter.Units.PERCENT)
+    .setDescription("Saturation offset of the relative or linked gradient")
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+  public final CompoundParameter gradientBrightness =
+    new CompoundParameter("B-Offset", 0, -100, 100)
+    .setUnits(CompoundParameter.Units.PERCENT)
+    .setDescription("Brightness offset of the relative or linked gradient")
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+  public final CompoundParameter linkedHue =
+    new CompoundParameter("H-Linked", 0, -360, 360)
+    .setUnits(CompoundParameter.Units.DEGREES)
+    .setDescription("Hue offset from the linked palette color")
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+  public final CompoundParameter linkedSaturation =
+    new CompoundParameter("S-Linked", 0, -100, 100)
+    .setUnits(CompoundParameter.Units.PERCENT)
+    .setDescription("Saturation offset from the linked palette color")
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+  public final CompoundParameter linkedBrightness =
+    new CompoundParameter("B-Linked", 0, -100, 100)
+    .setUnits(CompoundParameter.Units.PERCENT)
+    .setDescription("Brightness offset from the linked palette color")
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+  public final DiscreteParameter paletteIndex =
+    new LXPalette.IndexSelector("Index")
+    .setDescription("First palette color used by the gradient");
+
+  public final DiscreteParameter paletteStops =
+    new DiscreteParameter("Stops", LXSwatch.MAX_COLORS, 2, LXSwatch.MAX_COLORS + 1)
+    .setDescription("Number of palette colors used by the gradient");
+
+  public final BooleanParameter paletteInvert =
+    new BooleanParameter("Invert", false)
+    .setDescription("Reverses the palette gradient");
+
+  public final CompoundParameter paletteDepth =
+    new CompoundParameter("Palette Depth", 1)
+    .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+    .setDescription("Fraction of the palette gradient used");
+
+  public final CompoundParameter amount =
+    new CompoundParameter("Amount", 1)
+    .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+    .setDescription("Crossfade between the input and colorized result");
+
+  private final ColorStops colorStops = new ColorStops();
+
+  public ColorizeMultiplyEffect(LX lx) {
+    super(lx);
+    addParameter("depth", this.depth);
+    addParameter("source", this.source);
+    addParameter("threshold", this.threshold);
+    addParameter("thresholdMode", this.thresholdMode);
+    addParameter("blendMode", this.blendMode);
+    addParameter("colorMode", this.colorMode);
+    addParameter("color1", this.color1);
+    addParameter("color2", this.color2);
+    addParameter("gradientHue", this.gradientHue);
+    addParameter("gradientSaturation", this.gradientSaturation);
+    addParameter("gradientBrightness", this.gradientBrightness);
+    addParameter("primaryHue", this.linkedHue);
+    addParameter("primarySaturation", this.linkedSaturation);
+    addParameter("primaryBrightness", this.linkedBrightness);
+    addParameter("paletteIndex", this.paletteIndex);
+    addParameter("paletteStops", this.paletteStops);
+    addParameter("paletteInvert", this.paletteInvert);
+    addParameter("paletteDepth", this.paletteDepth);
+    addParameter("amount", this.amount);
+  }
+
+  @Override
+  public void onParameterChanged(LXParameter parameter) {
+    if (parameter == this.colorMode ||
+        parameter == this.color1 ||
+        parameter == this.gradientHue ||
+        parameter == this.gradientSaturation ||
+        parameter == this.gradientBrightness ||
+        parameter == this.linkedHue ||
+        parameter == this.linkedSaturation ||
+        parameter == this.linkedBrightness) {
+      updateGradientParameters();
+    }
+  }
+
+  private void updateGradientParameters() {
+    if (this.colorMode.getEnum() == ColorMode.RELATIVE) {
+      this.color2.brightness.setValue(this.color1.brightness.getValue() + this.gradientBrightness.getValue());
+      this.color2.saturation.setValue(this.color1.saturation.getValue() + this.gradientSaturation.getValue());
+      this.color2.hue.setValue((360 + this.color1.hue.getValue() + this.gradientHue.getValue()) % 360);
+    } else if (this.colorMode.getEnum() == ColorMode.LINKED) {
+      LXDynamicColor swatchColor = getSwatchColor();
+      this.color1.brightness.setValue(swatchColor.getBrightness() + this.linkedBrightness.getValue());
+      this.color1.saturation.setValue(swatchColor.getSaturation() + this.linkedSaturation.getValue());
+      this.color1.hue.setValue((360 + swatchColor.getHue() + this.linkedHue.getValue()) % 360);
+      this.color2.brightness.setValue(swatchColor.getBrightness() + this.gradientBrightness.getValue());
+      this.color2.saturation.setValue(swatchColor.getSaturation() + this.gradientSaturation.getValue());
+      this.color2.hue.setValue((360 + swatchColor.getHue() + this.gradientHue.getValue()) % 360);
+    }
+  }
+
+  public LXDynamicColor getSwatchColor() {
+    return this.lx.engine.palette.getSwatchColor(this.paletteIndex.getValuei() - 1);
+  }
+
+  private void updateColorStops() {
+    switch (this.colorMode.getEnum()) {
+      case FIXED -> {
+        this.colorStops.stops[0].set(this.color1);
+        this.colorStops.stops[1].set(this.color2);
+        this.colorStops.setNumStops(2);
+      }
+      case RELATIVE -> {
+        this.colorStops.stops[0].set(this.color1);
+        this.colorStops.stops[1].set(this.color1,
+          this.gradientHue.getValuef(),
+          this.gradientSaturation.getValuef(),
+          this.gradientBrightness.getValuef());
+        this.colorStops.setNumStops(2);
+      }
+      case LINKED -> {
+        LXDynamicColor swatchColor = getSwatchColor();
+        this.colorStops.stops[0].set(swatchColor,
+          this.linkedHue.getValuef(),
+          this.linkedSaturation.getValuef(),
+          this.linkedBrightness.getValuef());
+        this.colorStops.stops[1].set(swatchColor,
+          this.gradientHue.getValuef(),
+          this.gradientSaturation.getValuef(),
+          this.gradientBrightness.getValuef());
+        this.colorStops.setNumStops(2);
+      }
+      case PALETTE -> this.colorStops.setPaletteGradient(
+        this.lx.engine.palette,
+        this.paletteIndex.getValuei() - 1,
+        this.paletteStops.getValuei());
+    }
+  }
+
+  @Override
+  public int getGradientColor(float lerp) {
+    lerp *= this.paletteDepth.getValuef();
+    if (this.paletteInvert.isOn()) {
+      lerp = 1 - lerp;
+    }
+    return this.colorStops.getColor(lerp, this.blendMode.getEnum().function);
+  }
+
+  @Override
+  protected void run(double deltaMs, double enabledAmount) {
+    updateGradientParameters();
+    updateColorStops();
+
+    final float effectAmount = (float) (enabledAmount * this.amount.getValue());
+    if (effectAmount == 0) {
+      return;
+    }
+
+    final SourceFunction sourceFunction = this.source.getEnum().lerp;
+    final BlendFunction blendFunction = this.blendMode.getEnum().function;
+    final boolean palette = this.colorMode.getEnum() == ColorMode.PALETTE;
+    final float gradientDepth = palette ? this.paletteDepth.getValuef() : 1;
+    final boolean invert = palette && this.paletteInvert.isOn();
+    final float depth = this.depth.getValuef();
+    final float threshold = this.threshold.getValuef();
+    final ThresholdMode thresholdMode = this.thresholdMode.getEnum();
+
+    for (LXPoint point : this.model.points) {
+      final int index = point.index;
+      final int original = this.colors[index];
+      final float sourceValue = sourceFunction.getLerpFactor(original);
+
+      if (sourceValue < threshold) {
+        switch (thresholdMode) {
+          case LEAVE -> { }
+          case BLACK -> this.colors[index] = blendRgbPreserveAlpha(original, LXColor.BLACK, effectAmount);
+          case CLEAR -> this.colors[index] = fadeAlpha(original, effectAmount);
+        }
+        continue;
+      }
+
+      // Exact zero is the core black-preservation guarantee, including at depth=0.
+      if (sourceValue == 0) {
+        this.colors[index] = blendRgbPreserveAlpha(original, LXColor.BLACK, effectAmount);
+        continue;
+      }
+
+      float gradientLerp = sourceValue * gradientDepth;
+      if (invert) {
+        gradientLerp = 1 - gradientLerp;
+      }
+      final int gradientColor = this.colorStops.getColor(gradientLerp, blendFunction);
+      final int multipliedColor = LXColor.scaleBrightness(gradientColor, sourceValue);
+      final int depthColor = lerpRgb(gradientColor, multipliedColor, depth);
+      this.colors[index] = blendRgbPreserveAlpha(original, depthColor, effectAmount);
+    }
+  }
+
+  private static int fadeAlpha(int color, float amount) {
+    final int alpha = LXUtils.lerpi(color >>> LXColor.ALPHA_SHIFT, 0, amount);
+    return (alpha << LXColor.ALPHA_SHIFT) | (color & LXColor.RGB_MASK);
+  }
+
+  private static int blendRgbPreserveAlpha(int original, int target, float amount) {
+    return (original & LXColor.ALPHA_MASK) | (lerpRgb(original, target, amount) & LXColor.RGB_MASK);
+  }
+
+  private static int lerpRgb(int from, int to, float amount) {
+    final int red = LXUtils.lerpi(
+      (from & LXColor.R_MASK) >>> LXColor.R_SHIFT,
+      (to & LXColor.R_MASK) >>> LXColor.R_SHIFT,
+      amount);
+    final int green = LXUtils.lerpi(
+      (from & LXColor.G_MASK) >>> LXColor.G_SHIFT,
+      (to & LXColor.G_MASK) >>> LXColor.G_SHIFT,
+      amount);
+    final int blue = LXUtils.lerpi(from & LXColor.B_MASK, to & LXColor.B_MASK, amount);
+    return (red << LXColor.R_SHIFT) | (green << LXColor.G_SHIFT) | blue;
+  }
+}

--- a/src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java
+++ b/src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java
@@ -1,3 +1,25 @@
+/**
+ * Copyright 2020- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * Gradient configuration and parameter behavior are derived from
+ * heronarts.lx.effect.color.ColorizeEffect. Rendering changes by Dan Oved.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ * @author Dan Oved
+ */
+
 package apotheneum.doved.effects;
 
 import heronarts.lx.LX;
@@ -85,7 +107,7 @@ public class ColorizeMultiplyEffect extends LXEffect implements GradientFunction
   public final CompoundParameter depth =
     new CompoundParameter("Depth", 1)
     .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
-    .setDescription("How strongly source brightness scales the gradient color");
+    .setDescription("Blends from plain colorize RGB with source alpha retained to full brightness scaling");
 
   public final EnumParameter<SourceMode> source =
     new EnumParameter<SourceMode>("Source", SourceMode.BRIGHTNESS)
@@ -292,6 +314,8 @@ public class ColorizeMultiplyEffect extends LXEffect implements GradientFunction
     final float gradientDepth = palette ? this.paletteDepth.getValuef() : 1;
     final boolean invert = palette && this.paletteInvert.isOn();
     final float depth = this.depth.getValuef();
+    final boolean zeroDepth = depth == 0;
+    final boolean fullDepth = depth == 1;
     final float threshold = this.threshold.getValuef();
     final ThresholdMode thresholdMode = this.thresholdMode.getEnum();
 
@@ -320,18 +344,29 @@ public class ColorizeMultiplyEffect extends LXEffect implements GradientFunction
         gradientLerp = 1 - gradientLerp;
       }
       final int gradientColor = this.colorStops.getColor(gradientLerp, blendFunction);
-      final int multipliedColor = LXColor.scaleBrightness(gradientColor, sourceValue);
-      final int depthColor = lerpRgb(gradientColor, multipliedColor, depth);
+      final int depthColor;
+      if (zeroDepth) {
+        depthColor = gradientColor;
+      } else {
+        final int multipliedColor = LXColor.scaleBrightness(gradientColor, sourceValue);
+        depthColor = fullDepth ? multipliedColor : lerpRgb(gradientColor, multipliedColor, depth);
+      }
       this.colors[index] = blendRgbPreserveAlpha(original, depthColor, effectAmount);
     }
   }
 
   private static int fadeAlpha(int color, float amount) {
+    if (amount == 1) {
+      return color & LXColor.RGB_MASK;
+    }
     final int alpha = LXUtils.lerpi(color >>> LXColor.ALPHA_SHIFT, 0, amount);
     return (alpha << LXColor.ALPHA_SHIFT) | (color & LXColor.RGB_MASK);
   }
 
   private static int blendRgbPreserveAlpha(int original, int target, float amount) {
+    if (amount == 1) {
+      return (original & LXColor.ALPHA_MASK) | (target & LXColor.RGB_MASK);
+    }
     return (original & LXColor.ALPHA_MASK) | (lerpRgb(original, target, amount) & LXColor.RGB_MASK);
   }
 

--- a/src/main/resources/catalog/apotheneum.doved.effects.ColorizeMultiplyEffect.md
+++ b/src/main/resources/catalog/apotheneum.doved.effects.ColorizeMultiplyEffect.md
@@ -1,0 +1,32 @@
+---
+class: apotheneum.doved.effects.ColorizeMultiplyEffect
+kind: effect
+sourceRepo: Apotheneum
+sourcePath: src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java
+sourceSha256: 1f9cb6ffb039abb0faea5cd1f8ae1954d5204afe6b6bfe8d955584b6cdf02769
+classBytesSha256: 4301ad780c2d2f51ce058f394ef3a07ba6ad11683dd3ad7dbd54a404930139ee
+classBytesOrigin: target/classes
+lxVersion: 1.2.2
+generatedAt: 2026-08-11T00:00:00Z
+generator: chromatik-mcp-catalog/2 (codex)
+tags: color, gradient, palette, brightness
+---
+
+## Summary
+
+ColorizeMultiplyEffect maps incoming brightness or luminosity to a gradient while retaining the source image's form.
+- Source value selects a gradient hue and scales that hue's brightness, so exact black remains black even when the first gradient stop is saturated.
+- Source alpha is retained by colorization; transparent threshold gating is the intentional exception.
+- Fixed, relative, linked, and multi-stop palette gradients use LX's standard RGB and HSV interpolation choices.
+
+## Parameter interactions
+
+- Multiply depth continuously crossfades from ordinary colorization to full source-brightness scaling; exact zero remains black at all depths, the deliberate exception to ordinary colorization at zero.
+- Threshold gating does not rescale values above the cutoff, so changing the cutoff does not shift their selected hues.
+- The final amount continuously crossfades RGB against the incoming frame after gradient lookup and brightness scaling.
+
+## Usage tips
+
+- Use this after grayscale or monochrome patterns when dark structure must survive a multi-color palette mapping.
+- Raise the threshold to suppress faint LED haze; use clear gating when lower channels should show through instead of being covered by black.
+- RGB interpolation is the safe default for wide-arc palettes; HSV modes can keep analogous palettes more saturated.

--- a/src/main/resources/catalog/apotheneum.doved.effects.ColorizeMultiplyEffect.md
+++ b/src/main/resources/catalog/apotheneum.doved.effects.ColorizeMultiplyEffect.md
@@ -3,11 +3,11 @@ class: apotheneum.doved.effects.ColorizeMultiplyEffect
 kind: effect
 sourceRepo: Apotheneum
 sourcePath: src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java
-sourceSha256: 1f9cb6ffb039abb0faea5cd1f8ae1954d5204afe6b6bfe8d955584b6cdf02769
-classBytesSha256: 4301ad780c2d2f51ce058f394ef3a07ba6ad11683dd3ad7dbd54a404930139ee
+sourceSha256: 73da55629ef3074cfbbcb7f67f4aee94df211baa6eb550c25943e897d3244566
+classBytesSha256: b138e30d6ea1979e7b36f450fb3924e470d9590a74ad9a1439905c44e9cd7c76
 classBytesOrigin: target/classes
 lxVersion: 1.2.2
-generatedAt: 2026-08-11T00:00:00Z
+generatedAt: 2026-08-11T18:59:05Z
 generator: chromatik-mcp-catalog/2 (codex)
 tags: color, gradient, palette, brightness
 ---
@@ -16,12 +16,12 @@ tags: color, gradient, palette, brightness
 
 ColorizeMultiplyEffect maps incoming brightness or luminosity to a gradient while retaining the source image's form.
 - Source value selects a gradient hue and scales that hue's brightness, so exact black remains black even when the first gradient stop is saturated.
-- Source alpha is retained by colorization; transparent threshold gating is the intentional exception.
+- Source alpha is retained by colorization and black threshold gating; clear threshold gating is the intentional transparent exception.
 - Fixed, relative, linked, and multi-stop palette gradients use LX's standard RGB and HSV interpolation choices.
 
 ## Parameter interactions
 
-- Multiply depth continuously crossfades from ordinary colorization to full source-brightness scaling; exact zero remains black at all depths, the deliberate exception to ordinary colorization at zero.
+- Multiply depth continuously crossfades from ordinary colorization RGB to full source-brightness scaling; exact zero remains black at all depths, while nonzero depth-zero output matches ordinary colorization only in RGB because source alpha is retained.
 - Threshold gating does not rescale values above the cutoff, so changing the cutoff does not shift their selected hues.
 - The final amount continuously crossfades RGB against the incoming frame after gradient lookup and brightness scaling.
 
@@ -30,3 +30,4 @@ ColorizeMultiplyEffect maps incoming brightness or luminosity to a gradient whil
 - Use this after grayscale or monochrome patterns when dark structure must survive a multi-color palette mapping.
 - Raise the threshold to suppress faint LED haze; use clear gating when lower channels should show through instead of being covered by black.
 - RGB interpolation is the safe default for wide-arc palettes; HSV modes can keep analogous palettes more saturated.
+- The gradient preview shows the undimmed lookup color; rendered output additionally applies multiply depth.

--- a/src/test/java/apotheneum/HeadlessLxTest.java
+++ b/src/test/java/apotheneum/HeadlessLxTest.java
@@ -1,0 +1,31 @@
+package apotheneum;
+
+import org.junit.jupiter.api.AfterEach;
+
+import heronarts.lx.LX;
+import heronarts.lx.model.GridModel;
+import heronarts.lx.model.LXModel;
+
+/** Minimal reusable headless-LX fixture for Apotheneum component tests. */
+public abstract class HeadlessLxTest {
+
+  private LX lx;
+
+  protected LX newHeadlessLx() {
+    this.lx = new LX(newModel());
+    return this.lx;
+  }
+
+  protected LXModel newModel() {
+    // Immutable-model LX construction does not reset LXPoint's JVM-global indices.
+    return new GridModel(2, 2).reindexPoints();
+  }
+
+  @AfterEach
+  final void disposeLx() {
+    if (this.lx != null) {
+      this.lx.dispose();
+      this.lx = null;
+    }
+  }
+}

--- a/src/test/java/apotheneum/ProviderWarmupListener.java
+++ b/src/test/java/apotheneum/ProviderWarmupListener.java
@@ -1,0 +1,22 @@
+package apotheneum;
+
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+
+/**
+ * Initializes the macOS audio and MIDI providers serially before headless LX tests.
+ * LX starts asynchronous device discovery, which can otherwise race the JVM's first
+ * sound-provider initialization and deadlock on opposing class-initialization locks.
+ */
+public class ProviderWarmupListener implements LauncherSessionListener {
+
+  @Override
+  public void launcherSessionOpened(LauncherSession session) {
+    try {
+      javax.sound.midi.MidiSystem.getMidiDeviceInfo();
+      javax.sound.sampled.AudioSystem.getMixerInfo();
+    } catch (Throwable ignored) {
+      // Soundless runners may throw after the classloading side effect we need.
+    }
+  }
+}

--- a/src/test/java/apotheneum/ProviderWarmupListener.java
+++ b/src/test/java/apotheneum/ProviderWarmupListener.java
@@ -15,7 +15,7 @@ public class ProviderWarmupListener implements LauncherSessionListener {
     try {
       javax.sound.midi.MidiSystem.getMidiDeviceInfo();
       javax.sound.sampled.AudioSystem.getMixerInfo();
-    } catch (Throwable ignored) {
+    } catch (Exception | LinkageError ignored) {
       // Soundless runners may throw after the classloading side effect we need.
     }
   }

--- a/src/test/java/apotheneum/doved/effects/ColorizeMultiplyCatalogProvenanceTest.java
+++ b/src/test/java/apotheneum/doved/effects/ColorizeMultiplyCatalogProvenanceTest.java
@@ -1,0 +1,65 @@
+package apotheneum.doved.effects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+class ColorizeMultiplyCatalogProvenanceTest {
+
+  private static final String CATALOG_RESOURCE =
+    "/catalog/apotheneum.doved.effects.ColorizeMultiplyEffect.md";
+  private static final Path SOURCE_PATH =
+    Path.of("src/main/java/apotheneum/doved/effects/ColorizeMultiplyEffect.java");
+
+  @Test
+  void catalogHashesMatchSourceAndCompiledClass() throws IOException, NoSuchAlgorithmException {
+    String catalog = resourceText(CATALOG_RESOURCE);
+    assertEquals(field(catalog, "sourceSha256"), sha256(Files.readAllBytes(SOURCE_PATH)));
+    assertEquals(field(catalog, "classBytesSha256"), sha256(resourceBytes(
+      "/apotheneum/doved/effects/ColorizeMultiplyEffect.class")));
+  }
+
+  @Test
+  void catalogGenerationTimestampIsRealAndNotInTheFuture() throws IOException {
+    Instant generatedAt = Instant.parse(field(resourceText(CATALOG_RESOURCE), "generatedAt"));
+    assertTrue(generatedAt.isAfter(Instant.parse("2026-08-11T18:00:00Z")));
+    assertFalse(generatedAt.isAfter(Instant.now()));
+  }
+
+  private static String field(String catalog, String name) {
+    Matcher matcher = Pattern.compile("(?m)^" + Pattern.quote(name) + ": (\\S+)$").matcher(catalog);
+    assertTrue(matcher.find(), "catalog field is present: " + name);
+    return matcher.group(1);
+  }
+
+  private static String resourceText(String path) throws IOException {
+    return new String(resourceBytes(path), StandardCharsets.UTF_8);
+  }
+
+  private static byte[] resourceBytes(String path) throws IOException {
+    try (InputStream input = ColorizeMultiplyEffect.class.getResourceAsStream(path)) {
+      if (input == null) {
+        throw new IOException("Missing classpath resource: " + path);
+      }
+      return input.readAllBytes();
+    }
+  }
+
+  private static String sha256(byte[] bytes) throws NoSuchAlgorithmException {
+    return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+  }
+}

--- a/src/test/java/apotheneum/doved/effects/ColorizeMultiplyEffectTest.java
+++ b/src/test/java/apotheneum/doved/effects/ColorizeMultiplyEffectTest.java
@@ -1,0 +1,246 @@
+package apotheneum.doved.effects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import apotheneum.HeadlessLxTest;
+import heronarts.lx.LX;
+import heronarts.lx.ModelBuffer;
+import heronarts.lx.color.GradientUtils.BlendMode;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.effect.color.ColorizeEffect;
+import heronarts.lx.utils.LXUtils;
+
+class ColorizeMultiplyEffectTest extends HeadlessLxTest {
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0, .25, .5, .75, 1 })
+  void zeroBrightnessStaysBlackAtEveryDepth(double depth) {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    configureThreeColorPalette(lx, effect);
+    effect.depth.setValue(depth);
+
+    assertEquals(0x7f000000, apply(effect, 0x7f000000));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = { 16, 64, 128, 224, 255 })
+  void depthZeroMatchesColorizeForNonzeroBrightness(int value) {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.color1.setColor(0xffff3300);
+    effect.color2.setColor(0xff0066ff);
+
+    ColorizeEffect stock = new ColorizeEffect(lx);
+    stock.setDamping(false);
+    stock.color1.setColor(0xffff3300);
+    stock.color2.setColor(0xff0066ff);
+
+    int input = LXColor.rgba(value, value, value, 255);
+    assertEquals(apply(stock, input), apply(effect, input));
+  }
+
+  @ParameterizedTest
+  @EnumSource(BlendMode.class)
+  void depthZeroMatchesColorizeAcrossBlendModes(BlendMode blendMode) {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.blendMode.setValue(blendMode);
+    effect.color1.setColor(0xffff3300);
+    effect.color2.setColor(0xff0066ff);
+
+    ColorizeEffect stock = new ColorizeEffect(lx);
+    stock.setDamping(false);
+    stock.blendMode.setValue(blendMode);
+    stock.color1.setColor(0xffff3300);
+    stock.color2.setColor(0xff0066ff);
+
+    int input = LXColor.rgba(137, 137, 137, 255);
+    assertEquals(apply(stock, input), apply(effect, input));
+  }
+
+  static Stream<Arguments> fullDepthCases() {
+    return Stream.of(
+      Arguments.of(25, 0xffff0000, 0xff0000ff),
+      Arguments.of(50, 0xffff0000, 0xff0000ff),
+      Arguments.of(75, 0xffff0000, 0xff0000ff));
+  }
+
+  @ParameterizedTest
+  @MethodSource("fullDepthCases")
+  void fullDepthScalesGradientColorBySourceBrightness(int brightness, int color1, int color2) {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.color1.setColor(color1);
+    effect.color2.setColor(color2);
+    effect.depth.setValue(1);
+
+    int input = LXColor.gray(brightness);
+    float source = LXColor.b(input) * .01f;
+    int gradient = effectColor(color1, color2, source);
+    int expected = 0xff000000 | (LXColor.scaleBrightness(gradient, source) & LXColor.RGB_MASK);
+    assertEquals(expected, apply(effect, input));
+  }
+
+  @Test
+  void thresholdDoesNotRemapColorAboveCutoff() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.BLUE);
+    int input = LXColor.gray(60);
+
+    effect.threshold.setValue(.1);
+    int lowThreshold = apply(effect, input);
+    effect.threshold.setValue(.5);
+    int highThreshold = apply(effect, input);
+
+    assertEquals(lowThreshold, highThreshold);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = { 0, .35, 1 })
+  void preservesSourceAlphaThroughColorization(double amount) {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.BLUE);
+    effect.amount.setValue(amount);
+
+    assertEquals(73, apply(effect, LXColor.rgba(80, 80, 80, 73)) >>> LXColor.ALPHA_SHIFT);
+  }
+
+  @Test
+  void clearThresholdModeProducesTransparentPixel() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.threshold.setValue(.5);
+    effect.thresholdMode.setValue(ColorizeMultiplyEffect.ThresholdMode.CLEAR);
+
+    assertEquals(0x000a141e, apply(effect, LXColor.rgba(10, 20, 30, 97)));
+  }
+
+  @Test
+  void paletteUsesBrightnessToSelectAmongThreeStops() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    configureThreeColorPalette(lx, effect);
+    effect.depth.setValue(1);
+
+    int result = apply(effect, LXColor.gray(50));
+    int red = (result & LXColor.R_MASK) >>> LXColor.R_SHIFT;
+    int green = (result & LXColor.G_MASK) >>> LXColor.G_SHIFT;
+    int blue = result & LXColor.B_MASK;
+
+    assertTrue(green > red && green > blue,
+      "mid-brightness input selects and scales the middle green palette stop");
+  }
+
+  @Test
+  void blackThresholdModePreservesAlpha() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.threshold.setValue(.5);
+    effect.thresholdMode.setValue(ColorizeMultiplyEffect.ThresholdMode.BLACK);
+
+    assertEquals(0x61000000, apply(effect, LXColor.rgba(10, 20, 30, 97)));
+  }
+
+  @Test
+  void leaveThresholdModeDoesNotChangePixel() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.threshold.setValue(.5);
+    effect.thresholdMode.setValue(ColorizeMultiplyEffect.ThresholdMode.LEAVE);
+    int input = LXColor.rgba(10, 20, 30, 97);
+
+    assertEquals(input, apply(effect, input));
+  }
+
+  @Test
+  void defaultsToRgbInterpolationAndFullDepth() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+
+    assertEquals(BlendMode.RGB, effect.blendMode.getEnum());
+    assertEquals(1, effect.depth.getValue());
+  }
+
+  @Test
+  void semanticCatalogEntryShipsWithOwningClass() {
+    assertNotNull(ColorizeMultiplyEffect.class.getResource(
+      "/catalog/apotheneum.doved.effects.ColorizeMultiplyEffect.md"));
+  }
+
+  @Test
+  void luminosityCanDriveColorization() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.source.setValue(ColorizeMultiplyEffect.SourceMode.LUMINOSITY);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.BLUE);
+    effect.depth.setValue(0);
+    int input = LXColor.rgba(255, 0, 0, 255);
+    float luminosity = LXColor.luminosity(input) * .01f;
+
+    assertEquals(0xff000000 | (effectColor(LXColor.RED, LXColor.BLUE, luminosity) & LXColor.RGB_MASK),
+      apply(effect, input));
+  }
+
+  private static ColorizeMultiplyEffect effect(LX lx) {
+    ColorizeMultiplyEffect effect = new ColorizeMultiplyEffect(lx);
+    effect.setDamping(false);
+    return effect;
+  }
+
+  private static void configureThreeColorPalette(LX lx, ColorizeMultiplyEffect effect) {
+    lx.engine.palette.swatch.getColor(0).primary.setColor(LXColor.RED);
+    lx.engine.palette.swatch.addColor().primary.setColor(LXColor.GREEN);
+    lx.engine.palette.swatch.addColor().primary.setColor(LXColor.BLUE);
+    effect.colorMode.setValue(ColorizeMultiplyEffect.ColorMode.PALETTE);
+    effect.paletteStops.setValue(3);
+  }
+
+  private static int apply(ColorizeMultiplyEffect effect, int input) {
+    return applyEffect(effect, input);
+  }
+
+  private static int apply(ColorizeEffect effect, int input) {
+    return applyEffect(effect, input);
+  }
+
+  private static int applyEffect(heronarts.lx.effect.LXEffect effect, int input) {
+    ModelBuffer buffer = new ModelBuffer(effect.getLX());
+    try {
+      buffer.getArray()[0] = input;
+      effect.setBuffer(buffer);
+      effect.onLoop(16);
+      return buffer.getArray()[0];
+    } finally {
+      buffer.dispose();
+    }
+  }
+
+  private static int effectColor(int color1, int color2, float amount) {
+    int red = LXUtils.lerpi((color1 & LXColor.R_MASK) >>> LXColor.R_SHIFT,
+      (color2 & LXColor.R_MASK) >>> LXColor.R_SHIFT, amount);
+    int green = LXUtils.lerpi((color1 & LXColor.G_MASK) >>> LXColor.G_SHIFT,
+      (color2 & LXColor.G_MASK) >>> LXColor.G_SHIFT, amount);
+    int blue = LXUtils.lerpi(color1 & LXColor.B_MASK, color2 & LXColor.B_MASK, amount);
+    return LXColor.rgba(red, green, blue, 255);
+  }
+}

--- a/src/test/java/apotheneum/doved/effects/ColorizeMultiplyEffectTest.java
+++ b/src/test/java/apotheneum/doved/effects/ColorizeMultiplyEffectTest.java
@@ -1,7 +1,9 @@
 package apotheneum.doved.effects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.Stream;
@@ -18,6 +20,7 @@ import heronarts.lx.LX;
 import heronarts.lx.ModelBuffer;
 import heronarts.lx.color.GradientUtils.BlendMode;
 import heronarts.lx.color.LXColor;
+import heronarts.lx.effect.LXEffect;
 import heronarts.lx.effect.color.ColorizeEffect;
 import heronarts.lx.utils.LXUtils;
 
@@ -34,9 +37,32 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
     assertEquals(0x7f000000, apply(effect, 0x7f000000));
   }
 
+  @Test
+  void fixedSaturatedFirstStopStillMapsExactZeroToBlack() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.BLUE);
+    effect.depth.setValue(0);
+
+    assertEquals(0xff000000, apply(effect, 0xff000000));
+  }
+
+  @Test
+  void luminosityZeroStillMapsToBlack() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.source.setValue(ColorizeMultiplyEffect.SourceMode.LUMINOSITY);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.BLUE);
+    effect.depth.setValue(0);
+
+    assertEquals(0x4d000000, apply(effect, 0x4d000000));
+  }
+
   @ParameterizedTest
   @ValueSource(ints = { 16, 64, 128, 224, 255 })
-  void depthZeroMatchesColorizeForNonzeroBrightness(int value) {
+  void depthZeroMatchesColorizeRgbForOpaqueNonzeroBrightness(int value) {
     LX lx = newHeadlessLx();
     ColorizeMultiplyEffect effect = effect(lx);
     effect.depth.setValue(0);
@@ -49,12 +75,12 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
     stock.color2.setColor(0xff0066ff);
 
     int input = LXColor.rgba(value, value, value, 255);
-    assertEquals(apply(stock, input), apply(effect, input));
+    assertEquals(apply(stock, input) & LXColor.RGB_MASK, apply(effect, input) & LXColor.RGB_MASK);
   }
 
   @ParameterizedTest
   @EnumSource(BlendMode.class)
-  void depthZeroMatchesColorizeAcrossBlendModes(BlendMode blendMode) {
+  void depthZeroMatchesColorizeRgbAcrossBlendModes(BlendMode blendMode) {
     LX lx = newHeadlessLx();
     ColorizeMultiplyEffect effect = effect(lx);
     effect.depth.setValue(0);
@@ -69,7 +95,28 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
     stock.color2.setColor(0xff0066ff);
 
     int input = LXColor.rgba(137, 137, 137, 255);
-    assertEquals(apply(stock, input), apply(effect, input));
+    assertEquals(apply(stock, input) & LXColor.RGB_MASK, apply(effect, input) & LXColor.RGB_MASK);
+  }
+
+  @Test
+  void depthZeroMatchesColorizeRgbButPreservesNonOpaqueSourceAlpha() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.color1.setColor(0xffff3300);
+    effect.color2.setColor(0xff0066ff);
+
+    ColorizeEffect stock = new ColorizeEffect(lx);
+    stock.setDamping(false);
+    stock.color1.setColor(0xffff3300);
+    stock.color2.setColor(0xff0066ff);
+
+    int input = LXColor.rgba(137, 137, 137, 73);
+    int stockOutput = apply(stock, input);
+    int effectOutput = apply(effect, input);
+    assertEquals(stockOutput & LXColor.RGB_MASK, effectOutput & LXColor.RGB_MASK);
+    assertEquals(255, stockOutput >>> LXColor.ALPHA_SHIFT);
+    assertEquals(73, effectOutput >>> LXColor.ALPHA_SHIFT);
   }
 
   static Stream<Arguments> fullDepthCases() {
@@ -96,6 +143,37 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
   }
 
   @Test
+  void fullDepthHalfBrightnessRedHasHandDerivedArgb() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.RED);
+    effect.depth.setValue(1);
+
+    assertEquals(0xff800000, apply(effect, 0xff808080));
+  }
+
+  static Stream<Arguments> amountCases() {
+    return Stream.of(
+      Arguments.of(0, 0xff204060),
+      Arguments.of(.5, 0xff706050),
+      Arguments.of(1, 0xffc08040));
+  }
+
+  @ParameterizedTest
+  @MethodSource("amountCases")
+  void amountCrossfadesRgbAgainstOriginal(double amount, int expected) {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.color1.setColor(0xffc08040);
+    effect.color2.setColor(0xffc08040);
+    effect.amount.setValue(amount);
+
+    assertEquals(expected, apply(effect, 0xff204060));
+  }
+
+  @Test
   void thresholdDoesNotRemapColorAboveCutoff() {
     LX lx = newHeadlessLx();
     ColorizeMultiplyEffect effect = effect(lx);
@@ -110,6 +188,20 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
     int highThreshold = apply(effect, input);
 
     assertEquals(lowThreshold, highThreshold);
+  }
+
+  @Test
+  void thresholdEqualityIsNotGated() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.color1.setColor(LXColor.RED);
+    effect.color2.setColor(LXColor.RED);
+    effect.thresholdMode.setValue(ColorizeMultiplyEffect.ThresholdMode.BLACK);
+    int input = LXColor.gray(25);
+    effect.threshold.setValue(LXColor.b(input) * .01f);
+
+    assertEquals(LXColor.RED, apply(effect, input));
   }
 
   @ParameterizedTest
@@ -139,15 +231,60 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
     LX lx = newHeadlessLx();
     ColorizeMultiplyEffect effect = effect(lx);
     configureThreeColorPalette(lx, effect);
-    effect.depth.setValue(1);
+    effect.depth.setValue(0);
 
-    int result = apply(effect, LXColor.gray(50));
-    int red = (result & LXColor.R_MASK) >>> LXColor.R_SHIFT;
-    int green = (result & LXColor.G_MASK) >>> LXColor.G_SHIFT;
-    int blue = result & LXColor.B_MASK;
+    int middle = apply(effect, LXColor.gray(50));
+    int green = (middle & LXColor.G_MASK) >>> LXColor.G_SHIFT;
+    assertTrue(green > ((middle & LXColor.R_MASK) >>> LXColor.R_SHIFT));
+    assertTrue(green > (middle & LXColor.B_MASK));
 
-    assertTrue(green > red && green > blue,
-      "mid-brightness input selects and scales the middle green palette stop");
+    effect.paletteDepth.setValue(.5);
+    int shallow = apply(effect, LXColor.gray(50));
+    effect.paletteInvert.setValue(true);
+    int shallowInverted = apply(effect, LXColor.gray(50));
+
+    assertNotEquals(middle, shallow, "palette depth changes the sampled range");
+    assertNotEquals(shallow, shallowInverted, "palette inversion reverses the sampled range");
+    assertTrue(((shallow & LXColor.R_MASK) >>> LXColor.R_SHIFT) > (shallow & LXColor.B_MASK));
+    assertTrue((shallowInverted & LXColor.B_MASK) >
+      ((shallowInverted & LXColor.R_MASK) >>> LXColor.R_SHIFT));
+  }
+
+  @Test
+  void relativeModeMatchesColorizeRgb() {
+    LX lx = newHeadlessLx();
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.color1.setColor(LXColor.RED);
+    effect.gradientHue.setValue(120);
+    effect.colorMode.setValue(ColorizeMultiplyEffect.ColorMode.RELATIVE);
+
+    ColorizeEffect stock = new ColorizeEffect(lx);
+    stock.setDamping(false);
+    stock.color1.setColor(LXColor.RED);
+    stock.gradientHue.setValue(120);
+    stock.colorMode.setValue(ColorizeEffect.ColorMode.RELATIVE);
+
+    int input = LXColor.gray(67);
+    assertEquals(apply(stock, input) & LXColor.RGB_MASK, apply(effect, input) & LXColor.RGB_MASK);
+  }
+
+  @Test
+  void linkedModeMatchesColorizeRgb() {
+    LX lx = newHeadlessLx();
+    lx.engine.palette.swatch.getColor(0).primary.setColor(LXColor.RED);
+    ColorizeMultiplyEffect effect = effect(lx);
+    effect.depth.setValue(0);
+    effect.gradientHue.setValue(120);
+    effect.colorMode.setValue(ColorizeMultiplyEffect.ColorMode.LINKED);
+
+    ColorizeEffect stock = new ColorizeEffect(lx);
+    stock.setDamping(false);
+    stock.gradientHue.setValue(120);
+    stock.colorMode.setValue(ColorizeEffect.ColorMode.LINKED);
+
+    int input = LXColor.gray(67);
+    assertEquals(apply(stock, input) & LXColor.RGB_MASK, apply(effect, input) & LXColor.RGB_MASK);
   }
 
   @Test
@@ -199,6 +336,17 @@ class ColorizeMultiplyEffectTest extends HeadlessLxTest {
 
     assertEquals(0xff000000 | (effectColor(LXColor.RED, LXColor.BLUE, luminosity) & LXColor.RGB_MASK),
       apply(effect, input));
+  }
+
+  @Test
+  void instantiatesByFullyQualifiedClassName() throws LX.InstantiationException {
+    LX lx = newHeadlessLx();
+    LXEffect instance = lx.instantiateEffect(ColorizeMultiplyEffect.class.getName());
+    try {
+      assertInstanceOf(ColorizeMultiplyEffect.class, instance);
+    } finally {
+      instance.dispose();
+    }
   }
 
   private static ColorizeMultiplyEffect effect(LX lx) {

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+apotheneum.ProviderWarmupListener


### PR DESCRIPTION
Closes oveddan/chromatik-mcp#202

## Summary
- add ColorizeMultiplyEffect under apotheneum.doved.effects using LX GradientUtils color stops and blend modes
- preserve source brightness, alpha, multi-stop palette behavior, and stable no-rescale threshold gating
- add Apotheneum reusable headless-LX JUnit harness with macOS provider warmup
- ship the get_component_doc semantic catalog entry from the owning Apotheneum JAR

Exact zero is deliberately forced to black at every multiply depth, including depth 0. This prioritizes the issue core regression; depth-0 parity with stock ColorizeEffect therefore applies to nonzero source values.

## Validation
- mvn -Dtest=ColorizeMultiplyEffectTest test (29 tests)
- mvn -B clean package (29 tests)
- mvn -Pinstall install (29 tests and local package install)
- verified source and class byte hashes match catalog metadata
- verified the built JAR contains the effect and catalog resource

No chromatik-mcp production change is included; the permanent class, tests, and catalog live here.